### PR TITLE
Add a new executable allocator.

### DIFF
--- a/vm/api.cpp
+++ b/vm/api.cpp
@@ -79,7 +79,10 @@ SourcePawnEngine::ExecAlloc(size_t size)
 void *
 SourcePawnEngine::AllocatePageMemory(size_t size)
 {
-  return Environment::get()->AllocateCode(size);
+  CodeChunk chunk = Environment::get()->AllocateCode(size + sizeof(CodeChunk));
+  CodeChunk* hidden = (CodeChunk*)chunk.address();
+  new (hidden) CodeChunk(chunk);
+  return hidden + 1;
 }
 
 void
@@ -97,7 +100,8 @@ SourcePawnEngine::SetReadWrite(void *ptr)
 void
 SourcePawnEngine::FreePageMemory(void *ptr)
 {
-  Environment::get()->FreeCode(ptr);
+  CodeChunk* hidden = (CodeChunk*)((uint8_t*)ptr - sizeof(CodeChunk));
+  hidden->~CodeChunk();
 }
 
 void
@@ -287,7 +291,7 @@ SourcePawnEngine2::CreateFakeNative(SPVM_FAKENATIVE_FUNC callback, void *pData)
 void
 SourcePawnEngine2::DestroyFakeNative(SPVM_NATIVE_FUNC func)
 {
-  return Environment::get()->FreeCode((void *)func);
+  return Environment::get()->APIv1()->FreePageMemory((void *)func);
 }
 
 #if !defined(SOURCEPAWN_VERSION)

--- a/vm/code-allocator.h
+++ b/vm/code-allocator.h
@@ -1,47 +1,104 @@
-#ifndef _INCLUDE_KNIGHT_KE_CODE_ALLOCATOR_H_
-#define _INCLUDE_KNIGHT_KE_CODE_ALLOCATOR_H_
+// vim: set sts=2 ts=8 sw=2 tw=99 et:
+// 
+// Copyright (C) 2006-2015 AlliedModders LLC
+// 
+// This file is part of SourcePawn. SourcePawn is free software: you can
+// redistribute it and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License along with
+// SourcePawn. If not, see http://www.gnu.org/licenses/.
+//
+#ifndef _include_sourcepawn_code_allocator_h_
+#define _include_sourcepawn_code_allocator_h_
 
 #include <stddef.h>
 #include <stdint.h>
+#include <am-refcounting.h>
+#include <am-vector.h>
 
-namespace Knight
+namespace sp {
+
+using namespace ke;
+
+// Manages CodeChunks, optimized for the underlying system allocator.
+class CodePool : public ke::Refcounted<CodePool>
 {
-	class KeCodeCache;
+  friend class CodeAllocator;
 
-	/**
-	 * @brief Creates a new code cache/allocator.
-	 *
-	 * @return				New code cache allocator.
-	 */
-	extern KeCodeCache *KE_CreateCodeCache();
+ public:
+  ~CodePool();
 
-	/**
-	 * @brief Destroys a code cache allocator.
-	 *
-	 * @param cache			Code cache object.
-	 */
-	extern void KE_DestroyCodeCache(KeCodeCache *cache);
+ private:
+  CodePool(uint8_t* start, size_t size);
 
-	/**
-	 * @brief Allocates code memory that is readable, writable, 
-	 * and executable.
-	 *
-	 * The address returned wlil be aligned, minimally, on a 16-byte 
-	 * boundary.
-	 *
-	 * @param cache			Code cache object.
-	 * @param size			Amount of memory needed.
-	 * @return				Address pointing to the memory.
-	 */
-	extern void *KE_AllocCode(KeCodeCache *cache, size_t size);
+  static PassRef<CodePool> AllocateFor(size_t bytes);
 
-	/**
-	 * @brief Frees code memory.
-	 *
-	 * @param cache			Code cache object.
-	 * @param code			Address of code memory.
-	 */
-	extern void KE_FreeCode(KeCodeCache *cache, void *code);
-}
+  uint8_t* allocate(size_t bytes);
+  size_t bytesFree() const {
+    return end_ - ptr_;
+  }
 
-#endif //_INCLUDE_KNIGHT_KE_CODE_ALLOCATOR_H_
+ private:
+  CodePool(const CodePool&) = delete;
+  void operator =(const CodePool&) = delete;
+
+ private:
+  uint8_t* start_;
+  uint8_t* ptr_;
+  uint8_t* end_;
+  size_t size_;
+};
+
+// Raw reference to allocated code.
+struct CodeChunk
+{
+  CodeChunk()
+   : address_(nullptr),
+     bytes_(0)
+  {}
+  CodeChunk(PassRef<CodePool> pool, uint8_t* address, size_t bytes)
+   : pool_(pool),
+     address_(address),
+     bytes_(bytes)
+  {}
+
+  uint8_t* address() const {
+    return address_;
+  }
+  size_t bytes() const {
+    return bytes_;
+  }
+
+ private:
+  Ref<CodePool> pool_;
+  uint8_t* address_;
+  size_t bytes_;
+};
+
+// Manages CodePools.
+class CodeAllocator
+{
+ public:
+  CodeAllocator();
+  ~CodeAllocator();
+
+  CodeChunk Allocate(size_t bytes);
+
+ private:
+  PassRef<CodePool> newPool(size_t bytes);
+  PassRef<CodePool> findPool(size_t bytes);
+  CodeChunk allocateInPool(Ref<CodePool> pool, size_t bytes);
+
+ private:
+  CodeAllocator(const CodeAllocator&) = delete;
+  void operator =(const CodeAllocator&) = delete;
+
+ private:
+  Vector<Ref<CodePool>> cached_pools_;
+};
+
+} // namespace sp
+
+#endif // _sourcepawn_code_allocator_h_

