### PR TITLE
Additional checks for SMXv1 validation

### DIFF
--- a/vm/shell.cpp
+++ b/vm/shell.cpp
@@ -157,7 +157,7 @@ static int Execute(const char *file)
   char error[255];
   AutoPtr<IPluginRuntime> rt(sEnv->APIv2()->LoadBinaryFromFile(file, error, sizeof(error)));
   if (!rt) {
-    fprintf(stderr, "Could not load plugin: %s\n", error);
+    fprintf(stderr, "Could not load plugin %s: %s\n", file, error);
     return 1;
   }
 


### PR DESCRIPTION
1. The "out of memory" error could never be triggered on allocation failure due to new throwing instead of returning NULL.
2. Tampering with the SMX container could cause inflate() to crash (initially this was an equality check, but I found a single binary on the forums where the file was 1 byte larger than disksize).

@dvander 