### PR TITLE
Fix crash with corrupt array initializers. (bug 6378)

### DIFF
--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -2600,7 +2600,11 @@ static void initials2(int ident,int tag,cell *size,int dim[],int numdim,
         constvalue *ld=lastdim.next;
         int d,match;
         for (d=0; d<dim[numdim-2]; d++) {
-          assert(ld!=NULL);
+          if (!ld) {
+            error(108);
+            err++;
+            break;
+          }
           assert(strtol(ld->name,NULL,16)==d);
           if (d==0)
             match=ld->value;

--- a/compiler/sc5-in.scp
+++ b/compiler/sc5-in.scp
@@ -129,7 +129,7 @@ static const char *errmsg[] = {
 /*105*/  "cannot find method or property %s.%s\n",
 /*106*/  "cannot call methods on an array\n",
 /*107*/  "cannot call methods on a function\n",
-/*108*/  "unused108\n",
+/*108*/  "array initializer is invalid\n",
 /*109*/  "%s name must start with an uppercase letter\n",
 /*110*/  "%s has already been defined (previously seen as %s)\n",
 /*111*/  "expected identifier - did you forget a type?\n",

--- a/compiler/tests/fail-bad-array-initializer.sp
+++ b/compiler/tests/fail-bad-array-initializer.sp
@@ -1,0 +1,12 @@
+#define THIS_SIZE_WILL_CRASH 4
+
+new const String:to_crash_compiler[THIS_SIZE_WILL_CRASH][] = 
+{
+"x",
+"x"
+};
+
+public main()
+{
+  return to_crash_compiler[2][1];
+}

--- a/compiler/tests/fail-bad-array-initializer.txt
+++ b/compiler/tests/fail-bad-array-initializer.txt
@@ -1,0 +1,1 @@
+(7) : error 052: multi-dimensional arrays must be fully initialized


### PR DESCRIPTION
With some corrupt array initializers, an assert guarding a null deref fires. In a release build it crashes. Since initials2() is just horrible I'm going to paper over this. With the test case in the bug it errors anyway.