### PR TITLE
Fix unbound return_reported_error_ label

### DIFF
--- a/vm/x86/jit_x86.cpp
+++ b/vm/x86/jit_x86.cpp
@@ -1822,7 +1822,7 @@ Compiler::emitErrorPaths()
   }
 
   // We get here if we know an exception is already pending.
-  if (return_reported_error_.used()) {
+  if (return_reported_error_.used() || throw_timeout_.used()) {
     __ bind(&return_reported_error_);
     __ call(&return_to_invoke);
   }


### PR DESCRIPTION
If there are loops in the compiled function but no native calls, the
return_reported_error_ label is not bound but used by the throw_timeout_
stub.