### PR TITLE
Introduce a real native binding API.

### DIFF
--- a/compiler/libpawnc.cpp
+++ b/compiler/libpawnc.cpp
@@ -1,4 +1,4 @@
-// vim: set sts=8 ts=2 sw=2 tw=99 noet:
+// vim: set sts=8 ts=2 sw=2 tw=99 et:
 /*  LIBPAWNC.C
  *
  *  A "glue file" for building the Pawn compiler as a DLL or shared library.
@@ -53,6 +53,8 @@ int pc_printf(const char *message,...)
   return ret;
 }
 
+unsigned sc_total_errors = 0;
+
 /* pc_error()
  * Called for producing error output.
  *    number      the error number (as documented in the manual)
@@ -80,6 +82,9 @@ static const char *prefix[3]={ "error", "fatal error", "warning" };
       idx = 1;
     else
       idx = 2;
+
+    if (idx == 0 || idx == 1)
+      sc_total_errors++;
 
     const char *pre=prefix[idx];
     if (firstline>=0)
@@ -234,9 +239,9 @@ char *pc_readsrc(void *handle,unsigned char *target,int maxchars)
         if (outptr < outend)
           *outptr++ = '\n';
       } else {
-				// Replace with \n.
-				*(outptr - 1) = '\n';
-			}
+        // Replace with \n.
+        *(outptr - 1) = '\n';
+      }
       break;
     }
   }

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -967,6 +967,7 @@ extern int pc_anytag;       /* global any tag */
 extern int glbstringread;	  /* last global string read */
 extern int sc_require_newdecls; /* only newdecls are allowed */
 extern bool sc_warnings_are_errors;
+extern unsigned sc_total_errors;
 
 extern constvalue sc_automaton_tab; /* automaton table */
 extern constvalue sc_state_tab;     /* state table */

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -969,6 +969,13 @@ extern int sc_require_newdecls; /* only newdecls are allowed */
 extern bool sc_warnings_are_errors;
 extern unsigned sc_total_errors;
 
+// Returns true if compilation is in its second phase (writing phase) and has
+// so far proceeded without error.
+static inline bool cc_ok()
+{
+  return sc_status == statWRITE && sc_total_errors == 0;
+}
+
 extern constvalue sc_automaton_tab; /* automaton table */
 extern constvalue sc_state_tab;     /* state table */
 

