### PR TITLE
Fix loops not freeing heap-allocated variables when using continue or break.

### DIFF
--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -7048,6 +7048,7 @@ static int dofor(void)
   save_nestlevel=nestlevel;
   save_endlessloop=endlessloop;
   pushstacklist();
+  pushheaplist();
   
   addwhile(wq);
   skiplab=getlabel();
@@ -7144,6 +7145,8 @@ static int dofor(void)
   jumplabel(wq[wqLOOP]);
   setlabel(wq[wqEXIT]);
   delwhile();
+
+  popheaplist();
 
   assert(nestlevel>=save_nestlevel);
   if (nestlevel>save_nestlevel) {


### PR DESCRIPTION
Stupid bug. The compiler stores an index for each loop indicating the current position of the "stack usage" tracker. When a "continue" keyword is encountered, we generate stack restores for everything newer than this index.

There is a separate tracker for heap usage, but the same index is expected to work in both. Whenever we enter a new nesting level in the stack usage tracker, we must also enter one in the heap usage tracker.