### PR TITLE
Refactor native generation and place restrictions on the native API.

### DIFF
--- a/include/smx/smx-v2.h
+++ b/include/smx/smx-v2.h
@@ -28,7 +28,7 @@
 #ifndef _INCLUDE_SPFILE_HEADERS_v2_H
 #define _INCLUDE_SPFILE_HEADERS_v2_H
 
-#include <smx-headers.h>
+#include <smx/smx-headers.h>
 
 namespace sp {
 
@@ -120,7 +120,7 @@ enum class TypeSpec : uint8_t
   // Only legal as the initial byte or byte following "named" (0x7e) in a
   // parameter for a method signature.
   //
-  // Followed by a typespec. Only typespecs < 0x60 ar elegal.
+  // Followed by a typespec. Only typespecs < 0x60 are legal.
   byref             = 0x70,
 
   // Only legal as the initial byte or byte following "named" (0x7e) in a
@@ -134,13 +134,17 @@ enum class TypeSpec : uint8_t
   // Followed by:
   //     uint32    name    ; Index into the .names section.
   //     typespec  type    ; Type.
-  named             = 0x7E,
+  named             = 0x7D,
+
+  // Not legal; used as a placeholder in certain contexts.
+  none              = 0x7E,
 
   // For readability, this may be emitted at the end of typespec lists. It must
   // not be emitted at the end of nested typespecs.
   terminator        = 0x7F
 };
 
+#if 0
 // Flags for method definitions.
 enum class MethodFlags : uint32_t
 {
@@ -202,6 +206,7 @@ struct smx_pcode_header_t
   // Number of bytes of pcode in the method.
   uint32_t length;
 };
+#endif
 
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 // DO NOT DEFINE NEW STRUCTURES BELOW.

--- a/include/sp_vm_types.h
+++ b/include/sp_vm_types.h
@@ -154,16 +154,33 @@ typedef struct sp_pubvar_s
 #define SP_NTVFLAG_EPHEMERAL		(1<<1)	/**< Native can be unbound */
 
 /** 
- * @brief Native lookup table, by default names point back to the sp_plugin_infotab_t structure.
+ * @brief Information about a native entry in a plugin.
  */