--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -5252,7 +5252,7 @@ static int newfunc(declinfo_t *decl, const int *thistag, int fpublic, int fstati
   cell cidx,glbdecl;
   short filenum;
 
-  assert(litidx==0);    /* literal queue should be empty */
+  assert(litidx==0 || !cc_ok());    /* literal queue should be empty */
   litidx=0;             /* clear the literal pool (should already be empty) */
   lastst=0;             /* no statement yet */
   cidx=0;               /* just to avoid compiler warnings */

--- a/compiler/sc3.cpp
+++ b/compiler/sc3.cpp
@@ -2798,7 +2798,6 @@ static void callfunction(symbol *sym, const svalue *aImplicitThis, value *lval_r
   int close,lvalue;
   int argpos;       /* index in the output stream (argpos==nargs if positional parameters) */
   int argidx=0;     /* index in "arginfo" list */
-  int nargs=0;      /* number of arguments */
   int heapalloc=0;
   int namedparams=FALSE;
   value lval = {0};
@@ -2868,6 +2867,8 @@ static void callfunction(symbol *sym, const svalue *aImplicitThis, value *lval_r
         lexpush();                /* reset the '.' */
     } /* if */
   } /* if */
+
+  unsigned nargs = 0;
   if (args.handling_this() || !close) {
     do {
       bool was_handling_this = args.handling_this();
@@ -3187,9 +3188,7 @@ static void callfunction(symbol *sym, const svalue *aImplicitThis, value *lval_r
         check_userop(NULL,arg[argidx].defvalue_tag,arg[argidx].tags[0],2,NULL,&dummytag);
         assert(dummytag==arg[argidx].tags[0]);
       } /* if */
-      pushreg(sPRI);            /* store the function argument on the stack */
-      markexpr(sPARM,NULL,0);   /* mark the end of a sub-expression */
-      sCallStackUsage++;
+      args.next_arg();
     } else {
       error(92,argidx);        /* argument count mismatch */
     } /* if */

--- a/compiler/sc4.cpp
+++ b/compiler/sc4.cpp
@@ -189,7 +189,7 @@ void writetrailer(void)
   } /* if */
 
   /* pad data segment to align the stack and the heap */
-  assert(litidx==0);            /* literal queue should have been emptied */
+  assert(litidx==0 || !cc_ok());            /* literal queue should have been emptied */
   assert(sc_dataalign % sizeof(cell) == 0);
   if (((glb_declared*sizeof(cell)) % sc_dataalign)!=0) {
     begdseg();

--- a/include/sp_native_api.h
+++ b/include/sp_native_api.h
@@ -1,0 +1,154 @@
+// vim: set ts=4 sw=4 tw=99 et:
+// 
+// Copyright (C) 2006-2015 AlliedModders LLC
+// 
+// This file is part of SourcePawn. SourcePawn is free software: you can
+// redistribute it and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License along with
+// SourcePawn. If not, see http://www.gnu.org/licenses/.
+//
+#ifndef _include_sourcepawn_includes_native_api_h_
+#define _include_sourcepawn_includes_native_api_h_
+
+#include <stdint.h>
+#include <am-refcounting.h>
+#include <am-function.h>
+
+namespace sp {
+class NativeGroup;
+class NativeRegistry;
+}
+
+namespace SourcePawn {
+
+class IPluginRuntime;
+
+// @brief An INativeGroup is used to unbind or remove natives that are part of
+// the same subsystem, library, or module.
+//
+// Native groups are created within native registries, and cannot be used
+// across registries.
+class INativeGroup : public ke::IRefcounted
+{
+ public:
+  // @brief Return a pointer to the implementation of this class.
+  virtual sp::NativeGroup* ToNativeGroup() = 0;
+
+  // @brief Returns true if the native group has any dependents.
+  //
+  // @return True if any runtimes depend on this native group, false otherwise.
+  virtual bool HasDependents() const = 0;
+
+  // @brief Enumerate all dependent plugin runtimes.
+  //
+  // @callback        Callback to be invoked for each dependent.
+  virtual void EnumerateDependents(ke::FuncPtr<void(IPluginRuntime*)> callback) const = 0;
+};
+
+// @brief Describes the calling convention of a native.
+struct NativeSignature
+{
+  // Flags from the NativeSpecFlags namespace.
+  uint32_t flags;
+
+  // Signature layout. Unused.
+  const uint8_t* signature;
+
+  // Length of signature. Unused.
+  size_t length;
+};
+
+// @brief Describes a native definition.
+struct NativeDef
+{
+  // The native's name.
+  const char* name;
+
+  // The native's method pointer.
+  void* method;
+
+  // The native's signature. If null, this native uses the old legacy
+  // signature:
+  //   int32_t (*)(SourcePawn::IPluginContext*, const int32_t*)
+  // (Where int32_t is aliased to cell_t.)
+  const NativeSignature* sig;
+};
+
+// @brief Describes a native cache.
+class INativeRegistry : public ke::IRefcounted
+{
+ public:
+  // @brief Returns a pointer to the structure's implementation.
+  virtual sp::NativeRegistry* ToNativeRegistry() = 0;
+
+  // @brief Allocate a native grouping object.
+  //
+  // @param delegate   A pointer to an object to receive notifications.
+  // @param name       Native group name, for internal debugging. The pointer
+  //                   must be statically scoped.
+  // @return           A new reference-counted INativeGroup object.
+  virtual ke::PassRef<INativeGroup> NewNativeGroup(const char* name) = 0;
+
+  // @brief Add natives to the native cache.
+  //
+  // @param group      The group that will own this native. This may be
+  //                   null. If non-null, the caller must own at least
+  //                   one reference for the duration of this call.
+  // @param defs       The native definition. Must be statically scoped.
+  // @param count      Number of natives in the vector.
+  virtual void AddNativeVector(INativeGroup* group, const NativeDef* def, size_t count) = 0;
+
+  // @brief Add a list of natives to the native cache.
+  //
+  // @param group      The group that will own this native. This may be
+  //                   null. If non-null, the caller must own at least
+  //                   one reference for the duration of this call.
+  // @param defs       Pointer to an array of native definitions. The list
+  //                   is terminated by NativeDef::name being null. Must be
+  //                   statically scoped.
+  virtual void AddNativeList(INativeGroup* group, const NativeDef* defs) = 0;
+
+  // @brief Add a legacy native list to the native cache. The list is
+  // terminated by a null "name" field.
+  //
+  // This internally converts a LegacyNativeDef to a NativeDef. The result of
+  // this conversion is allocated in the given registry, or if provided, the
+  // the group instead.
+  //
+  // @param group      The group that will own this native. This may be
+  //                   null. If non-null, the caller must own at least
+  //                   one reference for the duration of this call.
+  // @param defs       Native definitions.
+  virtual void AddLegacyNatives(INativeGroup* group, const sp_nativeinfo_t* defs) = 0;
+
+  // @brief Add a native router. This will invoke the given callback when the
+  // the native is invoked, with the given callback data.
+  //
+  // @param group      The group that will own this native. This may be
+  //                   null. If non-null, the caller must own at least
+  //                   one reference for the duration of this call.
+  // @param name       The native's name.
+  // @param callback   Callback to be invoked with the name.
+  // @param data       Data to be passed to the callback.
+  // @return           True on success, false otherwise.
+  virtual bool AddRoutedNative(INativeGroup* group,
+                               const char* name,
+                               SPVM_FAKENATIVE_FUNC callback,
+                               void* data) = 0;
+
+  // @brief Remove all natives owned by the given group.
+  //
+  // The caller must ensure that any actively bound natives in this group are
+  // bound with the SP_NTVFLAG_OPTIONAL flag. Otherwise, this call will fail.
+  // In a debug build an assert will fire.
+  //
+  // @param group      The group that is being unregistered. Cannot be null.
+  virtual void RemoveNatives(const ke::Ref<INativeGroup>& group) = 0;
+};
+
+} // namespace SourcePawn
+
+#endif // _include_sourcepawn_includes_native_api_h_

--- a/include/sp_vm_types.h
+++ b/include/sp_vm_types.h
@@ -150,8 +150,16 @@ typedef struct sp_pubvar_s
 #define SP_NATIVE_UNBOUND		(0)		/**< Native is undefined */
 #define SP_NATIVE_BOUND			(1)		/**< Native is bound */
 
-#define SP_NTVFLAG_OPTIONAL		(1<<0)	/**< Native is optional */
-#define SP_NTVFLAG_EPHEMERAL		(1<<1)	/**< Native can be unbound */
+// The native can be left unbound. This implies SP_NTVFLAG_EPHEMERAL.
+static const uint32_t SP_NTVFLAG_OPTIONAL  = (1<<0);
+
+// The native can be bound or unbound dynamically.
+static const uint32_t SP_NTVFLAG_EPHEMERAL = (1<<1);
+
+// The above flags are equivalent, but can be used to differentiate slightly
+// different cases in the host application. They are combined internally in
+// most cases.
+static const uint32_t SP_NTVFLAG_DYNAMIC = (SP_NTVFLAG_OPTIONAL|SP_NTVFLAG_EPHEMERAL);
 
 /** 
  * @brief Information about a native entry in a plugin.

--- a/vm/AMBuilder
+++ b/vm/AMBuilder
@@ -29,6 +29,8 @@ library.sources += [
   'environment.cpp',
   'file-utils.cpp',
   'md5/md5.cpp',
+  'native-group.cpp',
+  'native-registry.cpp',
   'opcodes.cpp',
   'plugin-context.cpp',
   'plugin-runtime.cpp',

--- a/vm/api.cpp
+++ b/vm/api.cpp
@@ -285,13 +285,12 @@ SourcePawnEngine2::LoadBinaryFromFile(const char *file, char *error, size_t maxl
 SPVM_NATIVE_FUNC
 SourcePawnEngine2::CreateFakeNative(SPVM_FAKENATIVE_FUNC callback, void *pData)
 {
-  return Environment::get()->stubs()->CreateFakeNativeStub(callback, pData);
+  return nullptr;
 }
 
 void
 SourcePawnEngine2::DestroyFakeNative(SPVM_NATIVE_FUNC func)
 {
-  return Environment::get()->APIv1()->FreePageMemory((void *)func);
 }
 
 #if !defined(SOURCEPAWN_VERSION)

--- a/vm/assembler.h
+++ b/vm/assembler.h
@@ -154,7 +154,11 @@ class ExternalAddress
 {
  public:
   explicit ExternalAddress(void *p)
-    : p_(p)
+   : p_(p)
+  {
+  }
+  explicit ExternalAddress(void* const* p)
+   : p_(const_cast<void **>(p))
   {
   }
 

--- a/vm/code-allocator.cpp
+++ b/vm/code-allocator.cpp
@@ -92,7 +92,7 @@ CodeAllocator::allocateInPool(Ref<CodePool> pool, size_t bytes)
 
 static const size_t kDefaultMinPoolSize = 1 * kMB;
 static size_t kPageGranularity = 0;
-static size_t kMinPoolSize = 1 * kMB;
+static size_t kMinPoolSize = kDefaultMinPoolSize;
 
 PassRef<CodePool>
 CodePool::AllocateFor(size_t askBytes)
@@ -108,7 +108,7 @@ CodePool::AllocateFor(size_t askBytes)
     kPageGranularity = sysconf(_SC_PAGESIZE);
 #endif
     assert(ke::IsAligned(kPageGranularity, kMallocAlignment));
-    assert(ke::IsAligned(kDefaultMinPoolSize, kPageGranularity));
+    assert(ke::IsAligned(kMinPoolSize, kPageGranularity));
   }
 
   // If the allocation is larger than our minimum pool size, we only align up

--- a/vm/code-stubs.h
+++ b/vm/code-stubs.h
@@ -15,6 +15,7 @@
 
 #include <stdint.h>
 #include <sp_vm_api.h>
+#include <am-utility.h>
 #include "code-allocator.h"
 
 namespace sp {
@@ -32,7 +33,7 @@ class CodeStubs
  public:
   bool Initialize();
 
-  SPVM_NATIVE_FUNC CreateFakeNativeStub(SPVM_FAKENATIVE_FUNC callback, void *userData);
+  CodeChunk CreateFakeNativeStub(SPVM_FAKENATIVE_FUNC callback, void *userData);
 
   InvokeStubFn InvokeStub() const {
     return (InvokeStubFn)invoke_stub_.address();

--- a/vm/environment.cpp
+++ b/vm/environment.cpp
@@ -16,6 +16,7 @@
 #include "api.h"
 #include "code-stubs.h"
 #include "watchdog_timer.h"
+#include "native-registry.h"
 #include <stdarg.h>
 
 using namespace sp;
@@ -392,4 +393,10 @@ int
 Environment::getPendingExceptionCode() const
 {
   return exception_code_;
+}
+
+ke::PassRef<INativeRegistry>
+Environment::NewNativeRegistry(const char* name)
+{
+  return new NativeRegistry(this, name);
 }

--- a/vm/environment.h
+++ b/vm/environment.h
@@ -59,6 +59,7 @@ class Environment : public ISourcePawnEnvironment
   void LeaveExceptionHandlingScope(ExceptionHandler *handler) override;
   bool HasPendingException(const ExceptionHandler *handler) override;
   const char *GetPendingExceptionMessage(const ExceptionHandler *handler) override;
+  ke::PassRef<INativeRegistry> NewNativeRegistry(const char* name) override;
 
   // Runtime functions.
   const char *GetErrorString(int err);

--- a/vm/native-group.cpp
+++ b/vm/native-group.cpp
@@ -1,0 +1,132 @@
+// vim: set sts=2 ts=8 sw=2 tw=99 et:
+// 
+// Copyright (C) 2006-2015 AlliedModders LLC
+// 
+// This file is part of SourcePawn. SourcePawn is free software: you can
+// redistribute it and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License along with
+// SourcePawn. If not, see http://www.gnu.org/licenses/.
+//
+#include "native-group.h"
+#include "native-registry.h"
+#include "plugin-runtime.h"
+#include "environment.h"
+
+using namespace sp;
+using namespace ke;
+using namespace SourcePawn;
+
+NativeGroup::NativeGroup(NativeRegistry* registry, const char* name)
+ : name_(name),
+   registry_(registry),
+   binding_generation_(0)
+{
+  weak_refs_.init();
+}
+
+bool
+NativeGroup::HasDependents() const
+{
+  return strong_refs_.elements() > 0;
+}
+
+void
+NativeGroup::EnumerateDependents(FuncPtr<void(SourcePawn::IPluginRuntime*)> callback) const
+{
+  for (StrongRefSet::iterator iter = strong_refs_.iter(); !iter.empty(); iter.next())
+    callback(*iter);
+}
+
+auto
+NativeGroup::addWeakRef(PluginRuntime* rt) -> PassRef<WeakRef>
+{
+  WeakRefMap::Insert p = weak_refs_.findForAdd(rt);
+  if (p.found())
+    return p->value;
+
+  Ref<WeakRef> ref = new WeakRef(rt, this);
+  weak_refs_.add(p, rt, ref);
+  return ref;
+}
+
+void
+NativeGroup::dropLastWeakRef(PluginRuntime* rt)
+{
+  WeakRefMap::Result r = weak_refs_.find(rt);
+  weak_refs_.remove(r);
+}
+
+void
+NativeGroup::detachWeakDependents()
+{
+  // Since wiping a plugin's native list could zap a WeakRef, and mutate the
+  // hashtable during iteration, we build a list first.
+  Vector<PluginRuntime*> runtimes;
+  for (WeakRefMap::iterator iter = weak_refs_.iter(); !iter.empty(); iter.next())
+    runtimes.append(iter->key);
+
+  for (size_t i = 0; i < runtimes.length(); i++) {
+    PluginRuntime* rt = runtimes[i];
+    for (size_t j = 0; j < rt->GetNativesNum(); j++) {
+      NativeEntry* entry = rt->NativeAt(j);
+      if (entry->weak_ref && entry->weak_ref->group() == this) {
+        assert(entry->flags & SP_NTVFLAG_DYNAMIC);
+        entry->binding = nullptr;
+        entry->status = SP_NATIVE_UNBOUND;
+        entry->weak_ref = nullptr;
+      }
+    }
+  }
+}
+
+void
+NativeGroup::addStrongRef(PluginRuntime* rt)
+{
+  StrongRefSet::Insert p = strong_refs_.findForAdd(rt);
+  if (p.found())
+    return;
+
+  strong_refs_.add(p, rt);
+  rt->addDependency(new StrongRef(rt, this));
+}
+
+void
+NativeGroup::dropStrongRef(PluginRuntime* rt)
+{
+  StrongRefSet::Result p = strong_refs_.find(rt);
+  strong_refs_.remove(p);
+}
+
+void
+NativeGroup::forEachNative(FuncPtr<void(const NativeDef*)> callback)
+{
+  for (size_t i = 0; i < natives_.length(); i++) {
+    for (size_t j = 0; j < natives_[i].length; j++)
+      callback(&natives_[i].defs[j]);
+  }
+}
+
+NativeGroup::WeakRef::WeakRef(PluginRuntime* rt, NativeGroup* group)
+ : rt_(rt),
+   group_(group)
+{
+}
+
+NativeGroup::WeakRef::~WeakRef()
+{
+  group_->dropLastWeakRef(rt_);
+}
+
+NativeGroup::StrongRef::StrongRef(PluginRuntime* rt, NativeGroup* group)
+ : rt_(rt),
+   group_(group)
+{
+}
+
+NativeGroup::StrongRef::~StrongRef()
+{
+  group_->dropStrongRef(rt_);
+}

--- a/vm/native-group.h
+++ b/vm/native-group.h
@@ -1,0 +1,157 @@
+// vim: set sts=2 ts=8 sw=2 tw=99 et:
+// 
+// Copyright (C) 2006-2015 AlliedModders LLC
+// 
+// This file is part of SourcePawn. SourcePawn is free software: you can
+// redistribute it and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License along with
+// SourcePawn. If not, see http://www.gnu.org/licenses/.
+//
+#ifndef _include_sourcepawn_vm_native_group_h_
+#define _include_sourcepawn_vm_native_group_h_
+
+#include <sp_vm_api.h>
+#include <am-hashmap.h>
+#include <am-hashset.h>
+#include <am-refcounting.h>
+#include <am-vector.h>
+#include <am-function.h>
+#include <string.h>
+
+namespace sp {
+
+using namespace SourcePawn;
+using namespace ke;
+
+class PluginRuntime;
+struct NativeEntry;
+
+class NativeGroup :
+  public SourcePawn::INativeGroup,
+  public ke::Refcounted<NativeGroup>
+{
+ public:
+  NativeGroup(NativeRegistry* cache, const char* name);
+
+  KE_IMPL_REFCOUNTING(NativeGroup);
+
+  NativeGroup* ToNativeGroup() override {
+    return this;
+  }
+  bool HasDependents() const override;
+  void EnumerateDependents(FuncPtr<void(SourcePawn::IPluginRuntime*)> callback) const override;
+
+  NativeRegistry* registry() const {
+    return registry_;
+  }
+  void forEachNative(FuncPtr<void(const NativeDef*)> callback);
+
+  void addHeldPointer(NativeDef* def) {
+    AutoArray<NativeDef> ptr(def);
+    held_pointers_.append(ke::Move(ptr));
+  }
+
+  unsigned bindingGeneration() const {
+    return binding_generation_;
+  }
+  void setBindingGeneration(unsigned binding_generation) {
+    binding_generation_ = binding_generation;
+  }
+
+ public:
+  // We allocate one WeakRef for each runtime that depends on this native
+  // group. When that plugin drops all references to the WeakRef, it will
+  // silently remove its dependency on to the native group.
+  class WeakRef : public ke::Refcounted<WeakRef>
+  {
+   public:
+    WeakRef(PluginRuntime* rt, NativeGroup* group);
+    ~WeakRef();
+
+    NativeGroup* group() const {
+      return group_;
+    }
+
+   private:
+    PluginRuntime* rt_;
+    Ref<NativeGroup> group_;
+  };
+
+  PassRef<WeakRef> addWeakRef(PluginRuntime* rt);
+  void dropLastWeakRef(PluginRuntime* rt);
+  void detachWeakDependents();
+
+ public:
+  // Strong references are for dependents that cannot be safely accessed once
+  // they are bound to this group. We require that these dependents be unloaded
+  // before dissolving a StrongRef.
+  //
+  // Most dependents are strong dependents, so rather than attach them to each
+  // native we attach a list in the PluginRuntime.
+  class StrongRef : public ke::Refcounted<StrongRef>
+  {
+   public:
+    StrongRef(PluginRuntime* rt, NativeGroup* group);
+    ~StrongRef();
+
+   private:
+    PluginRuntime* rt_;
+    Ref<NativeGroup> group_;
+  };
+
+  void addStrongRef(PluginRuntime* rt);
+  void dropStrongRef(PluginRuntime* rt);
+
+ public:
+  struct NativeVector {
+    NativeVector()
+     : defs(nullptr),
+       length(0)
+    {}
+    NativeVector(const NativeDef* defs, size_t count)
+     : defs(defs),
+       length(count)
+    {}
+    const NativeDef* defs;
+    size_t length;
+  };
+
+  void addNatives(const NativeVector& natives) {
+    natives_.append(natives);
+  }
+
+ private:
+  const char* name_;
+  Ref<NativeRegistry> registry_;
+  Vector<NativeVector> natives_;
+
+  struct RuntimePolicy {
+    static bool matches(PluginRuntime* key, PluginRuntime* other) {
+      return key == other;
+    }
+    static uint32_t hash(PluginRuntime* key) {
+      return HashPointer(key);
+    }
+  };
+
+  // Note: we don't store the WeakRef in a Ref<>, since we want the WeakRef's
+  // dtor to be responsible for fixing up the dependency map. If we used a
+  // Ref<> here its dtor would never fire.
+  typedef HashMap<PluginRuntime*, WeakRef*, RuntimePolicy> WeakRefMap;
+  WeakRefMap weak_refs_;
+
+  typedef HashSet<PluginRuntime*, RuntimePolicy> StrongRefSet;
+  mutable StrongRefSet strong_refs_;
+
+  unsigned binding_generation_;
+
+  // For storing lists that we had to construct dynamically.
+  ke::Vector<AutoArray<NativeDef>> held_pointers_;
+};
+
+} // namespace sp
+
+#endif // _include_sourcepawn_vm_native_group_h_

--- a/vm/native-registry.cpp
+++ b/vm/native-registry.cpp
@@ -1,0 +1,200 @@
+// vim: set sts=2 ts=8 sw=2 tw=99 et:
+// 
+// Copyright (C) 2006-2015 AlliedModders LLC
+// 
+// This file is part of SourcePawn. SourcePawn is free software: you can
+// redistribute it and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License along with
+// SourcePawn. If not, see http://www.gnu.org/licenses/.
+//
+#include "native-registry.h"
+#include "plugin-runtime.h"
+#include "environment.h"
+#include "code-stubs.h"
+
+using namespace sp;
+using namespace ke;
+using namespace SourcePawn;
+
+NativeRegistry::NativeRegistry(Environment* env, const char* name)
+ : env_(env),
+   name_(name),
+   binding_generation_(0)
+{
+  table_.init(128);
+}
+
+PassRef<INativeGroup>
+NativeRegistry::NewNativeGroup(const char* name)
+{
+  return new NativeGroup(this, name);
+}
+
+void
+NativeRegistry::AddNativeVector(INativeGroup* aGroup, const NativeDef* defs, size_t count)
+{
+  NativeGroup* group = aGroup ? aGroup->ToNativeGroup() : nullptr;
+  assert(!group || group->registry() == this);
+
+  for (size_t i = 0; i < count; i++)
+    addNative(group, &defs[i]);
+
+  if (group)
+    group->addNatives(NativeGroup::NativeVector(defs, count));
+}
+
+void
+NativeRegistry::AddNativeList(INativeGroup* aGroup, const NativeDef* defs)
+{
+  NativeGroup* group = aGroup ? aGroup->ToNativeGroup() : nullptr;
+  assert(!group || group->registry() == this);
+
+  size_t count = 0;
+  for (const NativeDef* iter = defs; iter->name; iter++, count++)
+    addNative(group, iter);
+
+  if (group)
+    group->addNatives(NativeGroup::NativeVector(defs, count));
+}
+
+void
+NativeRegistry::AddLegacyNatives(INativeGroup* group, const sp_nativeinfo_t* defs)
+{
+  size_t count = 0;
+  for (const sp_nativeinfo_t* iter = defs; iter->name; iter++)
+    count++;
+
+  NativeDef *newlist = new NativeDef[count];
+  for (size_t i = 0; i < count; i++) {
+    newlist[i].name = defs[i].name;
+    newlist[i].method = (void *)defs[i].func;
+    newlist[i].sig = nullptr;
+  }
+
+  AddNativeVector(group, newlist, count);
+
+  if (group)
+    group->ToNativeGroup()->addHeldPointer(newlist);
+  else
+    held_pointers_.append(newlist);
+}
+
+void
+NativeRegistry::addNative(NativeGroup* group, const NativeDef* def)
+{
+  NativeTable::Insert i = table_.findForAdd(def->name);
+  if (i.found()) {
+    assert(false);
+    return;
+  }
+  if (!table_.add(i))
+    return;
+
+  i->def = def;
+  i->group = group;
+}
+
+bool
+NativeRegistry::AddRoutedNative(INativeGroup* aGroup,
+                                const char* name,
+                                SPVM_FAKENATIVE_FUNC callback,
+                                void* data)
+{
+  NativeGroup* group = aGroup ? aGroup->ToNativeGroup() : nullptr;
+
+  AutoPtr<RoutedNative> rn(new RoutedNative);
+  rn->chunk = env_->stubs()->CreateFakeNativeStub(callback, data);
+  if (!rn->chunk.address())
+    return false;
+
+  rn->name = new char[strlen(name)+1];
+  strcpy(rn->name, name);
+
+  rn->def = new NativeDef;
+  rn->def->method = rn->chunk.address();
+  rn->def->name = rn->name;
+  rn->def->sig = nullptr;
+
+  CharsAndLength key(rn->name);
+  NativeTable::Insert i = table_.findForAdd(key);
+  if (i.found())
+    return false;
+
+  if (!table_.add(i))
+    return false;
+
+  i->def = rn->def;
+  i->group = group;
+  i->rn = rn.take();
+
+  if (group)
+    group->addNatives(NativeGroup::NativeVector(i->def, 1));
+  return true;
+}
+
+bool
+NativeRegistry::Bind(PluginRuntime* rt)
+{
+  // This generation number is valid only for this runtime.
+  binding_generation_++;
+
+  bool all_bound = true;
+  for (size_t i = 0; i < rt->GetNativesNum(); i++) {
+    NativeEntry* entry = rt->NativeAt(i);
+    if (entry->binding)
+      continue;
+
+    if (!bind(rt, entry)) {
+      if (!(entry->flags & SP_NTVFLAG_DYNAMIC))
+        all_bound = false;
+    }
+  }
+  return all_bound;
+}
+
+bool
+NativeRegistry::bind(PluginRuntime* rt, NativeEntry* entry)
+{
+  assert(!entry->binding || (entry->flags & SP_NTVFLAG_DYNAMIC));
+
+  CharsAndLength name(entry->name);
+  NativeTable::Result r = table_.find(name);
+  if (!r.found())
+    return false;
+
+  entry->status = SP_NATIVE_BOUND;
+  entry->binding = r->def;
+
+  entry->weak_ref = nullptr;
+  if (r->group) {
+    // If the native is optional, this becomes a weak reference. Otherwise,
+    // it's a strong reference.
+    if (entry->flags & SP_NTVFLAG_DYNAMIC) {
+      entry->weak_ref = r->group->addWeakRef(rt);
+    } else if (r->group->bindingGeneration() != binding_generation_) {
+      r->group->addStrongRef(rt);
+      r->group->setBindingGeneration(binding_generation_);
+    }
+  }
+  return true;
+}
+
+void
+NativeRegistry::RemoveNatives(const Ref<INativeGroup>& aGroup)
+{
+  NativeGroup* group = aGroup->ToNativeGroup();
+  group->detachWeakDependents();
+
+  assert(!group->HasDependents());
+
+  // Remove natives after having detached dependents. Otherwise, we could have
+  // freed a RoutedNative's allocated NativeDef.
+  for (NativeTable::iterator iter(&table_); !iter.empty(); iter.next()) {
+    if (iter->group != group)
+      continue;
+    iter.erase();
+  } 
+}

--- a/vm/native-registry.h
+++ b/vm/native-registry.h
@@ -1,0 +1,109 @@
+// vim: set sts=2 ts=8 sw=2 tw=99 et:
+// 
+// Copyright (C) 2006-2015 AlliedModders LLC
+// 
+// This file is part of SourcePawn. SourcePawn is free software: you can
+// redistribute it and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License along with
+// SourcePawn. If not, see http://www.gnu.org/licenses/.
+//
+#ifndef _include_sourcepawn_vm_native_cache_h_
+#define _include_sourcepawn_vm_native_cache_h_
+
+#include <sp_vm_api.h>
+#include <am-hashtable.h>
+#include <am-refcounting.h>
+#include "code-allocator.h"
+#include <string.h>
+
+namespace sp {
+
+using namespace SourcePawn;
+using namespace ke;
+
+class PluginRuntime;
+struct NativeEntry;
+
+class NativeRegistry :
+  public SourcePawn::INativeRegistry,
+  public ke::Refcounted<NativeRegistry>
+{
+ public:
+  NativeRegistry(Environment* env, const char* name);
+
+  KE_IMPL_REFCOUNTING(NativeRegistry);
+
+  NativeRegistry* ToNativeRegistry() override {
+    return this;
+  }
+  PassRef<INativeGroup> NewNativeGroup(const char* name) override;
+  void AddNativeVector(INativeGroup* group, const NativeDef* defs, size_t count) override;
+  void AddNativeList(INativeGroup* group, const NativeDef* defs) override;
+  void AddLegacyNatives(INativeGroup* group, const sp_nativeinfo_t* defs) override;
+  bool AddRoutedNative(INativeGroup* group,
+                       const char* name,
+                       SPVM_FAKENATIVE_FUNC callback,
+                       void* data) override;
+  void RemoveNatives(const Ref<INativeGroup>& group) override;
+
+  // Called by PluginRuntime::BindNatives.
+  bool Bind(PluginRuntime* rt);
+
+ private:
+  void addNative(NativeGroup* group, const NativeDef* def);
+  bool bind(PluginRuntime* rt, NativeEntry* entry);
+
+ private:
+  Environment* env_;
+  const char* name_;
+
+ private:
+  struct CharsAndLength
+  {
+    CharsAndLength(const char* ptr)
+     : ptr(ptr),
+       length(strlen(ptr))
+    {}
+    const char* ptr;
+    size_t length;
+  };
+
+  struct RoutedNative {
+    CodeChunk chunk;
+    ke::AutoPtr<NativeDef> def;
+    ke::AutoArray<char> name;
+  };
+
+  struct Record {
+    const NativeDef* def;
+    Ref<NativeGroup> group;
+    AutoPtr<RoutedNative> rn;
+  };
+
+  struct Policy {
+    typedef Record Payload;
+    static uint32_t hash(const CharsAndLength& key) {
+      return ke::FastHashCharSequence(key.ptr, key.length);
+    }
+    static bool matches(const CharsAndLength& key, const Payload& other) {
+      return strcmp(key.ptr, other.def->name) == 0;
+    }
+  };
+
+  typedef ke::HashTable<Policy> NativeTable;
+  NativeTable table_;
+
+  // Used to cache whether or not a plugin has participated in dependency
+  // tracking.
+  unsigned binding_generation_;
+
+  // For NativeDefs we had to allocate to convert from a nativeinfo_t.
+  ke::Vector<AutoArray<NativeDef>> held_pointers_;
+};
+
+}
+
+#endif // _include_sourcepawn_vm_native_cache_h_

--- a/vm/opcodes.cpp
+++ b/vm/opcodes.cpp
@@ -42,9 +42,9 @@ const char *OpcodeNames[] = {
 
 #ifdef JIT_SPEW
 void
-SourcePawn::SpewOpcode(const sp_plugin_t *plugin, cell_t *start, cell_t *cip)
+SourcePawn::SpewOpcode(PluginRuntime *runtime, const cell_t *start, const cell_t *cip)
 {
-  fprintf(stdout, "  [%05d:%04d]", cip - (cell_t *)plugin->pcode, cip - start);
+  fprintf(stdout, "  [%05d:%04d]", cip - (cell_t *)runtime->code().bytes, cip - start);
 
   if (*cip >= OPCODES_TOTAL) {
     fprintf(stdout, " unknown-opcode\n");
@@ -87,15 +87,15 @@ SourcePawn::SpewOpcode(const sp_plugin_t *plugin, cell_t *start, cell_t *cip)
     case OP_JSLEQ:
       fprintf(stdout, "%05d:%04d",
         cip[1] / 4,
-        ((cell_t *)plugin->pcode + cip[1] / 4) - start);
+        ((cell_t *)runtime->code().bytes + cip[1] / 4) - start);
       break;
 
     case OP_SYSREQ_C:
     case OP_SYSREQ_N:
     {
       uint32_t index = cip[1];
-      if (index < plugin->num_natives)
-        fprintf(stdout, "%s", plugin->natives[index].name); 
+      if (index < runtime->image()->NumNatives())
+        fprintf(stdout, "%s", runtime->NativeAt(index)->name); 
       if (op == OP_SYSREQ_N)
         fprintf(stdout, " ; (%d args, index %d)", cip[2], index);
       else

--- a/vm/opcodes.h
+++ b/vm/opcodes.h
@@ -33,8 +33,13 @@
 #define _INCLUDE_SOURCEPAWN_JIT_X86_OPCODES_H_
 
 #include <smx/smx-v1-opcodes.h>
+#include <sp_vm_types.h>
+#include "plugin-runtime.h"
 
 namespace SourcePawn {
+#ifdef JIT_SPEW
+	void SpewOpcode(sp::PluginRuntime *runtime, const cell_t *start, const cell_t *cip);
+#endif
 }
 
 #endif //_INCLUDE_SOURCEPAWN_JIT_X86_OPCODES_H_

--- a/vm/plugin-runtime.h
+++ b/vm/plugin-runtime.h
@@ -21,6 +21,8 @@
 #include "compiled-function.h"
 #include "scripted-invoker.h"
 #include "legacy-image.h"
+#include "native-group.h"
+#include "native-registry.h"
 
 namespace sp {
 
@@ -39,13 +41,14 @@ struct floattbl_t
 struct NativeEntry : public sp_native_t
 {
   NativeEntry()
-   : legacy_fn(nullptr)
+   : binding(nullptr)
   {}
-  SPVM_NATIVE_FUNC legacy_fn;
+  const NativeDef* binding;
+  Ref<NativeGroup::WeakRef> weak_ref;
 };
 
 /* Jit wants fast access to this so we expose things as public */
-class PluginRuntime
+class PluginRuntime final
   : public SourcePawn::IPluginRuntime,
     public SourcePawn::IPluginDebugInfo,
     public ke::InlineListNode<PluginRuntime>
@@ -83,13 +86,19 @@ class PluginRuntime
   void SetNames(const char *fullname, const char *name);
   unsigned GetNativeReplacement(size_t index);
   ScriptedInvoker *GetPublicFunction(size_t index);
-  int UpdateNativeBinding(uint32_t index, SPVM_NATIVE_FUNC pfn, uint32_t flags, void *data) override;
   const sp_native_t *GetNative(uint32_t index) override;
   int LookupLine(ucell_t addr, uint32_t *line) override;
   int LookupFunction(ucell_t addr, const char **name) override;
   int LookupFile(ucell_t addr, const char **filename) override;
   const char *GetFilename() override {
     return full_name_.chars();
+  }
+  bool BindNatives(const ke::Ref<INativeRegistry>& registry) override;
+  void MarkNativesOptional(const ke::Ref<INativeGroup>& group) override;
+  void MarkNativeOptional(const char* name) override;
+
+  void addDependency(NativeGroup::StrongRef* ref) {
+    dependencies_.append(ref);
   }
 
   NativeEntry* NativeAt(size_t index) {
@@ -152,6 +161,8 @@ class PluginRuntime
   FunctionMap function_map_;
   ke::Vector<CompiledFunction *> m_JitFunctions;
 
+  ke::Vector<Ref<NativeGroup::StrongRef>> dependencies_;
+
   // Pause state.
   bool paused_;
 
@@ -165,4 +176,3 @@ class PluginRuntime
 } // sp
 
 #endif //_INCLUDE_SOURCEPAWN_JIT_RUNTIME_H_
-

--- a/vm/shell.cpp
+++ b/vm/shell.cpp
@@ -23,6 +23,8 @@ using namespace sp;
 using namespace SourcePawn;
 
 Environment *sEnv;
+Ref<INativeRegistry> sRegistry;
+Ref<INativeGroup> sWeakGroup;
 
 static void
 DumpStack(IFrameIterator &iter)
@@ -100,18 +102,9 @@ static cell_t DoNothing(IPluginContext *cx, const cell_t *params)
   return 1;
 }
 
-static void BindNative(IPluginRuntime *rt, const char *name, SPVM_NATIVE_FUNC fn)
+static cell_t PrintFloat(IPluginContext *cx, const cell_t *params, void* data)
 {
-  int err;
-  uint32_t index;
-  if ((err = rt->FindNativeByName(name, &index)) != SP_ERROR_NONE)
-    return;
-
-  rt->UpdateNativeBinding(index, fn, 0, nullptr);
-}
-
-static cell_t PrintFloat(IPluginContext *cx, const cell_t *params)
-{
+  assert(data == reinterpret_cast<void*>(data));
   return printf("%f\n", sp_ctof(params[1]));
 }
 
@@ -161,15 +154,8 @@ static int Execute(const char *file)
     return 1;
   }
 
