### PR TITLE
Nuke opcodes that can't be generated.

### DIFF
--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -722,7 +722,6 @@ void setlabel(int index);
 void markexpr(optmark type,const char *name,cell offset);
 void startfunc(char *fname);
 void endfunc(void);
-void alignframe(int numbytes);
 void rvalue(value *lval);
 void rvalue(svalue *sval);
 void address(symbol *ptr,regid reg);
@@ -899,7 +898,6 @@ extern int sc_asmfile;      /* create .ASM file? */
 extern int sc_listing;      /* create .LST file? */
 extern int sc_needsemicolon;/* semicolon required to terminate expressions? */
 extern int sc_dataalign;    /* data alignment value */
-extern int sc_alignnext;    /* must frame of the next function be aligned? */
 extern int pc_docexpr;      /* must expression be attached to documentation comment? */
 extern int sc_showincludes; /* show include files? */
 extern int curseg;          /* 1 if currently parsing CODE, 2 if parsing DATA */

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -758,7 +758,6 @@ void cell2addr(void);
 void cell2addr_alt(void);
 void addr2cell(void);
 void char2addr(void);
-void charalign(void);
 void addconst(cell value);
 void setheap_save(cell value);
 void stradjust(regid reg);

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -749,7 +749,6 @@ void ffbounds(cell size);
 void jumplabel(int number);
 void defstorage(void);
 void modstk(int delta);
-void setstk(cell value);
 void modheap(int delta);
 void modheap_i();
 void setheap_pri(void);

--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -690,7 +690,6 @@ static void resetglobals(void)
   sc_status=statIDLE;
   sc_allowproccall=FALSE;
   pc_addlibtable=TRUE;  /* by default, add a "library table" to the output file */
-  sc_alignnext=FALSE;
   pc_docexpr=FALSE;
   pc_deprecate=NULL;
   pc_memflags=0;
@@ -1678,13 +1677,6 @@ static void declglb(declinfo_t *decl,int fpublic,int fstatic,int fstock)
     } /* if */
     begdseg();          /* real (initialized) data in data segment */
     assert(litidx==0 || !cc_ok());  /* literal queue should be empty */
-    if (sc_alignnext) {
-      litidx=0;
-      aligndata(sc_dataalign);
-      dumplits();       /* dump the literal queue */
-      sc_alignnext=FALSE;
-      litidx=0;         /* global initial data is dumped, so restart at zero */
-    } /* if */
     assert(litidx==0 || !cc_ok());  /* literal queue should be empty (again) */
     if (type->ident == iREFARRAY) {
       // Dynamc array in global scope.
@@ -1742,10 +1734,6 @@ static void declglb(declinfo_t *decl,int fpublic,int fstatic,int fstock)
 
 static bool parse_local_array_initializer(typeinfo_t *type, int *curlit, int *slength)
 {
-  if (sc_alignnext) {
-    aligndata(sc_dataalign);
-    sc_alignnext=FALSE;
-  } /* if */
   *curlit = litidx; /* save current index in the literal table */
   if (type->numdim && !type->dim[type->numdim-1])
     type->size = 0;
@@ -4741,7 +4729,6 @@ static symbol *funcstub(int tokid, declinfo_t *decl, const int *thistag)
  *                     curfunc  (altered)
  *                     declared (altered)
  *                     glb_declared (altered)
- *                     sc_alignnext (altered)
  */
 static int newfunc(declinfo_t *decl, const int *thistag, int fpublic, int fstatic, int stock, symbol **symp)
 {
@@ -4871,10 +4858,6 @@ static int newfunc(declinfo_t *decl, const int *thistag, int fpublic, int fstati
   startfunc(sym->name); /* creates stack frame */
   insert_dbgline(funcline);
   setline(FALSE);
-  if (sc_alignnext) {
-    alignframe(sc_dataalign);
-    sc_alignnext=FALSE;
-  } /* if */
   declared=0;           /* number of local cells */
   resetstacklist();
   resetheaplist();

--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -6420,9 +6420,7 @@ static void dolabel(void)
   /* since one can jump around variable declarations or out of compound
    * blocks, the stack must be manually adjusted
    */
-  //:TODO: This is actually generated, egads!
-  //We have to support this and LCTRL/SCTRL
-  setstk(-declared*sizeof(cell));
+  error(82);
   sym->usage|=uDEFINE;  /* label is now defined */
 }
 

--- a/compiler/sc2.cpp
+++ b/compiler/sc2.cpp
@@ -1090,8 +1090,6 @@ static int command(void)
           cell val;
           preproc_expr(&val,NULL);
           sc_tabsize=(int)val;
-        } else if (strcmp(str,"align")==0) {
-          sc_alignnext=TRUE;
         } else if (strcmp(str,"unused")==0) {
           char name[sNAMEMAX+1];
           size_t i;

--- a/compiler/sc3.cpp
+++ b/compiler/sc3.cpp
@@ -2176,7 +2176,6 @@ restart:
             #endif
             ob_add();
           } /* if */
-          charalign();                  /* align character index into array */
         } /* if */
         /* if the array index is a field from an enumeration, get the tag name
          * from the field and save the size of the field too.
@@ -2204,8 +2203,6 @@ restart:
         } /* if */
         popreg(sALT);
         ob_add();       /* base address was popped into secondary register */
-        if (close!=']' || magic_string)
-          charalign();  /* align character index into array */
       } /* if */
       /* the indexed item may be another array (multi-dimensional arrays) */
       assert(cursym==sym && sym!=NULL); /* should still be set */