-typedef struct sp_native_s
+struct sp_native_t
 {
-	SPVM_NATIVE_FUNC	pfn;	/**< Function pointer */
-	const char *		name;	/**< Name of function */
-	uint32_t			status;	/**< Status flags */
-	uint32_t			flags;	/**< Native flags */
-	void *				user;	/**< Host-specific data */
-} sp_native_t;
+  sp_native_t()
+   : unused1(nullptr),
+     name(nullptr),
+     status(0),
+     flags(0),
+     user(nullptr)
+  {}
+
+  // @brief Deprecated; do not use.
+	SPVM_NATIVE_FUNC	unused1;
+
+  // @brief Name of the native.
+	const char*		name;
+
+  // @brief Binding status (either SP_NATIVE_UNBOUND or SP_NATIVE_BOUND).
+	uint32_t			status;
+
+  // @brief Extra flags set by the host application.
+	uint32_t			flags;
+
+  // @brief An arbitrary pointer provided by the host application.
+	void *				user;
+};
 
 /** 
  * @brief Used for setting natives from modules/host apps.

--- a/vm/api.cpp
+++ b/vm/api.cpp
@@ -290,6 +290,10 @@ SourcePawnEngine2::DestroyFakeNative(SPVM_NATIVE_FUNC func)
   return Environment::get()->FreeCode((void *)func);
 }
 
+#if !defined(SOURCEPAWN_VERSION)
+# define SOURCEPAWN_VERSION "SourcePawn 1.8"
+#endif
+
 const char *
 SourcePawnEngine2::GetEngineName()
 {

--- a/vm/environment.h
+++ b/vm/environment.h
@@ -43,10 +43,10 @@ class Environment : public ISourcePawnEnvironment
 
   static Environment *New();
 
-  void Shutdown() KE_OVERRIDE;
-  ISourcePawnEngine *APIv1() KE_OVERRIDE;
-  ISourcePawnEngine2 *APIv2() KE_OVERRIDE;
-  int ApiVersion() KE_OVERRIDE {
+  void Shutdown() override;
+  ISourcePawnEngine *APIv1() override;
+  ISourcePawnEngine2 *APIv2() override;
+  int ApiVersion() override {
     return SOURCEPAWN_API_VERSION;
   }
 
@@ -55,10 +55,10 @@ class Environment : public ISourcePawnEnvironment
 
   bool InstallWatchdogTimer(int timeout_ms);
 
-  void EnterExceptionHandlingScope(ExceptionHandler *handler) KE_OVERRIDE;
-  void LeaveExceptionHandlingScope(ExceptionHandler *handler) KE_OVERRIDE;
-  bool HasPendingException(const ExceptionHandler *handler) KE_OVERRIDE;
-  const char *GetPendingExceptionMessage(const ExceptionHandler *handler) KE_OVERRIDE;
+  void EnterExceptionHandlingScope(ExceptionHandler *handler) override;
+  void LeaveExceptionHandlingScope(ExceptionHandler *handler) override;
+  bool HasPendingException(const ExceptionHandler *handler) override;
+  const char *GetPendingExceptionMessage(const ExceptionHandler *handler) override;
 
   // Runtime functions.
   const char *GetErrorString(int err);

--- a/vm/plugin-context.cpp
+++ b/vm/plugin-context.cpp
@@ -709,57 +709,6 @@ PluginContext::pushTracker(uint32_t amount)
   return SP_ERROR_NONE;
 }
 
-cell_t
-PluginContext::invokeNative(ucell_t native_idx, cell_t *params)
-{
-  cell_t save_sp = sp_;
-  cell_t save_hp = hp_;
-
-  const sp_native_t *native = m_pRuntime->GetNative(native_idx);
-
-  if (native->status == SP_NATIVE_UNBOUND) {
-    ReportErrorNumber(SP_ERROR_INVALID_NATIVE);
-    return 0;
-  }
-
-  cell_t result = native->pfn(this, params);
-
-  if (save_sp != sp_) {
-    if (!env_->hasPendingException())
-      ReportErrorNumber(SP_ERROR_STACKLEAK);
-    return 0;
-  }
-  if (save_hp != hp_) {
-    if (!env_->hasPendingException())
-      ReportErrorNumber(SP_ERROR_HEAPLEAK);
-    return 0;
-  }
-
-  return result;
-}
-
-cell_t
-PluginContext::invokeBoundNative(SPVM_NATIVE_FUNC pfn, cell_t *params)
-{
-  cell_t save_sp = sp_;
-  cell_t save_hp = hp_;
-
-  cell_t result = pfn(this, params);
-
-  if (save_sp != sp_) {
-    if (!env_->hasPendingException())
-      ReportErrorNumber(SP_ERROR_STACKLEAK);
-    return result;
-  }
-  if (save_hp != hp_) {
-    if (!env_->hasPendingException())
-      ReportErrorNumber(SP_ERROR_HEAPLEAK);
-    return result;
-  }
-
-  return result;
-}
-
 struct array_creation_t
 {
   const cell_t *dim_list;     /* Dimension sizes */

--- a/vm/plugin-context.h
+++ b/vm/plugin-context.h
@@ -151,8 +151,6 @@ class PluginContext : public IPluginContext
 
   int generateArray(cell_t dims, cell_t *stk, bool autozero);
   int generateFullArray(uint32_t argc, cell_t *argv, int autozero);
-  cell_t invokeNative(ucell_t native_idx, cell_t *params);
-  cell_t invokeBoundNative(SPVM_NATIVE_FUNC pfn, cell_t *params);
 
   inline bool checkAddress(cell_t *stk, cell_t addr) {
     if (uint32_t(addr) >= mem_size_)

--- a/vm/plugin-runtime.h
+++ b/vm/plugin-runtime.h
@@ -36,6 +36,14 @@ struct floattbl_t
   unsigned int index;
 };
 