-  BindNative(rt, "print", Print);
-  BindNative(rt, "printnum", PrintNum);
-  BindNative(rt, "printnums", PrintNums);
-  BindNative(rt, "printfloat", PrintFloat);
-  BindNative(rt, "donothing", DoNothing);
-  BindNative(rt, "execute", DoExecute);
-  BindNative(rt, "invoke", DoInvoke);
-  BindNative(rt, "dump_stack_trace", DumpStackTrace);
-  BindNative(rt, "report_error", ReportError);
+  rt->MarkNativesOptional(sWeakGroup);
+  rt->BindNatives(sRegistry);
 
   IPluginFunction *fun = rt->GetFunctionByName("main");
   if (!fun)
@@ -188,6 +174,22 @@ static int Execute(const char *file)
 
   return result;
 }
+
+const sp_nativeinfo_t sNatives[] = {
+  { "print",            Print },
+  { "printnum",         PrintNum },
+  { "printnums",        PrintNums },
+  { "donothing",        DoNothing },
+  { nullptr,            nullptr },
+};
+
+const sp_nativeinfo_t sWeakNatives[] = {
+  { "execute",          DoExecute },
+  { "invoke",           DoInvoke },
+  { "dump_stack_trace", DumpStackTrace },
+  { "report_error",     ReportError },
+  { nullptr,            nullptr },
+};
 
 int main(int argc, char **argv)
 {
@@ -208,7 +210,17 @@ int main(int argc, char **argv)
   sEnv->SetDebugger(&debug);
   sEnv->InstallWatchdogTimer(5000);
 
+  sRegistry = sEnv->NewNativeRegistry("shell");
+  sRegistry->AddLegacyNatives(nullptr, sNatives);
+  
+  sWeakGroup = sRegistry->NewNativeGroup("weak");
+  sRegistry->AddRoutedNative(sWeakGroup, "printfloat", PrintFloat, reinterpret_cast<void*>(0x1234));
+  sRegistry->AddLegacyNatives(sWeakGroup, sWeakNatives);
+
   int errcode = Execute(argv[1]);
+
+  sWeakGroup = nullptr;
+  sRegistry = nullptr;
 
   sEnv->SetDebugger(NULL);
   sEnv->Shutdown();

--- a/vm/x86/code-stubs-x86.cpp
+++ b/vm/x86/code-stubs-x86.cpp
@@ -33,7 +33,6 @@ CodeStubs::InitializeFeatureDetection()
   return true;
 }
 