--- a/compiler/sc4.cpp
+++ b/compiler/sc4.cpp
@@ -259,10 +259,7 @@ void rvalue(value *lval)
     /* indirect fetch, but address not yet in PRI */
     assert(sym!=NULL);
     assert(sym->vclass==sLOCAL);/* global references don't exist in Pawn */
-    if (sym->vclass==sLOCAL)
-      stgwrite("\tlref.s.pri ");
-    else
-      stgwrite("\tlref.pri ");
+    stgwrite("\tlref.s.pri ");
     outval(sym->addr,TRUE);
     markusage(sym,uREAD);
     code_idx+=opcodes(1)+opargs(1);
@@ -416,10 +413,8 @@ void store(value *lval)
     code_idx+=opcodes(1)+opargs(1);
   } else if (lval->ident==iREFERENCE) {
     assert(sym!=NULL);
-    if (sym->vclass==sLOCAL)
-      stgwrite("\tsref.s.pri ");
-    else
-      stgwrite("\tsref.pri ");
+    assert(sym->vclass==sLOCAL);
+    stgwrite("\tsref.s.pri ");
     outval(sym->addr,TRUE);
     code_idx+=opcodes(1)+opargs(1);
   } else if (lval->ident==iACCESSOR) {
@@ -1191,18 +1186,12 @@ void inc(value *lval)
     stgwrite("\tpush.pri\n");
     /* load dereferenced value */
     assert(sym->vclass==sLOCAL);    /* global references don't exist in Pawn */
-    if (sym->vclass==sLOCAL)
-      stgwrite("\tlref.s.pri ");
-    else
-      stgwrite("\tlref.pri ");
+    stgwrite("\tlref.s.pri ");
     outval(sym->addr,TRUE);
     /* increment */
     stgwrite("\tinc.pri\n");
     /* store dereferenced value */
-    if (sym->vclass==sLOCAL)
-      stgwrite("\tsref.s.pri ");
-    else
-      stgwrite("\tsref.pri ");
+    stgwrite("\tsref.s.pri ");
     outval(sym->addr,TRUE);
     stgwrite("\tpop.pri\n");
     code_idx+=opcodes(5)+opargs(2);
@@ -1249,18 +1238,12 @@ void dec(value *lval)
     stgwrite("\tpush.pri\n");
     /* load dereferenced value */
     assert(sym->vclass==sLOCAL);    /* global references don't exist in Pawn */
-    if (sym->vclass==sLOCAL)
-      stgwrite("\tlref.s.pri ");
-    else
-      stgwrite("\tlref.pri ");
+    stgwrite("\tlref.s.pri ");
     outval(sym->addr,TRUE);
     /* decrement */
     stgwrite("\tdec.pri\n");
     /* store dereferenced value */
-    if (sym->vclass==sLOCAL)
-      stgwrite("\tsref.s.pri ");
-    else
-      stgwrite("\tsref.pri ");
+    stgwrite("\tsref.s.pri ");
     outval(sym->addr,TRUE);
     stgwrite("\tpop.pri\n");
     code_idx+=opcodes(5)+opargs(2);

--- a/compiler/sc4.cpp
+++ b/compiler/sc4.cpp
@@ -238,34 +238,6 @@ void endfunc(void)
   stgwrite("\n");       /* skip a line */
 }
 
