### PR TITLE
A couple of breadcrumb and 404 fixes

### DIFF
--- a/exp/docgen/www/index.php
+++ b/exp/docgen/www/index.php
@@ -121,26 +121,24 @@
         
         $HeaderTitle = $CurrentOpenFile = $IncludeName;
 
-        switch ($Action) {
-        case '__raw':
-            $Query = 'select content from spdoc_include where name = :includeName';
-            $STH = $Database->prepare($Query);
-            $STH->bindValue(':includeName', $IncludeName, PDO::PARAM_STR);
-            $STH->execute();
-            
-            $PageFile = $STH->fetch();
-            
-            if (Empty($PageFile)) {
-                require __DIR__ . '/template/404.php';
+        if ($Action) {
+            if ($Action === '__raw') {
+                $Query = 'select content from spdoc_include where name = :includeName';
+                $STH = $Database->prepare($Query);
+                $STH->bindValue(':includeName', $IncludeName, PDO::PARAM_STR);
+                $STH->execute();
+
+                $PageFile = $STH->fetch();
+
+                if (Empty($PageFile)) {
+                    require __DIR__ . '/template/404.php';
+                    exit;
+                }
+
+                require __DIR__ . '/template/raw.php';
                 exit;
             }
-            
-            require __DIR__ . '/template/raw.php';
-            exit;
-            break;
-        }
 
-        if ($Action) {
             if (isset($Path[2]))
                 $Object = FindSubObject($Database, $IncludeName, $Action, $Path[2]);
             else
@@ -178,6 +176,18 @@
             }
         }
 
+        $Query = 'select name from spdoc_include where name = :includeName';
+        $STH = $Database->prepare($Query);
+        $STH->bindValue(':includeName', $IncludeName, PDO::PARAM_STR);
+        $STH->execute();
+
+        $PageFile = $STH->fetch();
+
+        if (Empty($PageFile)) {
+            require __DIR__ . '/template/404.php';
+            exit;
+        }
+
         $PageFunctions = FindFunctions($Database, $IncludeName);
         $PageClasses = FindClasses($Database, $IncludeName);
         $PageEnums = FindEnums($Database, $IncludeName);
@@ -188,5 +198,5 @@
         require __DIR__ . '/template/include.php';
         exit;
     }
-    
+
     require __DIR__ . '/template/main.php';

--- a/exp/docgen/www/search.php
+++ b/exp/docgen/www/search.php
@@ -292,5 +292,3 @@ function FindObject($Database, $IncludeName, $Name)
         return Array('type' => 'type', 'data' => $Object);
     return NULL;
 }
-
-?>

--- a/exp/docgen/www/template/404.php
+++ b/exp/docgen/www/template/404.php
@@ -4,7 +4,7 @@
 	require __DIR__ . '/header.php';
 ?>
 
-<h1 class="page-header">Nothing found</h1>
+<h1>Nothing found</h1>
 
 <?php
 	require __DIR__ . '/footer.php';

--- a/exp/docgen/www/template/class.php
+++ b/exp/docgen/www/template/class.php
@@ -7,6 +7,8 @@
 
 <ol class="breadcrumb">
     <li><a href="<?php echo $BaseURL . $CurrentOpenFile; ?>"><?php echo $CurrentOpenFile; ?>.inc</a></li>
+    <li>Classes</li>
+    <li class="active"><?php echo htmlspecialchars($PageClass['name']); ?></li>
     
     <li class="pull-right"><a href="<?php echo $BaseURL . $CurrentOpenFile; ?>/__raw">File</a></li>
 </ol>

--- a/exp/docgen/www/template/constants.php
+++ b/exp/docgen/www/template/constants.php
@@ -8,7 +8,6 @@
     <li class="active">Constants</li>
     
     <li class="pull-right"><a href="<?php echo $BaseURL . $CurrentOpenFile; ?>/__raw">File</a></li>
-    <li class="pull-right"><a href="<?php echo $BaseURL . $CurrentOpenFile; ?>/__functions">Functions</a></li>
 </ol>
 
 <h1 class="page-header">List of constants in <?php echo htmlspecialchars( $PageName ); ?>.inc</h1>

--- a/exp/docgen/www/template/enum.php
+++ b/exp/docgen/www/template/enum.php
@@ -7,6 +7,8 @@
 
 <ol class="breadcrumb">
     <li><a href="<?php echo $BaseURL . $CurrentOpenFile; ?>"><?php echo $CurrentOpenFile; ?>.inc</a></li>
+    <li>Enumerations</li>
+    <li class="active"><?php echo htmlspecialchars($PageEnum['name']); ?></li>
     
     <li class="pull-right"><a href="<?php echo $BaseURL . $CurrentOpenFile; ?>/__raw">File</a></li>
 </ol>

--- a/exp/docgen/www/template/function.php
+++ b/exp/docgen/www/template/function.php
@@ -13,7 +13,16 @@
 
 <ol class="breadcrumb">
     <li><a href="<?php echo $BaseURL . $CurrentOpenFile; ?>"><?php echo $CurrentOpenFile; ?>.inc</a></li>