--- a/vm/code-stubs.cpp
+++ b/vm/code-stubs.cpp
@@ -17,7 +17,6 @@ using namespace sp;
 
 CodeStubs::CodeStubs(Environment *env)
  : env_(env),
-   invoke_stub_(nullptr),
    return_stub_(nullptr)
 {
 }
@@ -30,11 +29,4 @@ CodeStubs::Initialize()
   if (!CompileInvokeStub())
     return false;
   return true;
-}
-
-void
-CodeStubs::Shutdown()
-{
-  if (invoke_stub_)
-    env_->FreeCode(invoke_stub_);
 }

--- a/vm/code-stubs.h
+++ b/vm/code-stubs.h
@@ -15,6 +15,7 @@
 
 #include <stdint.h>
 #include <sp_vm_api.h>
+#include "code-allocator.h"
 
 namespace sp {
 
@@ -30,12 +31,11 @@ class CodeStubs
 
  public:
   bool Initialize();
-  void Shutdown();
 
   SPVM_NATIVE_FUNC CreateFakeNativeStub(SPVM_FAKENATIVE_FUNC callback, void *userData);
 
   InvokeStubFn InvokeStub() const {
-    return (InvokeStubFn)invoke_stub_;
+    return (InvokeStubFn)invoke_stub_.address();
   }
   void *ReturnStub() const {
     return return_stub_;
@@ -48,7 +48,7 @@ class CodeStubs
 
  private:
   Environment *env_;
-  void *invoke_stub_;
+  CodeChunk invoke_stub_;
   void *return_stub_;   // Owned by invoke_stub_.
 };
 

--- a/vm/compiled-function.cpp
+++ b/vm/compiled-function.cpp
@@ -16,12 +16,11 @@
 
 using namespace sp;
 
-CompiledFunction::CompiledFunction(void *entry_addr, size_t code_length,
+CompiledFunction::CompiledFunction(const CodeChunk& code,
                                    cell_t pcode_offs,
                                    FixedArray<LoopEdge> *edges,
                                    FixedArray<CipMapEntry> *cipmap)
-  : entry_(entry_addr),
-    code_length_(code_length),
+  : code_(code),
     code_offset_(pcode_offs),
     edges_(edges),
     cip_map_(cipmap)
@@ -30,7 +29,6 @@ CompiledFunction::CompiledFunction(void *entry_addr, size_t code_length,
 
 CompiledFunction::~CompiledFunction()
 {
-  Environment::get()->FreeCode(entry_);
 }
 
 static int cip_map_entry_cmp(const void *a1, const void *aEntry)
@@ -47,11 +45,11 @@ static int cip_map_entry_cmp(const void *a1, const void *aEntry)
 ucell_t
 CompiledFunction::FindCipByPc(void *pc)
 {
-  if (uintptr_t(pc) < uintptr_t(entry_))
+  if (uintptr_t(pc) < uintptr_t(code_.address()))
     return kInvalidCip;
 
-  uint32_t pcoffs = intptr_t(pc) - intptr_t(entry_);
-  if (pcoffs > code_length_)
+  uint32_t pcoffs = intptr_t(pc) - intptr_t(code_.address());
+  if (pcoffs > code_.bytes())
     return kInvalidCip;
 
   void *ptr = bsearch(

--- a/vm/compiled-function.h
+++ b/vm/compiled-function.h
@@ -16,6 +16,7 @@
 #include <sp_vm_types.h>
 #include <am-fixedarray.h>
 #include <am-refcounting.h>
+#include "code-allocator.h"
 
 namespace sp {
 
@@ -43,8 +44,7 @@ static const ucell_t kInvalidCip = 0xffffffff;
 class CompiledFunction
 {
  public:
-  CompiledFunction(void *entry_addr,
-                   size_t code_length,
+  CompiledFunction(const CodeChunk& code,
                    cell_t pcode_offs,
                    FixedArray<LoopEdge> *edges,
                    FixedArray<CipMapEntry> *cip_map);
@@ -52,7 +52,7 @@ class CompiledFunction
 
  public:
   void *GetEntryAddress() const {
-    return entry_;
+    return code_.address();
   }
   cell_t GetCodeOffset() const {
     return code_offset_;
@@ -67,8 +67,7 @@ class CompiledFunction
   ucell_t FindCipByPc(void *pc);
 
  private:
-  void *entry_;
-  size_t code_length_;
+  CodeChunk code_;
   cell_t code_offset_;
   AutoPtr<FixedArray<LoopEdge>> edges_;
   AutoPtr<FixedArray<CipMapEntry>> cip_map_;

--- a/vm/environment.cpp
+++ b/vm/environment.cpp
@@ -29,7 +29,6 @@ Environment::Environment()
    profiler_(nullptr),
    jit_enabled_(true),
    profiling_enabled_(false),
-   code_pool_(nullptr),
    top_(nullptr)
 {
 }
@@ -68,9 +67,7 @@ Environment::Initialize()
   api_v2_ = new SourcePawnEngine2();
   code_stubs_ = new CodeStubs(this);
   watchdog_timer_ = new WatchdogTimer(this);
-
-  if ((code_pool_ = Knight::KE_CreateCodeCache()) == nullptr)
-    return false;
+  code_alloc_ = new CodeAllocator();
 
   // Safe to initialize code now that we have the code cache.
   if (!code_stubs_->Initialize())
@@ -83,8 +80,8 @@ void
 Environment::Shutdown()
 {
   watchdog_timer_->Shutdown();
-  code_stubs_->Shutdown();
-  Knight::KE_DestroyCodeCache(code_pool_);
+  code_stubs_ = nullptr;
+  code_alloc_ = nullptr;
 
   assert(sEnvironment == this);
   sEnvironment = nullptr;
@@ -165,16 +162,10 @@ Environment::GetErrorString(int error)
   return sErrorMsgTable[error];
 }
 
-void *
+CodeChunk
 Environment::AllocateCode(size_t size)
 {
-  return Knight::KE_AllocCode(code_pool_, size);
-}
-
-void
-Environment::FreeCode(void *code)
-{
-  Knight::KE_FreeCode(code_pool_, code);
+  return code_alloc_->Allocate(size);
 }
 
 void

--- a/vm/environment.h
+++ b/vm/environment.h
@@ -69,8 +69,7 @@ class Environment : public ISourcePawnEnvironment
   void ReportErrorVA(int code, const char *fmt, va_list ap);
 
   // Allocate and free executable memory.
-  void *AllocateCode(size_t size);
-  void FreeCode(void *code);
+  CodeChunk AllocateCode(size_t size);
   CodeStubs *stubs() {
     return code_stubs_;
   }
@@ -175,7 +174,7 @@ class Environment : public ISourcePawnEnvironment
   bool jit_enabled_;
   bool profiling_enabled_;
 
-  Knight::KeCodeCache *code_pool_;
+  ke::AutoPtr<CodeAllocator> code_alloc_;
   ke::InlineList<PluginRuntime> runtimes_;
 
   uintptr_t frame_id_;

--- a/vm/x86/code-stubs-x86.cpp
+++ b/vm/x86/code-stubs-x86.cpp
@@ -26,10 +26,10 @@ CodeStubs::InitializeFeatureDetection()
 {
   MacroAssemblerX86 masm;
   MacroAssemblerX86::GenerateFeatureDetection(masm);
-  void *code = LinkCode(env_, masm);
-  if (!code)
+  CodeChunk code = LinkCode(env_, masm);
+  if (!code.address())
     return false;
-  MacroAssemblerX86::RunFeatureDetection(code);
+  MacroAssemblerX86::RunFeatureDetection(code.address());
   return true;
 }
 
@@ -98,10 +98,10 @@ CodeStubs::CompileInvokeStub()
   __ jmp(&ret);
 
   invoke_stub_ = LinkCode(env_, masm);
-  if (!invoke_stub_)
+  if (!invoke_stub_.address())
     return false;
 
-  return_stub_ = reinterpret_cast<uint8_t *>(invoke_stub_) + error.offset();
+  return_stub_ = reinterpret_cast<uint8_t *>(invoke_stub_.address()) + error.offset();
   return true;
 }
 
@@ -129,5 +129,5 @@ CodeStubs::CreateFakeNativeStub(SPVM_FAKENATIVE_FUNC callback, void *pData)
   __ pop(ebx);
   __ ret();
 
-  return (SPVM_NATIVE_FUNC)LinkCode(env_, masm);
+  return (SPVM_NATIVE_FUNC)LinkCodeToLegacyPtr(env_, masm);
 }

--- a/vm/x86/jit_x86.cpp
+++ b/vm/x86/jit_x86.cpp
@@ -261,8 +261,8 @@ Compiler::emit(int *errp)
   // This has to come last.
   emitErrorPaths();
 
-  uint8_t *code = LinkCode(env_, masm);
-  if (!code) {
+  CodeChunk code = LinkCode(env_, masm);
+  if (!code.address()) {
     *errp = SP_ERROR_OUT_OF_MEMORY;
     return NULL;
   }
@@ -279,7 +279,7 @@ Compiler::emit(int *errp)
     new FixedArray<CipMapEntry>(cip_map_.length()));
   memcpy(cipmap->buffer(), cip_map_.buffer(), cip_map_.length() * sizeof(CipMapEntry));
 
-  return new CompiledFunction(code, masm.length(), pcode_start_, edges.take(), cipmap.take());
+  return new CompiledFunction(code, pcode_start_, edges.take(), cipmap.take());
 }
 
 // No exit frame - error code is returned directly.

--- a/vm/x86/x86-utils.cpp
+++ b/vm/x86/x86-utils.cpp
@@ -15,13 +15,27 @@
 
 using namespace sp;
 
-uint8_t *
+CodeChunk
 sp::LinkCode(Environment *env, AssemblerX86 &masm)
+{
+  if (masm.outOfMemory())
+    return CodeChunk();
+
+  CodeChunk code = env->AllocateCode(masm.length());
+  if (!code.address())
+    return code;
+
+  masm.emitToExecutableMemory(code.address());
+  return code;
+}
+
+uint8_t *
+sp::LinkCodeToLegacyPtr(Environment *env, AssemblerX86 &masm)
 {
   if (masm.outOfMemory())
     return nullptr;
 
-  void *code = env->AllocateCode(masm.length());
+  void *code = env->APIv1()->AllocatePageMemory(masm.length());
   if (!code)
     return nullptr;
 

--- a/vm/x86/x86-utils.h
+++ b/vm/x86/x86-utils.h
@@ -20,7 +20,8 @@ namespace sp {
 
 class Environment;
 
-uint8_t *LinkCode(Environment *env, AssemblerX86 &masm);
+CodeChunk LinkCode(Environment *env, AssemblerX86 &masm);
+uint8_t *LinkCodeToLegacyPtr(Environment *env, AssemblerX86 &masm);
 
 }
 


### PR DESCRIPTION
This is a replacement for our older, more complicated executable code allocator. The previous allocator kept a free list and searched free lists for matching allocations.

The new allocator keeps a small cache of recently used memory pools, and finds a best fit within the free space of those pools. We no longer track free regions.

Code allocation now returns an object which reference counts the underlying pool. This should be less error-prone than the old FreePageMemory() API. The older API is now a wrapper.