-/*  alignframe
- *
- *  Aligns the frame (and the stack) of the current function to a multiple
- *  of the specified byte count. Two caveats: the alignment ("numbytes") should
- *  be a power of 2, and this alignment must be done right after the frame
- *  is set up (before the first variable is declared)
- */
-void alignframe(int numbytes)
-{
-  #if !defined NDEBUG
-    /* "numbytes" should be a power of 2 for this code to work */
-    size_t i;
-    int count=0;
-    for (i=0; i<sizeof numbytes*8; i++)
-      if (numbytes & (1 << i))
-        count++;
-    assert(count==1);
-  #endif
-
-  stgwrite("\tlctrl 4\n");      /* get STK in PRI */
-  stgwrite("\tconst.alt ");     /* get ~(numbytes-1) in ALT */
-  outval(~(numbytes-1),TRUE);
-  stgwrite("\tand\n");          /* PRI = STK "and" ~(numbytes-1) */
-  stgwrite("\tsctrl 4\n");      /* set the new value of STK ... */
-  stgwrite("\tsctrl 5\n");      /* ... and FRM */
-  code_idx+=opcodes(5)+opargs(4);
-}
-
 /*  rvalue
  *
  *  Generate code to get the value of a symbol into "primary".

--- a/compiler/sc4.cpp
+++ b/compiler/sc4.cpp
@@ -937,25 +937,6 @@ void char2addr(void)
   #endif
 }
 
-/* Align PRI (which should hold a character index) to an address.
- * The first character in a "pack" occupies the highest bits of
- * the cell. This is at the lower memory address on Big Endian
- * computers and on the higher address on Little Endian computers.
- * The ALIGN.pri/alt instructions must solve this machine dependence;
- * that is, on Big Endian computers, ALIGN.pri/alt shuold do nothing
- * and on Little Endian computers they should toggle the address.
- *
- * NOTE: For Source Pawn, this is fliped.  It will do nothing on Little-Endian.
- */
-void charalign(void)
-{
-#if 0	/* TEMPORARILY DISABLED BECAUSE WE DON'T USE BIG ENDIAN */
-  stgwrite("\talign.pri ");
-  outval(sCHARBITS/8,TRUE);
-  code_idx+=opcodes(1)+opargs(1);
-#endif
-}
-
 /*
  *  Add a constant to the primary register.
  */

--- a/compiler/sc4.cpp
+++ b/compiler/sc4.cpp
@@ -823,15 +823,6 @@ void modstk(int delta)
   } /* if */
 }
 
