### PR TITLE
Fix complex this-values not being preserved across default arguments.

### DIFF
--- a/compiler/libpawnc.cpp
+++ b/compiler/libpawnc.cpp
@@ -1,4 +1,4 @@
-// vim: set sts=8 ts=2 sw=2 tw=99 noet:
+// vim: set sts=8 ts=2 sw=2 tw=99 et:
 /*  LIBPAWNC.C
  *
  *  A "glue file" for building the Pawn compiler as a DLL or shared library.
@@ -53,6 +53,8 @@ int pc_printf(const char *message,...)
   return ret;
 }
 
+unsigned sc_total_errors = 0;
+
 /* pc_error()
  * Called for producing error output.
  *    number      the error number (as documented in the manual)
@@ -80,6 +82,9 @@ static const char *prefix[3]={ "error", "fatal error", "warning" };
       idx = 1;
     else
       idx = 2;
+
+    if (idx == 0 || idx == 1)
+      sc_total_errors++;
 
     const char *pre=prefix[idx];
     if (firstline>=0)
@@ -234,9 +239,9 @@ char *pc_readsrc(void *handle,unsigned char *target,int maxchars)
         if (outptr < outend)
           *outptr++ = '\n';
       } else {
-				// Replace with \n.
-				*(outptr - 1) = '\n';
-			}
+        // Replace with \n.
+        *(outptr - 1) = '\n';
+      }
       break;
     }
   }

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -967,6 +967,7 @@ extern int pc_anytag;       /* global any tag */
 extern int glbstringread;	  /* last global string read */
 extern int sc_require_newdecls; /* only newdecls are allowed */
 extern bool sc_warnings_are_errors;
+extern unsigned sc_total_errors;
 
 extern constvalue sc_automaton_tab; /* automaton table */
 extern constvalue sc_state_tab;     /* state table */

--- a/compiler/sc3.cpp
+++ b/compiler/sc3.cpp
@@ -2798,7 +2798,6 @@ static void callfunction(symbol *sym, const svalue *aImplicitThis, value *lval_r
   int close,lvalue;
   int argpos;       /* index in the output stream (argpos==nargs if positional parameters) */
   int argidx=0;     /* index in "arginfo" list */
-  int nargs=0;      /* number of arguments */
   int heapalloc=0;
   int namedparams=FALSE;
   value lval = {0};
@@ -2868,6 +2867,8 @@ static void callfunction(symbol *sym, const svalue *aImplicitThis, value *lval_r
         lexpush();                /* reset the '.' */
     } /* if */
   } /* if */
+
+  unsigned nargs = 0;
   if (args.handling_this() || !close) {
     do {
       bool was_handling_this = args.handling_this();
@@ -3187,9 +3188,7 @@ static void callfunction(symbol *sym, const svalue *aImplicitThis, value *lval_r
         check_userop(NULL,arg[argidx].defvalue_tag,arg[argidx].tags[0],2,NULL,&dummytag);
         assert(dummytag==arg[argidx].tags[0]);
       } /* if */
-      pushreg(sPRI);            /* store the function argument on the stack */
-      markexpr(sPARM,NULL,0);   /* mark the end of a sub-expression */
-      sCallStackUsage++;
+      args.next_arg();
     } else {
       error(92,argidx);        /* argument count mismatch */
     } /* if */


### PR DESCRIPTION
A few methodmap fixes ago, we encountered a problem: spcomp evaluates arguments left-to-right, then reverses their evaluation order. The value of `this` is always computed first, and is never re-ordered. If the value of `this` depends on the value of a register, then argument evaluation can destroy it.

To fix this, we detected when the value of `this` was at risk, and started shuffling it down the stack as each argument evaluated. That worked, except, we forgot to carry that solution over to default values.

This fix comes in two parts. The first part attempts to extract a lot of the argument/stack manipulation out into a separate class. This doesn't change any behavior (I hope). The second part actually fixes the bug.