+struct NativeEntry : public sp_native_t
+{
+  NativeEntry()
+   : legacy_fn(nullptr)
+  {}
+  SPVM_NATIVE_FUNC legacy_fn;
+};
+
 /* Jit wants fast access to this so we expose things as public */
 class PluginRuntime
   : public SourcePawn::IPluginRuntime,
@@ -75,13 +83,17 @@ class PluginRuntime
   void SetNames(const char *fullname, const char *name);
   unsigned GetNativeReplacement(size_t index);
   ScriptedInvoker *GetPublicFunction(size_t index);
-  int UpdateNativeBinding(uint32_t index, SPVM_NATIVE_FUNC pfn, uint32_t flags, void *data) KE_OVERRIDE;
-  const sp_native_t *GetNative(uint32_t index) KE_OVERRIDE;
-  int LookupLine(ucell_t addr, uint32_t *line) KE_OVERRIDE;
-  int LookupFunction(ucell_t addr, const char **name) KE_OVERRIDE;
-  int LookupFile(ucell_t addr, const char **filename) KE_OVERRIDE;
-  const char *GetFilename() KE_OVERRIDE {
+  int UpdateNativeBinding(uint32_t index, SPVM_NATIVE_FUNC pfn, uint32_t flags, void *data) override;
+  const sp_native_t *GetNative(uint32_t index) override;
+  int LookupLine(ucell_t addr, uint32_t *line) override;
+  int LookupFunction(ucell_t addr, const char **name) override;
+  int LookupFile(ucell_t addr, const char **filename) override;
+  const char *GetFilename() override {
     return full_name_.chars();
+  }
+
+  NativeEntry* NativeAt(size_t index) {
+    return &natives_[index];
   }
 
   PluginContext *GetBaseContext();
@@ -121,7 +133,7 @@ class PluginRuntime
   ke::AString full_name_;
   Code code_;
   Data data_;
-  ke::AutoArray<sp_native_t> natives_;
+  ke::AutoArray<NativeEntry> natives_;
   ke::AutoArray<sp_public_t> publics_;
   ke::AutoArray<sp_pubvar_t> pubvars_;
   ke::AutoArray<ScriptedInvoker *> entrypoints_;

--- a/vm/stack-frames.h
+++ b/vm/stack-frames.h
@@ -23,6 +23,13 @@ using namespace SourcePawn;
 class PluginContext;
 class PluginRuntime;
 
+enum class FrameType : uintptr_t
+{
+  None,
+  Helper,
+  LegacyNative
+};
+
 // An ExitFrame represents the state of the most recent exit from VM state to
 // the outside world. Because this transition is on a critical path, we declare
 // exactly one ExitFrame and save/restore it in InvokeFrame(). Anytime we're in
@@ -32,32 +39,28 @@ class ExitFrame
  public:
   ExitFrame()
    : exit_sp_(nullptr),
-     exit_native_(-1)
+     frame_type_(FrameType::None)
   {}
 
  public:
   const intptr_t *exit_sp() const {
     return exit_sp_;
   }
-  bool has_exit_native() const {
-    return exit_native_ != -1;
-  }
-  uint32_t exit_native() const {
-    assert(has_exit_native());
-    return exit_native_;
+  FrameType frame_type() const {
+    return frame_type_;
   }
 
  public:
   static inline size_t offsetOfExitSp() {
     return offsetof(ExitFrame, exit_sp_);
   }
-  static inline size_t offsetOfExitNative() {
-    return offsetof(ExitFrame, exit_native_);
+  static inline size_t offsetOfFrameType() {
+    return offsetof(ExitFrame, frame_type_);
   }
 
  private:
   const intptr_t *exit_sp_;
-  int exit_native_;
+  FrameType frame_type_;
 };
 
 // An InvokeFrame represents one activation of Execute2().

--- a/vm/x86/frames-x86.h
+++ b/vm/x86/frames-x86.h
@@ -44,20 +44,18 @@ struct JitFrame
 //
 // Note that it looks reversed compared to JitFrame because we capture the sp
 // before saving registers and pushing arguments.
-struct JitExitFrameForNative
+struct JitExitFrameForLegacyNative
 {
   void *return_address;
   PluginContext *cx;
-  union {
-    uint32_t native_index;
-    SPVM_NATIVE_FUNC fn;
-  } arg;
   const cell_t *params;
+  uint32_t native_index;
+  cell_t saved_hp;
   cell_t saved_alt;
 
-  static inline const JitExitFrameForNative *FromExitSp(const intptr_t *exit_sp) {
-    return reinterpret_cast<const JitExitFrameForNative *>(
-      reinterpret_cast<const uint8_t *>(exit_sp) - sizeof(JitExitFrameForNative));
+  static inline const JitExitFrameForLegacyNative *FromExitSp(const intptr_t *exit_sp) {
+    return reinterpret_cast<const JitExitFrameForLegacyNative *>(
+      reinterpret_cast<const uint8_t *>(exit_sp) - sizeof(JitExitFrameForLegacyNative));
   }
 };
 

--- a/vm/x86/jit_x86.cpp
+++ b/vm/x86/jit_x86.cpp
@@ -295,20 +295,6 @@ InvokePopTrackerAndSetHeap(PluginContext *cx)
   return cx->popTrackerAndSetHeap();
 }
 
-// Error code must be checked in the environment.
-static cell_t
-InvokeNativeHelper(PluginContext *cx, ucell_t native_idx, cell_t *params)
-{
-  return cx->invokeNative(native_idx, params);
-}
-
-// Error code must be checked in the environment.
-static cell_t
-InvokeBoundNativeHelper(PluginContext *cx, SPVM_NATIVE_FUNC fn, cell_t *params)
-{
-  return cx->invokeBoundNative(fn, params);
-}
-
 // No exit frame - error code is returned directly.
 static int
 InvokeGenerateFullArray(PluginContext *cx, uint32_t argc, cell_t *argv, int autozero)
@@ -1276,8 +1262,12 @@ Compiler::emitOp(OPCODE op)
       break;
 
     case OP_SYSREQ_C:
+      if (!emitSysreqC())
+        return false;
+      break;
+
     case OP_SYSREQ_N:
-      if (!emitNativeCall(op))
+      if (!emitSysreqN())
         return false;
       break;
 
@@ -1452,7 +1442,7 @@ Compiler::emitCallThunks()
     // Create the exit frame, then align the stack.
     __ push(0);
     __ movl(ecx, intptr_t(&Environment::get()->exit_frame()));
-    __ movl(Operand(ecx, ExitFrame::offsetOfExitNative()), -1);
+    __ movl(Operand(ecx, ExitFrame::offsetOfFrameType()), uint32_t(FrameType::Helper));
     __ movl(Operand(ecx, ExitFrame::offsetOfExitSp()), esp);
 
     // We need to push 4 arguments, and one of them will need an extra word
@@ -1490,7 +1480,7 @@ Compiler::readCell()
 }
 
 bool
-Compiler::emitNativeCall(OPCODE op)
+Compiler::emitSysreqN()
 {
   uint32_t native_index = readCell();
 
@@ -1499,31 +1489,67 @@ Compiler::emitNativeCall(OPCODE op)
     return false;
   }
 
-  uint32_t num_params;
-  if (op == OP_SYSREQ_N) {
-    num_params = readCell();
+  NativeEntry* native = rt_->NativeAt(native_index);
+  uint32_t nparams = readCell();
 
-    // See if we can get a replacement opcode. If we can, then recursively
-    // call emitOp() to generate it. Note: it's important that we do this
-    // before generating any code for the SYSREQ.N.
-    unsigned replacement = rt_->GetNativeReplacement(native_index);
+  if (native->status == SP_NATIVE_BOUND &&
+      !(native->flags & (SP_NTVFLAG_EPHEMERAL|SP_NTVFLAG_OPTIONAL)))
+  {
+    uint32_t replacement = rt_->GetNativeReplacement(native_index);
     if (replacement != OP_NOP)
       return emitOp((OPCODE)replacement);
-
-    // Store the number of parameters.
-    __ movl(Operand(stk, -4), num_params);
-    __ subl(stk, 4);
   }
 
-  // Create the exit frame. This is a JitExitFrameForNative, so everything we
-  // push up to the return address of the call instruction is reflected in
-  // that structure.
+  // Store the number of parameters on the stack.
+  __ movl(Operand(stk, -4), nparams);
+  __ subl(stk, 4);
+  if (!emitLegacyNativeCall(native_index, native))
+    return false;
+  __ addl(stk, (nparams + 1) * sizeof(cell_t));
+
+  return true;
+}
+
+bool
+Compiler::emitSysreqC()
+{
+  uint32_t native_index = readCell();
+
+  if (native_index >= image_->NumNatives()) {
+    error_ = SP_ERROR_INSTRUCTION_PARAM;
+    return false;
+  }
+
+  return emitLegacyNativeCall(native_index, rt_->NativeAt(native_index));
+}
+
+bool
+Compiler::emitLegacyNativeCall(uint32_t native_index, NativeEntry* native)
+{
+  // Create the exit frame. This is a JitExitFrameForLegacyNative, so
+  // everything we push up to the return address of the call instruction is
+  // reflected in that structure.
   __ movl(eax, intptr_t(&Environment::get()->exit_frame()));
-  __ movl(Operand(eax, ExitFrame::offsetOfExitNative()), native_index);
+  __ movl(Operand(eax, ExitFrame::offsetOfFrameType()), uint32_t(FrameType::LegacyNative));
   __ movl(Operand(eax, ExitFrame::offsetOfExitSp()), esp);
 
   // Save registers.
   __ push(edx);
+
+  // Check whether the native is bound.
+  bool immutable = native->status == SP_NATIVE_BOUND &&
+                   !(native->flags & (SP_NTVFLAG_EPHEMERAL|SP_NTVFLAG_OPTIONAL));
+  if (!immutable) {
+    __ movl(edx, Operand(ExternalAddress(&native->legacy_fn)));
+    __ testl(edx, edx);
+    jumpOnError(zero, SP_ERROR_INVALID_NATIVE);
+  }
+
+  // Save the old heap pointer.
+  __ push(Operand(hpAddr()));
+
+  // Push the native index - this is for debugging/callstacks.
+  __ push(native_index);
 
   // Push the last parameter for the C++ function.
   __ push(stk);
@@ -1531,27 +1557,22 @@ Compiler::emitNativeCall(OPCODE op)
   // Relocate our absolute stk to be dat-relative, and update the context's
   // view.
   __ subl(stk, dat);
-  __ movl(eax, intptr_t(context_));
-  __ movl(Operand(eax, PluginContext::offsetOfSp()), stk);
+  __ movl(Operand(spAddr()), stk);
 
-  const sp_native_t *native = rt_->GetNative(native_index);
-  if ((native->status != SP_NATIVE_BOUND) ||
-      (native->flags & (SP_NTVFLAG_OPTIONAL | SP_NTVFLAG_EPHEMERAL)))
-  {
-    // The native is either unbound, or it could become unbound in the
-    // future. Invoke the slower native callback.
-    __ push(native_index);
-    __ push(intptr_t(rt_->GetBaseContext()));
-    __ call(ExternalAddress((void *)InvokeNativeHelper));
-  } else {
-    // The native is bound so we have a few more guarantees.
-    __ push(intptr_t(native->pfn));
-    __ push(intptr_t(rt_->GetBaseContext()));
-    __ call(ExternalAddress((void *)InvokeBoundNativeHelper));
-  }
+  // Push the first parameter, the context.
+  __ push(intptr_t(rt_->GetBaseContext()));
 
+  // Invoke the native.
+  if (immutable)
+    __ call(ExternalAddress(native->legacy_fn));
+  else
+    __ call(edx);
   // Map the return address to the cip that initiated this call.
   emitCipMapping(op_cip_);
+
+  // Restore the heap pointer.
+  __ movl(edx, Operand(esp, 3 * sizeof(intptr_t)));
+  __ movl(Operand(hpAddr()), edx);
 
   // Check for errors. Note we jump directly to the return stub since the
   // error has already been reported.
@@ -1561,13 +1582,8 @@ Compiler::emitNativeCall(OPCODE op)
   
   // Restore local state.
   __ addl(stk, dat);
-  __ addl(esp, 12);
+  __ addl(esp, 4 * sizeof(intptr_t));
   __ pop(edx);
-
-  if (op == OP_SYSREQ_N) {
-    // Pop the stack. Do not check the margins.
-    __ addl(stk, (num_params + 1) * sizeof(cell_t));
-  }
   return true;
 }
 
@@ -1785,7 +1801,7 @@ Compiler::emitErrorPaths()
     // Create the exit frame. We always get here through a call from the opcode
     // (and always via an out-of-line thunk).
     __ movl(ecx, intptr_t(&Environment::get()->exit_frame()));
-    __ movl(Operand(ecx, ExitFrame::offsetOfExitNative()), -1);
+    __ movl(Operand(ecx, ExitFrame::offsetOfFrameType()), uint32_t(FrameType::Helper));
     __ movl(Operand(ecx, ExitFrame::offsetOfExitSp()), esp);
 
     __ push(eax);
@@ -1808,7 +1824,7 @@ Compiler::emitErrorPaths()
 
     // Create the exit frame.
     __ movl(ecx, intptr_t(&Environment::get()->exit_frame()));
-    __ movl(Operand(ecx, ExitFrame::offsetOfExitNative()), -1);
+    __ movl(Operand(ecx, ExitFrame::offsetOfFrameType()), uint32_t(FrameType::Helper));
     __ movl(Operand(ecx, ExitFrame::offsetOfExitSp()), esp);
 
     // Since the return stub wipes out the stack, we don't need to subl after

--- a/vm/x86/jit_x86.h
+++ b/vm/x86/jit_x86.h
@@ -99,7 +99,9 @@ class Compiler
  private:
   Label *labelAt(size_t offset);
   bool emitCall();
-  bool emitNativeCall(sp::OPCODE op);
+  bool emitSysreqN();
+  bool emitLegacyNativeCall(uint32_t native_index, NativeEntry* native);
+  bool emitSysreqC();
   bool emitSwitch();
   void emitGenArray(bool autozero);
   void emitCallThunks();
@@ -115,6 +117,9 @@ class Compiler
   }
   ExternalAddress frmAddr() {
     return ExternalAddress(context_->addressOfFrm());
+  }
+  ExternalAddress spAddr() {
+    return ExternalAddress(context_->addressOfSp());
   }
 
   // Map a return address (i.e. an exit point from a function) to its source
@@ -141,7 +146,6 @@ class Compiler
   const cell_t *code_end_;
   Label *jump_map_;
   ke::Vector<BackwardJump> backward_jumps_;
-
   ke::Vector<CipMapEntry> cip_map_;
 
   // Errors.


### PR DESCRIPTION
This patch does a few things. First, it removes access to the native function pointer from the SourcePawn API. This allows us to introduce new signatures without breaking embedders.

Second, it refactors exit frames to not depend on a native index. Now there is an explicit "FrameType" enumeration. The native index is now stored explicitly in JitExitFrameForLegacyNative. This lets us introduce new exit frame types in the future.

Third, the native invocation helpers have been removed. These had two functions, one, they verified that no stack/heap leaks occurred, and second, they verified that the native was bound. The check for whether or not the native is bound has been inlined directly into JIT code, and the stack/heap leak checks have been removed.

These checks were not very important. SP is implicitly unwound upon returning to the JIT, since the JIT maintains a local copy. HP was not, but now it is explicitly saved and restored.