-/* set the stack to a hard offset from the frame */
-void setstk(cell value)
-{
-  stgwrite("\tstackadjust ");
-  assert(value<=0);             /* STK should always become <= FRM */
-  outval(value, TRUE);        /* add (negative) offset */
-  code_idx+=opcodes(1)+opargs(1);
-}
-
 void modheap(int delta)
 {
   if (delta) {

--- a/compiler/sc5-in.scp
+++ b/compiler/sc5-in.scp
@@ -103,7 +103,7 @@ static const char *errmsg[] = {
 /*079*/  "inconsistent return types (array & non-array)\n",
 /*080*/  "unknown symbol, or not a constant symbol (symbol \"%s\")\n",
 /*081*/  "cannot take a tag as a default value for an indexed array parameter (symbol \"%s\")\n",
-/*082*/  "unused82\n",
+/*082*/  "goto-label is not supported\n",
 /*083*/  "unused83\n",
 /*084*/  "unused84\n",
 /*085*/  "unused85\n",

--- a/compiler/sc6.cpp
+++ b/compiler/sc6.cpp
@@ -379,7 +379,6 @@ static OPCODEC opcodelist[] = {
   { 61, "jsless",     sIN_CSEG, do_jump },
   { 51, "jump",       sIN_CSEG, do_jump },
   { 53, "jzer",       sIN_CSEG, do_jump },
-  { 31, "lctrl",      sIN_CSEG, parm1 },
   {167, "ldgfn.pri",  sIN_CSEG, do_ldgfen },
   { 98, "leq",        sIN_CSEG, parm0 },
   { 97, "less",       sIN_CSEG, parm0 },
@@ -432,7 +431,6 @@ static OPCODEC opcodelist[] = {
   {152, "push5.s",    sIN_CSEG, parm5 },  /* version 9 */
   { 47, "ret",        sIN_CSEG, parm0 },
   { 48, "retn",       sIN_CSEG, parm0 },
-  { 32, "sctrl",      sIN_CSEG, parm1 },
   { 73, "sdiv",       sIN_CSEG, parm0 },
   { 74, "sdiv.alt",   sIN_CSEG, parm0 },
   {104, "sgeq",       sIN_CSEG, parm0 },

--- a/compiler/sc6.cpp
+++ b/compiler/sc6.cpp
@@ -392,8 +392,6 @@ static OPCODEC opcodelist[] = {
   {155, "load.s.both",sIN_CSEG, parm2 },  /* version 9 */
   {  3, "load.s.pri", sIN_CSEG, parm1 },
   { 10, "lodb.i",     sIN_CSEG, parm1 },
-  {  6, "lref.alt",   sIN_CSEG, parm1 },
-  {  5, "lref.pri",   sIN_CSEG, parm1 },
   {  8, "lref.s.alt", sIN_CSEG, parm1 },
   {  7, "lref.s.pri", sIN_CSEG, parm1 },
   { 34, "move.alt",   sIN_CSEG, parm0 },
@@ -445,8 +443,6 @@ static OPCODEC opcodelist[] = {
   {101, "sless",      sIN_CSEG, parm0 },
   { 72, "smul",       sIN_CSEG, parm0 },
   { 88, "smul.c",     sIN_CSEG, parm1 },
-  { 20, "sref.alt",   sIN_CSEG, parm1 },
-  { 19, "sref.pri",   sIN_CSEG, parm1 },
   { 22, "sref.s.alt", sIN_CSEG, parm1 },
   { 21, "sref.s.pri", sIN_CSEG, parm1 },
   { 67, "sshr",       sIN_CSEG, parm0 },

--- a/compiler/sc6.cpp
+++ b/compiler/sc6.cpp
@@ -335,16 +335,12 @@ static OPCODEC opcodelist[] = {
   { 87, "add.c",      sIN_CSEG, parm1 },
   { 14, "addr.alt",   sIN_CSEG, parm1 },
   { 13, "addr.pri",   sIN_CSEG, parm1 },
-  { 30, "align.alt",  sIN_CSEG, parm1 },
-  { 29, "align.pri",  sIN_CSEG, parm1 },
   { 81, "and",        sIN_CSEG, parm0 },
   {121, "bounds",     sIN_CSEG, parm1 },
   {137, "break",      sIN_CSEG, parm0 },  /* version 8 */
   { 49, "call",       sIN_CSEG, do_call },
-  { 50, "call.pri",   sIN_CSEG, parm0 },
   {  0, "case",       sIN_CSEG, do_case },
   {130, "casetbl",    sIN_CSEG, parm0 },  /* version 1 */
-  {118, "cmps",       sIN_CSEG, parm1 },
   {  0, "code",       sIN_CSEG, set_currentfile },
   {156, "const",      sIN_CSEG, parm2 },  /* version 9 */
   { 12, "const.alt",  sIN_CSEG, parm1 },
@@ -361,12 +357,9 @@ static OPCODEC opcodelist[] = {
   { 95, "eq",         sIN_CSEG, parm0 },
   {106, "eq.c.alt",   sIN_CSEG, parm1 },
   {105, "eq.c.pri",   sIN_CSEG, parm1 },
-/*{124, "file",       sIN_CSEG, do_file }, */
   {119, "fill",       sIN_CSEG, parm1 },
   {162, "genarray",   sIN_CSEG, parm1 },
   {163, "genarray.z", sIN_CSEG, parm1 },
-  {100, "geq",        sIN_CSEG, parm0 },
-  { 99, "grtr",       sIN_CSEG, parm0 },
   {120, "halt",       sIN_CSEG, parm1 },
   { 45, "heap",       sIN_CSEG, parm1 },
   { 27, "idxaddr",    sIN_CSEG, parm0 },
@@ -378,19 +371,13 @@ static OPCODEC opcodelist[] = {
   {110, "inc.s",      sIN_CSEG, parm1 },
   { 86, "invert",     sIN_CSEG, parm0 },
   { 55, "jeq",        sIN_CSEG, do_jump },
-  { 60, "jgeq",       sIN_CSEG, do_jump },
-  { 59, "jgrtr",      sIN_CSEG, do_jump },
-  { 58, "jleq",       sIN_CSEG, do_jump },
-  { 57, "jless",      sIN_CSEG, do_jump },
   { 56, "jneq",       sIN_CSEG, do_jump },
   { 54, "jnz",        sIN_CSEG, do_jump },
-  { 52, "jrel",       sIN_CSEG, parm1 },  /* always a number */
   { 64, "jsgeq",      sIN_CSEG, do_jump },
   { 63, "jsgrtr",     sIN_CSEG, do_jump },
   { 62, "jsleq",      sIN_CSEG, do_jump },
   { 61, "jsless",     sIN_CSEG, do_jump },
   { 51, "jump",       sIN_CSEG, do_jump },
-  {128, "jump.pri",   sIN_CSEG, parm0 },  /* version 1 */
   { 53, "jzer",       sIN_CSEG, do_jump },
   { 31, "lctrl",      sIN_CSEG, parm1 },
   {167, "ldgfn.pri",  sIN_CSEG, do_ldgfen },
@@ -398,7 +385,6 @@ static OPCODEC opcodelist[] = {
   { 97, "less",       sIN_CSEG, parm0 },
   { 25, "lidx",       sIN_CSEG, parm0 },
   { 26, "lidx.b",     sIN_CSEG, parm1 },
-/*{125, "line",       sIN_CSEG, parm2 }, */
   {  2, "load.alt",   sIN_CSEG, parm1 },
   {154, "load.both",  sIN_CSEG, parm2 },  /* version 9 */
   {  9, "load.i",     sIN_CSEG, parm0 },
@@ -427,7 +413,6 @@ static OPCODEC opcodelist[] = {
   { 37, "push.alt",   sIN_CSEG, parm0 },
   { 39, "push.c",     sIN_CSEG, parm1 },
   { 36, "push.pri",   sIN_CSEG, parm0 },
-  { 38, "push.r",     sIN_CSEG, parm1 },  /* obsolete (never generated) */
   { 41, "push.s",     sIN_CSEG, parm1 },
   {139, "push2",      sIN_CSEG, parm2 },  /* version 9 */
   {141, "push2.adr",  sIN_CSEG, parm2 },  /* version 9 */
@@ -458,13 +443,10 @@ static OPCODEC opcodelist[] = {
   { 66, "shr",        sIN_CSEG, parm0 },
   { 71, "shr.c.alt",  sIN_CSEG, parm1 },
   { 70, "shr.c.pri",  sIN_CSEG, parm1 },
-  { 94, "sign.alt",   sIN_CSEG, parm0 },
-  { 93, "sign.pri",   sIN_CSEG, parm0 },
   {102, "sleq",       sIN_CSEG, parm0 },
   {101, "sless",      sIN_CSEG, parm0 },
   { 72, "smul",       sIN_CSEG, parm0 },
   { 88, "smul.c",     sIN_CSEG, parm1 },
-/*{127, "srange",     sIN_CSEG, parm2 }, -- version 1 */
   { 20, "sref.alt",   sIN_CSEG, parm1 },
   { 19, "sref.pri",   sIN_CSEG, parm1 },
   { 22, "sref.s.alt", sIN_CSEG, parm1 },
@@ -485,16 +467,9 @@ static OPCODEC opcodelist[] = {
   {132, "swap.alt",   sIN_CSEG, parm0 },  /* version 4 */
   {131, "swap.pri",   sIN_CSEG, parm0 },  /* version 4 */
   {129, "switch",     sIN_CSEG, do_switch }, /* version 1 */
-/*{126, "symbol",     sIN_CSEG, do_symbol }, */
-/*{136, "symtag",     sIN_CSEG, parm1 },  -- version 7 */
-  {123, "sysreq.c",   sIN_CSEG, parm1 },
   {135, "sysreq.n",   sIN_CSEG, parm2 },  /* version 9 (replaces SYSREQ.d from earlier version) */
-  {122, "sysreq.pri", sIN_CSEG, parm0 },
   {161, "tracker.pop.setheap", sIN_CSEG, parm0 },
   {160, "tracker.push.c", sIN_CSEG, parm1 },
-  { 76, "udiv",       sIN_CSEG, parm0 },
-  { 77, "udiv.alt",   sIN_CSEG, parm0 },
-  { 75, "umul",       sIN_CSEG, parm0 },
   { 35, "xchg",       sIN_CSEG, parm0 },
   { 83, "xor",        sIN_CSEG, parm0 },
   { 91, "zero",       sIN_CSEG, parm1 },

--- a/compiler/sc6.cpp
+++ b/compiler/sc6.cpp
@@ -453,7 +453,6 @@ static OPCODEC opcodelist[] = {
   { 21, "sref.s.pri", sIN_CSEG, parm1 },
   { 67, "sshr",       sIN_CSEG, parm0 },
   { 44, "stack",      sIN_CSEG, parm1 },
-  {165, "stackadjust",sIN_CSEG, parm1 },
   {  0, "stksize",    0,        noop },
   { 16, "stor.alt",   sIN_CSEG, parm1 },
   { 23, "stor.i",     sIN_CSEG, parm0 },

--- a/compiler/sc7-in.scp
+++ b/compiler/sc7-in.scp
@@ -868,26 +868,6 @@ static SEQUENCE sequences_cmp[] = {
     seqsize(2,1) - seqsize(1,1)
   },
   {
-      "less!jzer %1!",
-      "jgeq %1!",
-    seqsize(2,1) - seqsize(1,1)
-  },
-  {
-      "leq!jzer %1!",
-      "jgrtr %1!",
-    seqsize(2,1) - seqsize(1,1)
-  },
-  {
-      "grtr!jzer %1!",
-      "jleq %1!",
-    seqsize(2,1) - seqsize(1,1)
-  },
-  {
-      "geq!jzer %1!",
-      "jless %1!",
-    seqsize(2,1) - seqsize(1,1)
-  },
-  {
       "sless!jzer %1!",
       "jsgeq %1!",
     seqsize(2,1) - seqsize(1,1)

--- a/compiler/scvars.cpp
+++ b/compiler/scvars.cpp
@@ -65,7 +65,6 @@ int sc_asmfile= FALSE;  /* create .ASM file? */
 int sc_listing= FALSE;  /* create .LST file? */
 int sc_needsemicolon=TRUE;/* semicolon required to terminate expressions? */
 int sc_dataalign=sizeof(cell);/* data alignment value */
-int sc_alignnext=FALSE; /* must frame of the next function be aligned? */
 int pc_docexpr=FALSE;   /* must expression be attached to documentation comment? */
 int curseg    = 0;      /* 1 if currently parsing CODE, 2 if parsing DATA */
 cell pc_stksize=sDEF_AMXSTACK;/* default stack size */


### PR DESCRIPTION
The JIT doesn't support about 20-30 opcodes. Most aren't ever generated. This patch ensures this by taking them out of the assembler tables, and removing any code that could have generated those ops.