### PR TITLE
Fix internal error codes not propagating back to Execute2.

### DIFF
--- a/vm/x86/jit_x86.cpp
+++ b/vm/x86/jit_x86.cpp
@@ -1788,10 +1788,9 @@ Compiler::emitErrorPaths()
     __ movl(Operand(ecx, ExitFrame::offsetOfExitNative()), -1);
     __ movl(Operand(ecx, ExitFrame::offsetOfExitSp()), esp);
 
-    // Since the return stub wipes out the stack, we don't need to subl after
-    // the call.
     __ push(eax);
     __ call(ExternalAddress((void *)InvokeReportError));
+    __ pop(eax); // Get the error back off the stack.
     __ jmp(ExternalAddress(env_->stubs()->ReturnStub()));
   }
 


### PR DESCRIPTION
This is an unfortunate and nasty bug. When invoking ReportError from the JIT, we leave the code in `eax` and don't restore it after the call. So the value returned from the JIT in the case of an internal error is essentially random.

I only noticed it because I saw the HEAPLOW check double-reporting, since Execute2() will manually report this error if the JIT returned err=0 but HLW fails a sanity check.