### PR TITLE
Fix a regression when using accessors as |this|.

### DIFF
--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -734,6 +734,7 @@ void startfunc(char *fname);
 void endfunc(void);
 void alignframe(int numbytes);
 void rvalue(value *lval);
+void rvalue(svalue *sval);
 void address(symbol *ptr,regid reg);
 void store(value *lval);
 void loadreg(cell address,regid reg);

--- a/compiler/sc3.cpp
+++ b/compiler/sc3.cpp
@@ -2776,7 +2776,8 @@ static int nesting=0;
     // this reduces it to an iEXPRESSION. That's ok. We don't touch it
     // otherwise though, so the type checking logic below basically acts the
     // same. We are careful to not double-evaluate however.
-    rvalue(&implicit_this.val);
+    if (implicit_this.lvalue)
+      rvalue(&implicit_this);
     pushreg(sPRI);
     nest_stkusage++;
   }

--- a/compiler/sc4.cpp
+++ b/compiler/sc4.cpp
@@ -427,6 +427,16 @@ void rvalue(value *lval)
   } /* if */
 }
 
+// Wrapper that automatically markes lvalues as decayed if they are accessors,
+// since it is illegal to evaluate them twice.
+void rvalue(svalue *sval)
+{
+  int ident = sval->val.ident;
+  rvalue(&sval->val);
+  if (ident == iACCESSOR)
+    sval->lvalue = FALSE;
+}
+
 /* Get the address of a symbol into the primary or alternate register (used
  * for arrays, and for passing arguments by reference).
  */


### PR DESCRIPTION
If a |this| was computed off an expression, then it's not actually an l-value. I forgot to do an l-value check before calling rvalue().

For good measure I made a new wrapper around rvalue() that also resets l-value bits when evaluating an accessor.