### PR TITLE
Fix -Wshift-negative-value warning in Clang 3.8

### DIFF
--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -1201,7 +1201,7 @@ static void setconstants(void)
 #endif
   add_constant("charbits",sCHARBITS,sGLOBAL,0);
   add_constant("charmin",0,sGLOBAL,0);
-  add_constant("charmax",~(-1 << sCHARBITS) - 1,sGLOBAL,0);
+  add_constant("charmax",~(-1UL << sCHARBITS) - 1,sGLOBAL,0);
   add_constant("ucharmax",(1 << (sizeof(cell)-1)*8)-1,sGLOBAL,0);
 
   add_constant("__Pawn",VERSION_INT,sGLOBAL,0);

--- a/compiler/sc3.cpp
+++ b/compiler/sc3.cpp
@@ -1049,7 +1049,7 @@ static int hier14(value *lval1)
    * negative value would do).
    */
   for (i=0; i<sDIMEN_MAX; i++)
-    arrayidx1[i]=arrayidx2[i]=(cell)(-1L << (sizeof(cell)*8-1));
+    arrayidx1[i]=arrayidx2[i]=(cell)(-1UL << (sizeof(cell)*8-1));
   org_arrayidx=lval1->arrayidx; /* save current pointer, to reset later */
   if (lval1->arrayidx==NULL)
     lval1->arrayidx=arrayidx1;


### PR DESCRIPTION
GDB appears to agree that these are functionally identical, although that charmax constant appears to be incorrect...

@dvander 