### PR TITLE
Add missing debug info for multidimensional strings

### DIFF
--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -6270,7 +6270,20 @@ static int testsymbols(symbol *root,int level,int testlabs,int testconst)
   int entry=FALSE;
 
   symbol *sym=root->next;
-  while (sym!=NULL && sym->compound>=level) {
+  symbol *parent;
+  while (sym!=NULL) {
+    if (sym->compound < level) {
+      parent = sym->parent;
+      if (parent == NULL || (parent->ident != iARRAY && parent->ident != iREFARRAY))
+        break;
+      /* This is one dimension of a multidimensional array. Find the top symbol. */
+      while (parent->parent != NULL && (parent->parent->ident == iARRAY || parent->parent->ident == iREFARRAY)) {
+        parent = parent->parent;
+      }
+      /* Only the top symbol gets the compound level set. */
+      if (parent->compound < level)
+        break;
+    }
     switch (sym->ident) {
     case iLABEL:
       if (testlabs) {


### PR DESCRIPTION
```sourcepawn
new String:INVISIBLE[2][8];
```

Multidimensional arrays like this wouldn't get their debug info added to
the debug symbols table.
Bug: https://bugs.alliedmods.net/show_bug.cgi?id=6324

See Fyren's comment in the bug report.
This patch recursively checks the parent symbol of array dimensions
until it finds the top symbol and uses that to check for the compound
level.
This still allows for early exiting the loop when going out of scope.