-
 bool
 CodeStubs::CompileInvokeStub()
 {
@@ -105,8 +104,8 @@ CodeStubs::CompileInvokeStub()
   return true;
 }
 
-SPVM_NATIVE_FUNC
-CodeStubs::CreateFakeNativeStub(SPVM_FAKENATIVE_FUNC callback, void *pData)
+CodeChunk
+CodeStubs::CreateFakeNativeStub(SPVM_FAKENATIVE_FUNC callback, void *userData)
 {
   AssemblerX86 masm;
 
@@ -119,7 +118,7 @@ CodeStubs::CreateFakeNativeStub(SPVM_FAKENATIVE_FUNC callback, void *pData)
   __ andl(esp, 0xfffffff0);
   __ subl(esp, 4);
 
-  __ push(intptr_t(pData));
+  __ push(intptr_t(userData));
   __ push(esi);
   __ push(edi);
   __ call(ExternalAddress((void *)callback));
@@ -129,5 +128,5 @@ CodeStubs::CreateFakeNativeStub(SPVM_FAKENATIVE_FUNC callback, void *pData)
   __ pop(ebx);
   __ ret();
 
-  return (SPVM_NATIVE_FUNC)LinkCodeToLegacyPtr(env_, masm);
+  return LinkCode(env_, masm);
 }

