### PR TITLE
Fix declaring variable on same line after array

### DIFF
--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -3412,10 +3412,9 @@ static int reparse_new_decl(declinfo_t *decl, int flags)
     //
     // Reset the fact that we saw an array.
     decl->type.numdim = 0;
-    decl->type.size = 0;
     decl->type.enumroot = NULL;
     decl->type.ident = iVARIABLE;
-    decl->type.size = 0;
+    decl->type.size = 1;
     decl->type.has_postdims = false;
     if (matchtoken('['))
       parse_old_array_dims(decl, flags);


### PR DESCRIPTION
int a[5], b;
b would get a size of |0| on the stack instead of a sizeof(cell_t).
Bug: https://bugs.alliedmods.net/show_bug.cgi?id=6335