-    
+<?php
+if (isset($PageFunction['class_name'])) {
+?>
+    <li><?php echo htmlspecialchars($PageFunction['class_name']); ?></li>
+<?php
+}
+?>
+    <li><?php echo (isset($PageFunction['class_name']) ? 'Methods' : ($PageFunction['kind'] === 'forward' ? 'Callbacks' : 'Functions')); ?></li>
+    <li class="active"><?php echo htmlspecialchars($PageFunction['name']); ?></li>
+
     <li class="pull-right"><a href="<?php echo $BaseURL . $CurrentOpenFile; ?>/__raw">File</a></li>
 </ol>
 

--- a/exp/docgen/www/template/include.php
+++ b/exp/docgen/www/template/include.php
@@ -1,16 +1,20 @@
 <?php
 // vim: set ts=4 sw=4 tw=99 et:
     require __DIR__ . '/header.php';
+    
+    $FoundAny = false;
 ?>
 
 <ol class="breadcrumb">
     <li><a href="<?php echo $BaseURL . $CurrentOpenFile; ?>"><?php echo $CurrentOpenFile; ?>.inc</a></li>
-    
+    <li class="active">Overview</li>
+        
     <li class="pull-right"><a href="<?php echo $BaseURL . $CurrentOpenFile; ?>/__raw">File</a></li>
 </ol>
 
 <?php
 if ($PageClasses) {
+    $FoundAny = true;
 ?>
     <h3 class="page-header">Classes</h3>
     
@@ -43,6 +47,7 @@ if ($PageClasses) {
 
 <?php
 if ($PageEnums) {
+    $FoundAny = true;
 ?>
     <h3 class="page-header">Enums</h3>
     
@@ -75,6 +80,7 @@ if ($PageEnums) {
 
 <?php
 if ($PageTypes) {
+    $FoundAny = true;
 ?>
     <h3 class="page-header">Types</h3>
     
@@ -107,6 +113,7 @@ if ($PageTypes) {
 
 <?php
 if ($PageConstants) {
+    $FoundAny = true;
 ?>
     <h3 class="page-header">Constants</h3>
     
@@ -139,6 +146,7 @@ if ($PageConstants) {
 
 <?php
 if ($PageCallbacks) {
+    $FoundAny = true;
 ?>
     <h3 class="page-header">Callbacks</h3>
     
@@ -171,6 +179,7 @@ if ($PageCallbacks) {
 
 <?php
 if ($PageFunctions) {
+    $FoundAny = true;
 ?>
     <h3 class="page-header">Functions</h3>
     
@@ -196,6 +205,15 @@ if ($PageFunctions) {
                 }
             ?>
         </table>
+    </div>
+<?php
+}
+
+if (!$FoundAny) {
+?>
+    <div class="panel panel-primary">
+        <div class="panel-heading">Empty</div>
+        <div class="panel-body">This include file has no types, functions, or constants.</div>
     </div>
 <?php
 }

--- a/exp/docgen/www/template/property.php
+++ b/exp/docgen/www/template/property.php
@@ -7,6 +7,9 @@
 
 <ol class="breadcrumb">
     <li><a href="<?php echo $BaseURL . $CurrentOpenFile; ?>"><?php echo $CurrentOpenFile; ?>.inc</a></li>
+    <li><?php echo htmlspecialchars($PageProperty['class_name']); ?></li>
+    <li>Properties</li>
+    <li class="active"><?php echo htmlspecialchars($PageProperty['name']); ?></li>
     
     <li class="pull-right"><a href="<?php echo $BaseURL . $CurrentOpenFile; ?>/__raw">File</a></li>
 </ol>

--- a/exp/docgen/www/template/raw.php
+++ b/exp/docgen/www/template/raw.php
@@ -5,10 +5,9 @@
 
 <ol class="breadcrumb">
     <li><a href="<?php echo $BaseURL . $CurrentOpenFile; ?>"><?php echo $CurrentOpenFile; ?>.inc</a></li>
-    <li class="active">Raw</li>
+    <li class="active">File</li>
     
-    <li class="pull-right"><a href="<?php echo $BaseURL . $CurrentOpenFile; ?>/__functions">Functions</a></li>
-    <li class="pull-right"><a href="<?php echo $BaseURL . $CurrentOpenFile; ?>">Constants</a></li>
+    <li class="pull-right"><a href="<?php echo $BaseURL . $CurrentOpenFile; ?>">Overview</a></li>
 </ol>
 
 <h1 class="page-header"><?php echo htmlspecialchars( $CurrentOpenFile ); ?>.inc</h1>

--- a/exp/docgen/www/template/render.php
+++ b/exp/docgen/www/template/render.php
@@ -46,5 +46,3 @@ function MethodName($Function)
     }
     return $Function['name'];
 }
-
-?>

--- a/exp/docgen/www/template/type.php
+++ b/exp/docgen/www/template/type.php
@@ -7,6 +7,8 @@
 
 <ol class="breadcrumb">
     <li><a href="<?php echo $BaseURL . $CurrentOpenFile; ?>"><?php echo $CurrentOpenFile; ?>.inc</a></li>
+    <li>Types</li>
+    <li class="active"><?php echo htmlspecialchars($PageType['name']); ?></li>
     
     <li class="pull-right"><a href="<?php echo $BaseURL . $CurrentOpenFile; ?>/__raw">File</a></li>
 </ol>


### PR DESCRIPTION
- Added a check to see if include exists before trying to find objects in it and renders 404 page if not found
- Breadcrumb improvements so that it actually says where you are now
- Added a panel saying there are no types/functions if include file exists but there is nothing to display