--- a/vm/x86/code-stubs-x86.h
+++ b/vm/x86/code-stubs-x86.h
@@ -1,0 +1,44 @@
+// vim: set ts=8 sts=2 sw=2 tw=99 et:
+//
+// This file is part of SourcePawn.
+// 
+// SourcePawn is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// SourcePawn is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with SourcePawn.  If not, see <http://www.gnu.org/licenses/>.
+#ifndef _include_sourcepawn_vm_x86_code_stubs_h_
+#define _include_sourcepawn_vm_x86_code_stubs_h_
+
+#include "assembler-x86.h"
+
+namespace sp {
+
+class PluginRuntime;
+struct NativeInfo;
+
+enum class NativeCallContext
+{
+  Inline
+};
+
+// Caller must save edx.
+int GenerateNativeThunk(
+  MacroAssemblerX86& masm,
+  PluginRuntime* rt,
+  NativeCallContext context,
+  NativeInfo* native,
+  uint32_t native_index,
+  uint32_t nparams,
+  Label* error);
+
+} // namespace sp
+
+#endif // _include_sourcepawn_vm_x86_code_stubs_h_


### PR DESCRIPTION
(WIP)

The native binding API has evolved greatly since SourcePawn 1.0. The first iteration exposed the JIT's internal binding structures, with the host application left to perform all registration, binding, and dependency tracking. We have tried to reduce internal data structure exposure with each major release of SourcePawn, however, we have not yet solved the real burden of native management.

This patch aims to finally replace the native binding API. This is a breaking change in two ways. First, the 1.7 binding API is no longer functional. Embedders must use the 1.8 binding API. Second, the previously added 1.8 binding APIs have been removed from interface definitions entirely.

The new API focuses on two new concepts. The first is a "native registry" (`INativeRegistry`). A native registry is a collection of native names and their corresponding method pointers and signatures. Plugins now bind against a native registry. Additionally, we now expose a "native group". Native groups are created as part of a registry, and allow natives from the same module or library to be marked-as-optional or removed as a single unit.

These new APIs manage dependencies and weak references automatically, relieving embedders of this boilerplate, and making it more difficult to accidentally misuse internal data structures. They also eliminate the "MarkNativeAsOptional" hack present in SourceMod, allowing embedders to much more easily declare whether or not a module is optional.

Finally, the API to create "fake natives" has been removed. Instead, native registries can now add a "routed native". Routed natives serve the exact same purpose as fake natives, but their memory is managed safely and automatically.
