### PR TITLE
Unsilence and fix a number of warnings.

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -35,21 +35,16 @@ class Config(object):
         '-pipe',
         '-Wall',
         '-Werror',
-        '-Wno-switch',
         '-msse',
       ]
       cfg.cxxflags += ['-std=c++11']
 
       have_gcc = cxx.name is 'gcc'
       have_clang = cxx.name is 'clang'
-      if have_clang:
-        cfg.cxxflags += ['-Wno-unused-private-field']
       if have_clang or (have_gcc and cxx.majorVersion >= 4):
         cfg.cflags += ['-fvisibility=hidden']
         cfg.cxxflags += ['-fvisibility-inlines-hidden']
-        if have_clang or (have_gcc and cxx.minorVersion >= 6):
-          cfg.cflags += ['-Wno-narrowing']
-        if (have_gcc and cxx.minorVersion >= 7) or (have_clang and cxx.majorVersion >= 4):
+        if have_clang or (have_gcc and (cxx.majorVersion >= 5 or cxx.minorVersion >= 7)):
           cfg.cxxflags += ['-Wno-delete-non-virtual-dtor']
 
       # Disable some stuff we don't use, that gives us better binary
@@ -64,10 +59,6 @@ class Config(object):
 
       if have_gcc:
         cfg.cflags += ['-mfpmath=sse']
-
-      if (have_gcc and cxx.majorVersion >= 4 and cxx.minorVersion >= 7) or \
-          (have_clang and cxx.majorVersion >= 3):
-        cfg.cxxflags += ['-Wno-delete-non-virtual-dtor']
 
       cfg.postlink += ['-lm']
     elif cxx.name is 'msvc':

--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -2575,7 +2575,6 @@ static void decl_const(int vclass)
   token_t tok;
   int exprtag;
   int symbolline;
-  symbol *sym;
 
   do {
     int orgfline;
@@ -2625,7 +2624,7 @@ static void decl_const(int vclass)
     matchtag(tag,exprtag,FALSE);
     fline=orgfline;
 
-    sym=add_constant(constname,val,vclass,tag);
+    add_constant(constname,val,vclass,tag);
   } while (matchtoken(',')); /* enddo */   /* more? */
   needtoken(tTERM);
 }

--- a/compiler/sc2.cpp
+++ b/compiler/sc2.cpp
@@ -407,9 +407,6 @@ static void stripcom(unsigned char *line)
     char comment[COMMENT_LIMIT+COMMENT_MARGIN];
     int commentidx=0;
     int skipstar=TRUE;
-    static int prev_singleline=FALSE;
-
-    prev_singleline=FALSE;  /* preset */
   #endif
 
   while (*line){
@@ -478,7 +475,6 @@ static void stripcom(unsigned char *line)
             if ((end=strrchr(str,'\n'))!=NULL)
               *end='\0';/* erase trailing '\n' */
             insert_docstring(str);
-            prev_singleline=TRUE;
           } /* if */
         #endif
         *line++='\n';   /* put "newline" at first slash */

--- a/exp/compiler/AMBuilder
+++ b/exp/compiler/AMBuilder
@@ -26,10 +26,14 @@ binary.compiler.cxxincludes += [
 
 if binary.compiler.like('gcc'):
   binary.compiler.cflags += [
+    '-Wno-error=switch',
+    '-Wno-error=unused-private-field',
     '-Wno-invalid-offsetof',
-    '-Wno-implicit-exception-spec-mismatch',
-    '-Wno-unused-const-variable',
   ]
+
+  if binary.compiler.like('clang'):
+    binary.compiler.cflags += ['-Wno-implicit-exception-spec-mismatch']
+
   binary.compiler.cxxflags += ['-fno-rtti']
 
 binary.sources += [

--- a/exp/compiler/ast.h
+++ b/exp/compiler/ast.h
@@ -1622,7 +1622,6 @@ class TypesetDecl : public Statement
 
  private:
   NameToken name_;
-  TokenKind token_;
   Entries *types_;
   TypeSymbol *sym_;
   bool can_eagerly_resolve_ : 1;

--- a/exp/tools/docparse/docparse.cpp
+++ b/exp/tools/docparse/docparse.cpp
@@ -387,7 +387,6 @@ class Analyzer : public PartialAstVisitor
   Atom *atom_doc_end_;
   Atom *atom_properties_;
   Atom *atom_methods_;
-  Atom *atom_method_;
   Atom *atom_getter_;
   Atom *atom_setter_;
   Atom *atom_entries_;

--- a/vm/scripted-invoker.h
+++ b/vm/scripted-invoker.h
@@ -87,7 +87,6 @@ class ScriptedInvoker : public IPluginFunction
 
  private:
   Environment *env_;
-  PluginRuntime *m_pRuntime;
   PluginContext *context_;
   cell_t m_params[SP_MAX_EXEC_PARAMS];
   ParamInfo m_info[SP_MAX_EXEC_PARAMS];


### PR DESCRIPTION
Didn't clean up the unused stuff in `exp/` as I presume it is there for future dev, moved them to `-Wno-error=` so the warnings are visible however. Also corrected the version check for `-Wno-delete-non-virtual-dtor`.

@dvander 