### PR TITLE
Fix view_as<> precedence. (bug 6380)

### DIFF
--- a/compiler/sc3.cpp
+++ b/compiler/sc3.cpp
@@ -1686,7 +1686,7 @@ static int hier2(value *lval)
 
     int paren = needtoken('(');
     lval->cmptag = tag;
-    lvalue = hier12(lval);
+    lvalue = hier14(lval);
     if (paren)
       needtoken(')');
     else


### PR DESCRIPTION
Since `view_as<>` is parenthesized, we can use the highest level of precedence for parsing the expression inside the parenthesis.