### PR TITLE
Fix VS project generation

### DIFF
--- a/exp/compiler/AMBuilder
+++ b/exp/compiler/AMBuilder
@@ -19,7 +19,7 @@
 import os
 
 ### CLI
-binary = builder.compiler.StaticLibrary('spcomp')
+binary = builder.compiler.StaticLibrary('libspcomp')
 binary.compiler.cxxincludes += [
   os.path.join(builder.sourcePath, 'include'),
 ]


### PR DESCRIPTION
ambuild doesn't like two binaries with the same name when generating VS
project files.

The static library and the executable are both called "spcomp" for the
experimental compiler. Rename the static library to "libspcomp".
