### PR TITLE
Kill off SYSREQ_C.

### DIFF
--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -4245,7 +4245,6 @@ static void dodelete()
   // stack 8
   pushreg(sPRI);
   {
-    pushval(1);
     ffcall(map->dtor->target, NULL, 1);
 
     // Only mark usage if we're not skipping codegen.
@@ -6399,9 +6398,8 @@ static void destructsymbols(symbol *root,int level)
         address(sym,sPRI);
         addconst(offset);       /* add offset to array data to the address */
         pushreg(sPRI);
-        pushval(2 /* *sizeof(cell)*/ );/* 2 parameters */
         assert(opsym->ident==iFUNCTN);
-        ffcall(opsym,NULL,1);
+        ffcall(opsym,NULL,2);
         if (sc_status!=statSKIP)
           markusage(opsym,uREAD);   /* do not mark as "used" when this call itself is skipped */
         if ((opsym->usage & uNATIVE)!=0 && opsym->x.lib!=NULL)

--- a/compiler/sc3.cpp
+++ b/compiler/sc3.cpp
@@ -266,7 +266,6 @@ int check_userop(void (*oper)(void),int tag1,int tag2,int numparam,
     assert(0);
   } /* switch */
   markexpr(sPARM,NULL,0);       /* mark the end of a sub-expression */
-  pushval((cell)paramspassed /* *sizeof(cell)*/ );
   assert(sym->ident==iFUNCTN);
   ffcall(sym,NULL,paramspassed);
   if (sc_status!=statSKIP)
@@ -3155,7 +3154,6 @@ static int nesting=0;
   } /* for */
   stgmark(sENDREORDER);         /* mark end of reversed evaluation */
 
-  pushval((cell)nargs /* *sizeof(cell)*/ );
   nest_stkusage++;
   ffcall(sym,NULL,nargs);
   if (sc_status!=statSKIP)

--- a/compiler/sc4.cpp
+++ b/compiler/sc4.cpp
@@ -835,7 +835,7 @@ void ffcall(symbol *sym,const char *label,int numargs)
   if ((sym->usage & uNATIVE)!=0) {
     /* reserve a SYSREQ id if called for the first time */
     assert(label==NULL);
-    stgwrite("\tsysreq.c ");
+    stgwrite("\tsysreq.n ");
     if (sc_status==statWRITE && (sym->usage & uREAD)==0 && sym->addr>=0)
       sym->addr=ntv_funcid++;
     /* Look for an alias */
@@ -850,15 +850,16 @@ void ffcall(symbol *sym,const char *label,int numargs)
       }
     }
     outval(sym->addr,FALSE);
+    stgwrite(" ");
+    outval(numargs,FALSE);
     if (sc_asmfile) {
       stgwrite("\t; ");
       stgwrite(symname);
     } /* if */
     stgwrite("\n"); /* write on a separate line, to mark a sequence point for the peephole optimizer */
-    stgwrite("\tstack ");
-    outval((numargs+1)*sizeof(cell), TRUE);
-    code_idx+=opcodes(2)+opargs(2);
+    code_idx+=opcodes(1)+opargs(2);
   } else {
+    pushval(numargs);
     /* normal function */
     stgwrite("\tcall ");
     if (label!=NULL) {
@@ -1482,11 +1483,9 @@ void invoke_getter(methodmap_method_t *method)
     return;
   }
 
-  // push.c 1
-  // sysreq.c N 1
+  // sysreq.n N 1
   // stack 8
   pushreg(sPRI);
-  pushval(1);
   ffcall(method->getter, NULL, 1);
 
   if (sc_status != statSKIP)
@@ -1504,7 +1503,6 @@ void invoke_setter(methodmap_method_t *method, int save)
     pushreg(sPRI);
   pushreg(sPRI);
   pushreg(sALT);
-  pushval(2);
   ffcall(method->setter, NULL, 2);
   if (save)
     popreg(sPRI);


### PR DESCRIPTION
SYSREQ_C is an older opcode for invoking natives that doesn't guarantee a static number of arguments at the callsite. It's pretty much junk, but of course, it is emitted by default. We rely on the peephole optimizer rewriting it into the much superior SYSREQ_N.

This patch replaces SYSREQ_C generation with SYSREQ_N so there is no chance of emitting it again.

I tried by hand to create code that emits SYSREQ_C past the peephole optimizer, but couldn't manage. I know it's possible, as I've seen it in the wild, which is unfortunate since I'd like to kill it off in the JIT too. Instead I'll just try to deprecate it, in that it won't be able to invoke newer natives.