### PR TITLE
Add experimental console debugger

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -76,6 +76,15 @@ class Config(object):
       if builder.options.debug == '1':
           cxx.cflags += ['-g3']
 
+      cxx.defines += [
+        'stricmp=strcasecmp',
+        '_stricmp=strcasecmp',
+        '_snprintf=snprintf',
+        '_vsnprintf=vsnprintf',
+        'HAVE_STDINT_H',
+        'GNUC',
+      ]
+
       have_gcc = cxx.family is 'gcc'
       have_clang = cxx.family is 'clang' or cxx.family is 'emscripten'
       if have_clang or have_gcc:

--- a/include/sp_vm_debug_api.h
+++ b/include/sp_vm_debug_api.h
@@ -57,13 +57,22 @@ namespace SourcePawn
     // @brief Returns whether debugging is enabled in general.
     virtual bool IsEnabled() = 0;
 
-    /** @brief Enables debugging in general. Prepares generated code for debugging.
-     * Must be set before a plugin is loaded.
+    /** 
+     * @brief Enables debugging in general. Prepares generated code for debugging.
+     * Must be set before any plugin is loaded.
      *
      * @param enable  Allow debugging?
      * @return        True if debugging is allowed now, false if there are loaded plugins already.
      */
     virtual bool SetEnabled(bool enable) = 0;
+
+    /**
+     * @brief Directly start a debugging session on the next loaded plugin.
+     * This will break into the plugin when the first instruction is executed.
+     *
+     * @return True if next plugin will be debugged, false if debugging is disabled.
+     */
+    virtual bool DebugNextLoadedPlugin() = 0;
 
     /**
      * @brief Activates the debugger on a plugin. Plugin will pause on the next instruction.

--- a/include/sp_vm_debug_api.h
+++ b/include/sp_vm_debug_api.h
@@ -20,6 +20,9 @@
 
 #include <am-vector.h>
 
+// This is subject to change.
+#define SOURCEPAWN_CONSOLE_DEBUGGER_API_VERSION 0x01
+
 namespace SourcePawn
 {
   class IPluginContext;
@@ -47,6 +50,9 @@ namespace SourcePawn
   class IConsoleDebugger
   {
   public:
+
+    // @brief Return the API version.
+    virtual int ApiVersion() = 0;
 
     // @brief Returns whether debugging is enabled in general.
     virtual bool IsEnabled() = 0;
@@ -94,6 +100,6 @@ namespace SourcePawn
 
   // @brief A function named "GetConsoleDebugger" is exported from the
   // SourcePawn DLL, conforming to the following signature:
-  typedef IConsoleDebugger *(*GetConsoleDebuggerFn)();
+  typedef IConsoleDebugger *(*GetConsoleDebuggerFn)(int apiVersion);
 }
 #endif //_INCLUDE_SOURCEPAWN_VM_DEBUG_API_H_

--- a/include/sp_vm_debug_api.h
+++ b/include/sp_vm_debug_api.h
@@ -47,6 +47,18 @@ namespace SourcePawn
   class IConsoleDebugger
   {
   public:
+
+    // @brief Returns whether debugging is enabled in general.
+    virtual bool IsEnabled() = 0;
+
+    /** @brief Enables debugging in general. Prepares generated code for debugging.
+     * Must be set before a plugin is loaded.
+     *
+     * @param enable  Allow debugging?
+     * @return        True if debugging is allowed now, false if there are loaded plugins already.
+     */
+    virtual bool SetEnabled(bool enable) = 0;
+
     /**
      * @brief Activates the debugger on a plugin. Plugin will pause on the next instruction.
      * @param ctx  Context of the plugin to debug.

--- a/include/sp_vm_debug_api.h
+++ b/include/sp_vm_debug_api.h
@@ -1,0 +1,87 @@
+// vim: set ts=4 sw=4 tw=99 noet:
+// 
+// Copyright (C) 2006-2015 AlliedModders LLC
+// 
+// This file is part of SourcePawn. SourcePawn is free software: you can
+// redistribute it and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License along with
+// SourcePawn. If not, see http://www.gnu.org/licenses/.
+//
+#ifndef _INCLUDE_SOURCEPAWN_VM_DEBUG_API_H_
+#define _INCLUDE_SOURCEPAWN_VM_DEBUG_API_H_
+
+/**
+* @file sp_vm_debug_api.h
+* @brief Contains all of the object structures used to interface with the experimental sourcepawn console debugger.
+*/
+
+#include <am-vector.h>
+
+namespace SourcePawn
+{
+  class IPluginContext;
+
+  // @brief Represents a debug breakpoint in a plugin.
+  class IBreakpoint
+  {
+  public:
+
+    // @brief Returns the name of the symbol (function) the breakpoint was set on if any.
+    virtual const char *name() = 0;
+
+    // @brief Returns the name of the file in which the line of the breakpoint is.
+    virtual const char *filename() = 0;
+    
+    // @brief Returns the line in the source file of the breakpoint.
+    virtual uint32_t line() = 0;
+
+    // @brief Returns whether the breakpoint is removed when it's hit or not.
+    virtual bool temporary() = 0;
+  };
+
+  // @brief Interface to the experimental console debugger.
+  // API is not stable yet.
+  class IConsoleDebugger
+  {
+  public:
+    /**
+     * @brief Activates the debugger on a plugin. Plugin will pause on the next instruction.
+     * @param ctx  Context of the plugin to debug.
+     * @return     True if debugging started, false otherwise.
+     */
+    virtual bool StartDebugger(const IPluginContext *ctx) = 0;
+
+    /**
+     * @brief Returns a list of all active breakpoints in a plugin.
+     * @param ctx  Context of the plugin.
+     * @return     List of breakpoints.
+     */
+    virtual ke::Vector<IBreakpoint *> *GetBreakpoints(const IPluginContext *ctx) = 0;
+
+    /**
+     * @brief Adds a breakpoint at a line or function in a plugin.
+     * Can be of format "<file>:<line>" or "<file>:<function>".
+     *
+     * @param ctx  Context of the plugin.
+     * @param line String describing the address to break on.
+     * @return     The new breakpoint or nullptr on error.
+     */
+    virtual IBreakpoint *AddBreakpoint(const IPluginContext *ctx, const char *line, bool temporary) = 0;
+
+    /**
+     * @brief Removes a breakpoint from a plugin.
+     * @param ctx   Context of the plugin.
+     * @param bpnum Breakpoint number to remove.
+     * @return      True if breakpoint found and removed, false otherwise.
+     */
+    virtual bool ClearBreakpoint(const IPluginContext *ctx, int bpnum) = 0;
+  };
+
+  // @brief A function named "GetConsoleDebugger" is exported from the
+  // SourcePawn DLL, conforming to the following signature:
+  typedef IConsoleDebugger *(*GetConsoleDebuggerFn)();
+}
+#endif //_INCLUDE_SOURCEPAWN_VM_DEBUG_API_H_

--- a/vm/AMBuilder
+++ b/vm/AMBuilder
@@ -54,6 +54,7 @@ for arch in Root.archs:
     'code-allocator.cpp',
     'code-stubs.cpp',
     'compiled-function.cpp',
+    'console-debugger.cpp',
     'environment.cpp',
     'file-utils.cpp',
     'interpreter.cpp',

--- a/vm/api.cpp
+++ b/vm/api.cpp
@@ -39,6 +39,7 @@
 #include "code-stubs.h"
 #include "smx-v1-image.h"
 #include <amtl/am-string.h>
+#include "console-debugger.h"
 
 using namespace sp;
 using namespace SourcePawn;
@@ -279,6 +280,13 @@ SourcePawnEngine2::LoadBinaryFromFile(const char *file, char *error, size_t maxl
 
   if (!pRuntime->Name())
     pRuntime->SetNames(file, file);
+
+  // Start debugging this new plugin right away!
+  ConsoleDebugger *debugger = (ConsoleDebugger *)Environment::get()->consoledebugger();
+  if (debugger->ShouldDebugNextLoadedPlugin()) {
+    debugger->ResetDebugNextLoadedPlugin();
+    pRuntime->GetBaseContext()->StartDebugger();
+  }
 
   return pRuntime;
 }

--- a/vm/console-debugger.cpp
+++ b/vm/console-debugger.cpp
@@ -1967,6 +1967,16 @@ ConsoleDebugger::SetEnabled(bool enable) {
 }
 
 bool
+ConsoleDebugger::DebugNextLoadedPlugin() {
+  if (!IsEnabled())
+    return false;
+
+  debugNext_ = true;
+
+  return true;
+}
+
+bool
 ConsoleDebugger::StartDebugger(const IPluginContext *ctx) {
   PluginContext *context = (PluginContext *)ctx;
   return context->StartDebugger();
@@ -2032,6 +2042,16 @@ ConsoleDebugger::ClearBreakpoint(const IPluginContext *ctx, int bpnum) {
     return false;
 
   return debugger->ClearBreakpoint(bpnum);
+}
+
+bool
+ConsoleDebugger::ShouldDebugNextLoadedPlugin() {
+  return debugNext_;
+}
+
+void
+ConsoleDebugger::ResetDebugNextLoadedPlugin() {
+  debugNext_ = false;
 }
 
 } // namespace SourcePawn

--- a/vm/console-debugger.cpp
+++ b/vm/console-debugger.cpp
@@ -547,8 +547,6 @@ Debugger::HandleInput(cell_t cip, bool isBp)
   // Only |step| and |next| can be repeated like that.
   static char lastcommand[32] = "";
 
-  LegacyImage *image = context_->runtime()->image();
-
   // Reset the state.
   FrameIterator frames;
   frames_ = &frames;
@@ -591,7 +589,7 @@ Debugger::HandleInput(cell_t cip, bool isBp)
 
     // Repeat the last command, if no new command was given.
     if (strlen(line) == 0) {
-      strncpy(line, lastcommand, sizeof(line));
+      ke::SafeStrcpy(line, sizeof(line), lastcommand);
     }
     lastcommand[0] = '\0';
 
@@ -619,12 +617,12 @@ Debugger::HandleInput(cell_t cip, bool isBp)
         return;
     }
     else if (!stricmp(command, "s") || !stricmp(command, "step")) {
-      strncpy(lastcommand, "s", sizeof(lastcommand));
+      ke::SafeStrcpy(lastcommand, sizeof(lastcommand), "s");
       SetRunmode(STEPPING);
       return;
     }
     else if (!stricmp(command, "n") || !stricmp(command, "next")) {
-      strncpy(lastcommand, "n", sizeof(lastcommand));
+      ke::SafeStrcpy(lastcommand, sizeof(lastcommand), "n");
       SetRunmode(STEPOVER);
       return;
     }
@@ -1044,7 +1042,7 @@ Debugger::HandleDisplayFormatChangeCmd(char *params)
   else {
     // Copy the symbol name from the params.
     char symname[32];
-    strncpy(symname, params, len);
+    ke::SafeStrcpy(symname, len, params);
     symname[len] = '\0';
 
     // Skip to the desired display type.
@@ -1277,22 +1275,22 @@ Debugger::HandleDumpMemoryCmd(char *command, char *params)
   switch (*format) {
   case 'd':
   case 'u':
-    snprintf(fmt_string, sizeof(fmt_string), "%%%d%c", size * 2, *format);
+    ke::SafeSprintf(fmt_string, sizeof(fmt_string), "%%%d%c", size * 2, *format);
     break;
   case 'o':
-    snprintf(fmt_string, sizeof(fmt_string), "0%%0%d%c", size * 2, *format);
+    ke::SafeSprintf(fmt_string, sizeof(fmt_string), "0%%0%d%c", size * 2, *format);
     break;
   case 'x':
-    snprintf(fmt_string, sizeof(fmt_string), "0x%%0%d%c", size * 2, *format);
+    ke::SafeSprintf(fmt_string, sizeof(fmt_string), "0x%%0%d%c", size * 2, *format);
     break;
   case 's':
-    strncpy(fmt_string, "\"%s\"", sizeof(fmt_string));
+    ke::SafeStrcpy(fmt_string, sizeof(fmt_string), "\"%s\"");
     break;
   case 'c':
-    strncpy(fmt_string, "'%c'", sizeof(fmt_string));
+    ke::SafeStrcpy(fmt_string, sizeof(fmt_string), "'%c'");
     break;
   case 'f':
-    strncpy(fmt_string, "%.2f", sizeof(fmt_string));
+    ke::SafeStrcpy(fmt_string, sizeof(fmt_string), "%.2f");
     break;
   default:
     return;
@@ -1503,8 +1501,6 @@ Debugger::FindBreakpoint(char *breakpoint)
 void
 Debugger::ListBreakpoints()
 {
-  LegacyImage *image = context_->runtime()->image();
-
   Breakpoint *bp;
   uint32_t line;
   const char *filename;

--- a/vm/console-debugger.cpp
+++ b/vm/console-debugger.cpp
@@ -767,7 +767,7 @@ Debugger::HandleFrameCmd(char *params)
   // See which frame to select.
   uint32_t frame = atoi(params);
   // Keep it in bounds.
-  if (frame < 0 || frame >= frame_count_) {
+  if (frame >= frame_count_) {
     printf("Invalid frame. There are only %d frames on the stack.\n", frame_count_);
     return;
   }
@@ -1810,8 +1810,7 @@ Debugger::DisplayVariable(SmxV1Image::Symbol *sym, uint32_t index[], int idxleve
       {
         uint32_t i;
         for (i = 0; i < MAXLINELENGTH - 1 && ptr[i] != '\0'; i++) {
-          if ((ptr[i] < ' ' && ptr[i] != '\n' && ptr[i] != '\r' && ptr[i] != '\t') ||
-            ptr[i] >= 128)
+          if ((ptr[i] < ' ' && ptr[i] != '\n' && ptr[i] != '\r' && ptr[i] != '\t'))
             break; // non-ASCII character
           if (i == 0 && !isalpha(ptr[i]))
             break; // want a letter at the start

--- a/vm/console-debugger.cpp
+++ b/vm/console-debugger.cpp
@@ -1836,6 +1836,11 @@ namespace SourcePawn {
 
 using namespace sp;
 
+int
+ConsoleDebugger::ApiVersion() {
+  return SOURCEPAWN_CONSOLE_DEBUGGER_API_VERSION;
+}
+
 bool
 ConsoleDebugger::IsEnabled() {
   return enabled_;

--- a/vm/console-debugger.cpp
+++ b/vm/console-debugger.cpp
@@ -1810,13 +1810,13 @@ Debugger::DisplayVariable(SmxV1Image::Symbol *sym, uint32_t index[], int idxleve
       if (ptr != nullptr)
       {
         uint32_t i;
-        for (i = 0; i < MAXLINELENGTH - 1 && ptr[i] != '\0'; i++) {
+        for (i = 0; ptr[i] != '\0'; i++) {
           if ((ptr[i] < ' ' && ptr[i] != '\n' && ptr[i] != '\r' && ptr[i] != '\t'))
             break; // non-ASCII character
           if (i == 0 && !isalpha(ptr[i]))
             break; // want a letter at the start
         }
-        if (i > 0 && i < MAXLINELENGTH - 1 && ptr[i] == '\0')
+        if (i > 0 && ptr[i] == '\0')
           sym->setVClass(sym->vclass() | DISP_STRING);
       }
     }

--- a/vm/console-debugger.cpp
+++ b/vm/console-debugger.cpp
@@ -1036,14 +1036,15 @@ Debugger::HandleDisplayFormatChangeCmd(char *params)
     /* nothing */;
 
   int len = (int)(ptr - params);
-  if (len == 0 || len > 31) {
+  // TODO: Use sNAMEMAX
+  if (len == 0 || len > 63) {
     fputs("\tInvalid (or missing) symbol name\n", stdout);
   }
   else {
     // Copy the symbol name from the params.
-    char symname[32];
+    char symname[64];
     ke::SafeStrcpy(symname, len, params);
-    symname[len] = '\0';
+    symname[len+1] = '\0';
 
     // Skip to the desired display type.
     params = SkipWhitespace(ptr);

--- a/vm/console-debugger.cpp
+++ b/vm/console-debugger.cpp
@@ -1,0 +1,1769 @@
+// vim: set sts=2 ts=8 sw=2 tw=99 et:
+// 
+// Copyright (C) 2006-2015 AlliedModders LLC
+// 
+// This file is part of SourcePawn. SourcePawn is free software: you can
+// redistribute it and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License along with
+// SourcePawn. If not, see http://www.gnu.org/licenses/.
+//
+// Based on pawndbg, the Pawn debugger, by ITB CompuPhase.
+//
+#include "console-debugger.h"
+#include "smx-v1-image.h"
+#include <cctype>
+#include "sp_typeutil.h"
+#include "plugin-context.h"
+#include "environment.h"
+#include "jit.h"
+#include "watchdog_timer.h"
+
+#if defined __GNUC__
+#include <unistd.h>
+#endif
+#if defined __linux__
+#include <termios.h>
+#endif
+#if defined WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
+
+namespace sp {
+
+enum {
+  DISP_DEFAULT = 0x10,
+  DISP_STRING = 0x20,
+  DISP_BIN = 0x30,   /* ??? not implemented */
+  DISP_HEX = 0x40,
+  DISP_BOOL = 0x50,
+  DISP_FIXED = 0x60,   /* unused in sourcepawn */
+  DISP_FLOAT = 0x70,
+};
+#define DISP_MASK 0x0f
+
+  // Convince debugging console to act more like an
+  // interactive input.
+#if defined __linux__
+tcflag_t GetTerminalLocalMode()
+{
+  struct termios term;
+  tcgetattr(STDIN_FILENO, &term);
+  return term.c_lflag;
+}
+
+void SetTerminalLocalMode(tcflag_t flag)
+{
+  struct termios term;
+  tcgetattr(STDIN_FILENO, &term);
+  term.c_lflag = flag;
+  tcsetattr(STDIN_FILENO, TCSANOW, &term);
+}
+
+tcflag_t EnableTerminalEcho()
+{
+  tcflag_t flags = GetTerminalLocalMode();
+  tcflag_t old_flags = flags;
+  flags |= (ICANON | ECHO | ECHOE | ECHOK | ECHOCTL | IEXTEN);
+  SetTerminalLocalMode(flags);
+  return old_flags;
+}
+
+void ResetTerminalEcho(tcflag_t flag)
+{
+  SetTerminalLocalMode(flag);
+}
+#endif
+
+#if defined WIN32
+DWORD EnableTerminalEcho()
+{
+  DWORD mode, old_mode;
+  HANDLE hConsole = GetStdHandle(STD_INPUT_HANDLE);
+  GetConsoleMode(hConsole, &mode);
+  old_mode = mode;
+  mode |= (ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_EXTENDED_FLAGS | ENABLE_INSERT_MODE);
+  SetConsoleMode(hConsole, mode);
+  return old_mode;
+}
+
+void ResetTerminalEcho(DWORD mode)
+{
+  HANDLE hConsole = GetStdHandle(STD_INPUT_HANDLE);
+  SetConsoleMode(hConsole, mode);
+}
+#endif
+
+int InvokeDebugger(PluginContext *ctx)
+{
+  if (!ctx->IsDebugging())
+    return SP_ERROR_NOTDEBUGGING;
+
+  Debugger *debugger = ctx->GetDebugger();
+  if (!debugger->active())
+    return SP_ERROR_NONE;
+
+  FrameIterator iter;
+  cell_t cip = 0;
+  // Find first scripted frame on the stack to get the cip from.
+  while (!iter.Done()) {
+    if (iter.IsScriptedFrame()) {
+      cip = iter.cip();
+      break;
+    }
+    iter.Next();
+  }
+
+  debugger->SetBreakCount(debugger->breakcount() + 1);
+  Runmode orig_runmode = debugger->runmode();
+
+  // when running until the function exit, check the frame address
+  if (debugger->runmode() == Runmode::STEPOUT &&
+    ctx->frm() > debugger->lastframe())
+  {
+    debugger->SetRunmode(Runmode::STEPPING);
+  }
+
+  bool isBreakpoint = false;
+  // when running, check the breakpoints
+  if (debugger->runmode() != Runmode::STEPPING &&
+    debugger->runmode() != Runmode::STEPOVER)
+  {
+    // check breakpoint address
+    isBreakpoint = debugger->CheckBreakpoint(cip);
+    if (!isBreakpoint)
+      return SP_ERROR_NONE;
+
+    debugger->SetRunmode(Runmode::STEPPING);
+  }
+
+  // try to avoid halting on the same line twice
+  uint32_t line = 0;
+  if (ctx->runtime()->LookupLine(cip, &line) == SP_ERROR_NONE) {
+    // assume that there are no more than 5 breaks on a single line.
+    // if there are, halt.
+    if (line == debugger->lastline() && debugger->breakcount() < 5) {
+      debugger->SetRunmode(orig_runmode);
+      return SP_ERROR_NONE;
+    }
+  }
+  debugger->SetLastLine(line);
+  debugger->SetBreakCount(0);
+
+  // check whether we are stepping through a sub-function
+  if (debugger->runmode() == Runmode::STEPOVER) {
+    assert(debugger->lastframe() != 0);
+    if (ctx->frm() < debugger->lastframe())
+      return SP_ERROR_NONE;
+  }
+
+  const char *filename;
+  if (ctx->runtime()->LookupFile(cip, &filename) == SP_ERROR_NONE) {
+    debugger->SetCurrentFile(filename);
+  }
+
+  // Tell the watchdog to take a break.
+  Environment::get()->watchdog()->SetIgnore(true);
+
+  // Echo input back and enable basic control
+  unsigned int old_flags = EnableTerminalEcho();
+  debugger->HandleInput(cip, isBreakpoint);
+  ResetTerminalEcho(old_flags);
+
+  // Enable the watchdog timer again.
+  Environment::get()->watchdog()->SetIgnore(false);
+
+  // step OVER functions (so save the stack frame)
+  if (debugger->runmode() == Runmode::STEPOVER ||
+    debugger->runmode() == Runmode::STEPOUT)
+    debugger->SetLastFrame(ctx->frm());
+
+  return SP_ERROR_NONE;
+}
+
+Debugger::Debugger(PluginContext *context)
+  : context_(context),
+  runmode_(RUNNING),
+  lastfrm_(0),
+  lastline_(-1),
+  currentfile_(""),
+  active_(false)
+{
+}
+
+bool
+Debugger::Initialize()
+{
+  if (!breakpoint_map_.init())
+    return false;
+
+  if (!watch_table_.init())
+    return false;
+
+  return true;
+}
+
+bool
+Debugger::active()
+{
+  return active_;
+}
+
+void
+Debugger::Activate()
+{
+  // TODO: Patch all breaks to call the debug handler
+  active_ = true;
+}
+
+void
+Debugger::Deactivate()
+{
+  // TODO: Unpatch calls
+  active_ = false;
+
+  ClearAllBreakpoints();
+  ClearAllWatches();
+  SetRunmode(RUNNING);
+}
+
+void
+Debugger::ReportError(const IErrorReport& report, FrameIterator& iter)
+{
+  if (report.IsFatal())
+    printf("STOP on FATAL exception: %s\n", report.Message());
+  else
+    printf("STOP on exception: %s\n", report.Message());
+
+  iter.Reset();
+
+  // Find the nearest scripted frame.
+  for (; !iter.Done(); iter.Next()) {
+    if (iter.IsScriptedFrame()) {
+      break;
+    }
+  }
+
+  cell_t cip = iter.cip();
+
+  uint32_t line = 0;
+  context_->runtime()->LookupLine(cip, &line);
+  SetLastLine(line);
+
+  const char *filename;
+  if (context_->runtime()->LookupFile(cip, &filename) == SP_ERROR_NONE) {
+    SetCurrentFile(filename);
+  }
+
+  // Tell the watchdog to take a break.
+  Environment::get()->watchdog()->SetIgnore(true);
+
+  // Echo input back and enable basic control
+  unsigned int old_flags = EnableTerminalEcho();
+  HandleInput(cip, false);
+  ResetTerminalEcho(old_flags);
+
+  // Enable the watchdog timer again.
+  Environment::get()->watchdog()->SetIgnore(false);
+
+  // step OVER functions (so save the stack frame)
+  if (runmode() == Runmode::STEPOVER ||
+    runmode() == Runmode::STEPOUT)
+    SetLastFrame(context_->frm());
+}
+
+Runmode
+Debugger::runmode()
+{
+  return runmode_;
+}
+
+void
+Debugger::SetRunmode(Runmode runmode)
+{
+  runmode_ = runmode;
+}
+
+cell_t
+Debugger::lastframe()
+{
+  return lastfrm_;
+}
+
+void
+Debugger::SetLastFrame(cell_t lastfrm)
+{
+  lastfrm_ = lastfrm;
+}
+
+uint32_t
+Debugger::lastline()
+{
+  return lastline_;
+}
+
+void
+Debugger::SetLastLine(uint32_t line)
+{
+  lastline_ = line;
+}
+
+uint32_t
+Debugger::breakcount()
+{
+  return breakcount_;
+}
+
+void
+Debugger::SetBreakCount(uint32_t breakcount)
+{
+  breakcount_ = breakcount;
+}
+
+const char *
+Debugger::currentfile()
+{
+  return currentfile_;
+}
+
+void
+Debugger::SetCurrentFile(const char *file)
+{
+  currentfile_ = file;
+}
+
+static char *strstrip(char *string)
+{
+  int pos;
+
+  /* strip leading white space */
+  while (*string != '\0' && *string <= ' ')
+    memmove(string, string + 1, strlen(string));
+  /* strip trailing white space */
+  for (pos = strlen(string); pos>0 && string[pos - 1] <= ' '; pos--)
+    string[pos - 1] = '\0';
+  return string;
+}
+
+static char *skipwhitespace(char *str)
+{
+  while (*str == ' ' || *str == '\t')
+    str++;
+  return (char*)str;
+}
+
+static const char *skippath(const char *str)
+{
+  const char *p1, *p2;
+
+  /* DOS/Windows pathnames */
+  if ((p1 = strrchr(str, '\\')) != NULL)
+    p1++;
+  else
+    p1 = str;
+  if (p1 == str && p1[1] == ':')
+    p1 = str + 2;
+  /* Unix pathnames */
+  if ((p2 = strrchr(str, '/')) != NULL)
+    p2++;
+  else
+    p2 = str;
+  return p1>p2 ? p1 : p2;
+}
+
+void
+Debugger::ListCommands(char *command)
+{
+  if (command == nullptr)
+    command = (char *)"";
+
+  if (strlen(command) == 0 || !strcmp(command, "?")) {
+    printf("At the prompt, you can type debug commands. For example, the word \"step\" is a\n"
+      "command to execute a single line in the source code. The commands that you will\n"
+      "use most frequently may be abbreviated to a single letter: instead of the full\n"
+      "word \"step\", you can also type the letter \"s\" followed by the enter key.\n\n"
+      "Available commands:\n");
+  }
+  else {
+    printf("Options for command \"%s\":\n", command);
+  }
+
+  if (!stricmp(command, "break") || !stricmp(command, "tbreak")) {
+    printf("\tUse TBREAK for one-time breakpoints\n\n"
+      "\tBREAK\t\tlist all breakpoints\n"
+      "\tBREAK n\t\tset a breakpoint at line \"n\"\n"
+      "\tBREAK name:n\tset a breakpoint in file \"name\" at line \"n\"\n"
+      "\tBREAK func\tset a breakpoint at function with name \"func\"\n"
+      "\tBREAK .\t\tset a breakpoint at the current location\n");
+  }
+  else if (!stricmp(command, "cbreak")) {
+    printf("\tCBREAK n\tremove breakpoint number \"n\"\n"
+      "\tCBREAK *\tremove all breakpoints\n");
+  }
+  else if (!stricmp(command, "cw") || !stricmp(command, "cwatch")) {
+    printf("\tCWATCH may be abbreviated to CW\n\n"
+      "\tCWATCH n\tremove watch number \"n\"\n"
+      "\tCWATCH var\tremove watch from \"var\"\n"
+      "\tCWATCH *\tremove all watches\n");
+  }
+  else if (!stricmp(command, "d") || !stricmp(command, "disp")) {
+    printf("\tDISP may be abbreviated to D\n\n"
+      "\tDISP\t\tdisplay all variables that are currently in scope\n"
+      "\tDISP var\tdisplay the value of variable \"var\"\n"
+      "\tDISP var[i]\tdisplay the value of array element \"var[i]\"\n");
+  }
+  else if (!stricmp(command, "f") || !stricmp(command, "frame")) {
+    printf("\tFRAME may be abbreviated to F\n\n");
+    printf("\tFRAME n\tselect frame n and show/change local variables in that function\n");
+  }
+  else if (!stricmp(command, "g") || !stricmp(command, "go")) {
+    printf("\tGO may be abbreviated to G\n\n"
+      "\tGO\t\trun until the next breakpoint or program termination\n"
+      //"\tGO n\t\trun until line number \"n\"\n"
+      //"\tGO name:n\trun until line number \"n\" in file \"name\"\n"
+      "\tGO func\t\trun until the current function returns (\"step out\")\n");
+  }
+  else if (!stricmp(command, "set")) {
+    printf("\tSET var=value\t\tset variable \"var\" to the numeric value \"value\"\n"
+      "\tSET var[i]=value\tset array item \"var\" to a numeric value\n"
+      "\tSET var=\"value\"\t\tset string variable \"var\" to string \"value\"\n");
+  }
+  else if (!stricmp(command, "type")) {
+    printf("\tTYPE var STRING\t\tdisplay \"var\" as string\n"
+      "\tTYPE var STD\t\tset default display format (decimal integer)\n"
+      "\tTYPE var HEX\t\tset hexadecimal integer format\n"
+      "\tTYPE var FLOAT\t\tset floating point format\n");
+  }
+  else if (!stricmp(command, "watch") || !stricmp(command, "w")) {
+    printf("\tWATCH may be abbreviated to W\n\n"
+      "\tWATCH var\tset a new watch at variable \"var\"\n");
+  }
+  else if (!stricmp(command, "x")) {
+    printf("\tX/FMT ADDRESS\texamine plugin memory at \"ADDRESS\"\n"
+      "\tADDRESS is an expression for the memory address to examine.\n"
+      "\tFMT is a repeat count followed by a format letter and a size letter.\n"
+      "\t\tFormat letters are o(octal), x(hex), d(decimal), u(unsigned decimal),\n"
+      "\t\t\tf(float), c(char) and s(string).\n"
+      "\t\tSize letters are b(byte), h(halfword), w(word).\n\n"
+      "\t\tThe specified number of objects of the specified size are printed\n"
+      "\t\taccording to the format.\n\n"
+      //"\tDefaults for format and size letters are those previously used.\n"
+      //"\tDefault count is 1.  Default address is following last thing printed\n"
+      //"\twith this command or \"disp\".\n"
+      );
+  }
+  else if (!stricmp(command, "n") || !stricmp(command, "next") ||
+    !stricmp(command, "quit") || !stricmp(command, "pos") ||
+    !stricmp(command, "s") || !stricmp(command, "step") ||
+    !stricmp(command, "files"))
+  {
+    printf("\tno additional information\n");
+  }
+  else {
+    printf("\tB(ack)T(race)\t\tdisplay the stack trace\n"
+      "\tBREAK\t\tset breakpoint at line number or variable name\n"
+      "\tCBREAK\t\tremove breakpoint\n"
+      "\tCW(atch)\tremove a \"watchpoint\"\n"
+      "\tD(isp)\t\tdisplay the value of a variable, list variables\n"
+      "\tFILES\t\tlist all files that this program is composed off\n"
+      "\tF(rame)\t\tSelect a frame from the back trace to operate on\n"
+      "\tFUNCS\t\tdisplay functions\n"
+      "\tG(o)\t\trun program (until breakpoint)\n"
+      "\tN(ext)\t\tRun until next line, step over functions\n"
+      "\tPOS\t\tShow current file and line\n"
+      "\tQUIT\t\texit debugger\n"
+      "\tSET\t\tSet a variable to a value\n"
+      "\tS(tep)\t\tsingle step, step into functions\n"
+      "\tTYPE\t\tset the \"display type\" of a symbol\n"
+      "\tW(atch)\t\tset a \"watchpoint\" on a variable\n"
+      "\tX\t\texamine plugin memory: x/FMT ADDRESS\n"
+      "\n\tUse \"? <command name>\" to view more information on a command\n");
+  }
+}
+
+void
+Debugger::HandleInput(cell_t cip, bool isBp)
+{
+  static char lastcommand[32] = "";
+  LegacyImage *image = context_->runtime()->image();
+
+  FrameIterator frames;
+  frames_ = &frames;
+  frame_count_ = 0;
+  selected_frame_ = 0;
+  cip_ = cip;
+  frm_ = context_->frm();
+  selected_context_ = context_;
+
+  // Count the frames
+  // Select first scripted frame, if it's not frame 0
+  bool selected_first_scripted = false;
+  for (; !frames.Done(); frames.Next(), frame_count_++) {
+    if (!selected_first_scripted && frames.IsScriptedFrame()) {
+      selected_frame_ = frame_count_;
+      selected_first_scripted = true;
+    }
+  }
+
+  frames.Reset();
+
+  if (!isBp)
+    printf("STOP at line %d in %s\n", lastline_, skippath(currentfile_));
+  else
+    printf("BREAK at line %d in %s\n", lastline_, skippath(currentfile_));
+
+  // Print all watched variables now.
+  ListWatches();
+
+  char line[512], command[32];
+  int result;
+  char *params;
+  for (;;) {
+    fgets(line, sizeof(line), stdin);
+
+    // strip newline character, plus leading or trailing white space
+    strstrip(line);
+
+    // Repeat the last command, if no new command was given.
+    if (strlen(line) == 0) {
+      strncpy(line, lastcommand, sizeof(line));
+    }
+    lastcommand[0] = '\0';
+
+    result = sscanf(line, "%8s", command);
+    if (result <= 0) {
+      ListCommands(nullptr);
+      continue;
+    }
+
+    params = strchr(line, ' ');
+    params = (params != nullptr) ? skipwhitespace(params) : (char*)"";
+
+    if (!stricmp(command, "?")) {
+      result = sscanf(line, "%*s %30s", command);
+      ListCommands(result ? command : nullptr);
+    }
+    else if (!stricmp(command, "quit")) {
+      fputs("Clearing all breakpoints. Running normally.\n", stdout);
+      Deactivate();
+      return;
+    }
+    else if (!stricmp(command, "g") || !stricmp(command, "go")) {
+      if (!stricmp(params, "func")) {
+        SetRunmode(STEPOUT);
+        return;
+      }
+      SetRunmode(RUNNING);
+      return;
+    }
+    else if (!stricmp(command, "s") || !stricmp(command, "step")) {
+      strncpy(lastcommand, "s", sizeof(lastcommand));
+      SetRunmode(STEPPING);
+      return;
+    }
+    else if (!stricmp(command, "n") || !stricmp(command, "next")) {
+      strncpy(lastcommand, "n", sizeof(lastcommand));
+      SetRunmode(STEPOVER);
+      return;
+    }
+    else if (!stricmp(command, "funcs")) {
+      fputs("Listing functions:\n", stdout);
+      SmxV1Image *imagev1 = (SmxV1Image *)image;
+      SmxV1Image::SymbolIterator iter = imagev1->symboliterator();
+      while (!iter.Done()) {
+        const SmxV1Image::Symbol sym = iter.Next();
+        if (sym.ident() == sp::IDENT_FUNCTION &&
+          imagev1->GetDebugName(sym.name()) != nullptr)
+        {
+          printf("%s", imagev1->GetDebugName(sym.name()));
+          const char *filename = image->LookupFile(sym.addr());
+          if (filename != nullptr) {
+            printf("\t(%s)", skippath(filename));
+          }
+          fputs("\n", stdout);
+        }
+      }
+    }
+    else if (!stricmp(command, "bt") || !stricmp(command, "backtrace")) {
+      printf("Stack trace:\n");
+      DumpStack();
+    }
+    else if (!stricmp(command, "f") || !stricmp(command, "frame")) {
+      if (*params == '\0' || !isdigit(*params)) {
+        fputs("Invalid syntax. Type \"? frame\" for help.\n", stdout);
+        continue;
+      }
+
+      uint32_t frame = atoi(params);
+      if (frame < 0 || frame_count_ <= frame) {
+        printf("Invalid frame. There are only %d frames on the stack.\n", frame_count_);
+        continue;
+      }
+
+      if (frame == selected_frame_) {
+        fputs("This frame is already selected.\n", stdout);
+        continue;
+      }
+
+      // Select this frame to operate on.
+      frames_->Reset();
+      uint32_t index = 0;
+      for (; !frames_->Done(); frames_->Next(), index++) {
+        // Iterator is at the chosen frame now.
+        if (index == frame)
+          break;
+      }
+
+      if (!frames_->IsScriptedFrame()) {
+        printf("%d is not a scripted frame.\n", frame);
+        continue;
+      }
+
+      // Get the plugin context of the target frame
+      selected_context_ = (PluginContext *)frames_->Context();
+      image = selected_context_->runtime()->image();
+
+      // Reset the frame iterator again and count all above frames in the context.
+      frames_->Reset();
+      index = 0;
+      uint32_t num_scripted_frames = 0;
+      for (; !frames_->Done(); frames_->Next(), index++) {
+        // Count the scripted frames in the context to find the right frm pointer.
+        if (frames_->IsScriptedFrame() && frames_->Context() == selected_context_)
+          num_scripted_frames++;
+        // We've reached the chosen frame.
+        if (index == frame)
+          break;
+      }
+
+      // Update internal state for this frame.
+      selected_frame_ = frame;
+      cip_ = frames_->cip();
+      currentfile_ = image->LookupFile(cip_);
+      image->LookupLine(cip_, &lastline_);
+
+      // Find correct new frame pointer.
+      cell_t frm = selected_context_->frm();
+      for (uint32_t i = 1; i < num_scripted_frames; i++) {
+        frm = *(cell_t *)(selected_context_->memory() + frm + 4);
+      }
+      frm_ = frm;
+
+      printf("Selected frame %d.\n", frame);
+    }
+    else if (!stricmp(command, "break") || !stricmp(command, "tbreak")) {
+      if (*params == '\0') {
+        ListBreakpoints();
+      }
+      else {
+        // check if a filename precedes the breakpoint location
+        char *sep;
+        const char *filename = currentfile_;
+        if ((sep = strchr(params, ':')) != nullptr) {
+          /* the user may have given a partial filename (e.g. without a path), so
+          * walk through all files to find a match
+          */
+          *sep = '\0';
+          filename = image->FindFileByPartialName(params);
+          if (filename == nullptr) {
+            fputs("Invalid filename.\n", stdout);
+            continue;
+          }
+
+          // Skip colon and settle before line number
+          params = sep + 1;
+        }
+
+        params = skipwhitespace(params);
+
+        Breakpoint *bp;
+        // User specified a line number
+        if (isdigit(*params)) {
+          bp = AddBreakpoint(filename, strtol(params, NULL, 10) - 1, !stricmp(command, "tbreak"));
+        }
+        // User wants to add a breakpoint at the current location
+        else if (*params == '.') {
+          bp = AddBreakpoint(filename, lastline_ - 1, !stricmp(command, "tbreak"));
+        }
+        // User specified a function name
+        else {
+          bp = AddBreakpoint(filename, params, !stricmp(command, "tbreak"));
+        }
+
+        if (bp == nullptr) {
+          fputs("Invalid breakpoint\n", stdout);
+        }
+        else {
+          uint32_t bpline = 0;
+          image->LookupLine(bp->addr(), &bpline);
+          printf("Set breakpoint %d in file %s on line %d", breakpoint_map_.elements(), skippath(filename), bpline);
+          if (bp->name() != nullptr)
+            printf(" in function %s", bp->name());
+          fputs("\n", stdout);
+        }
+      }
+    }
+    else if (!stricmp(command, "cbreak")) {
+      if (*params == '*') {
+        // clear all breakpoints
+        ClearAllBreakpoints();
+      }
+      else {
+        int number = FindBreakpoint(params);
+        if (number < 0 || !ClearBreakpoint(number))
+          fputs("\tUnknown breakpoint (or wrong syntax)\n", stdout);
+        else
+          printf("\tCleared breakpoint %d\n", number);
+      }
+    }
+    else if (!stricmp(command, "disp") || !stricmp(command, "d")) {
+      uint32_t idx[sDIMEN_MAX];
+      int dim = 0;
+      memset(idx, 0, sizeof(idx));
+      SmxV1Image *imagev1 = (SmxV1Image *)image;
+      if (*params == '\0') {
+        // display all variables that are in scope
+        SmxV1Image::SymbolIterator iter = imagev1->symboliterator();
+        while (!iter.Done()) {
+          ke::AutoPtr<SmxV1Image::Symbol> sym;
+          sym = iter.Next();
+          if (sym->ident() != sp::IDENT_FUNCTION &&
+            sym->codestart() <= (uint32_t)cip_ &&
+            sym->codeend() >= (uint32_t)cip_)
+          {
+            printf("%s\t<%#8x>\t", (sym->vclass() & DISP_MASK) > 0 ? "loc" : "glb", (sym->vclass() & DISP_MASK) > 0 ? frm_ + sym->addr() : sym->addr());
+            if (imagev1->GetDebugName(sym->name()) != nullptr) {
+              printf("%s\t", imagev1->GetDebugName(sym->name()));
+            }
+
+            DisplayVariable(sym, idx, 0);
+            fputs("\n", stdout);
+          }
+        }
+      }
+      // Display single variable
+      else {
+        ke::AutoPtr<SmxV1Image::Symbol> sym;
+        char *indexptr = strchr(params, '[');
+        char *behindname = nullptr;
+        assert(dim == 0);
+        // Parse all [x][y] dimensions
+        while (indexptr != nullptr && dim < sDIMEN_MAX) {
+          if (behindname == nullptr)
+            behindname = indexptr;
+
+          indexptr++;
+          idx[dim++] = atoi(indexptr);
+          indexptr = strchr(indexptr, '[');
+        }
+
+        // End the string before the first [ temporarily, 
+        // so GetVariable only looks for the variable name.
+        if (behindname != nullptr)
+          *behindname = '\0';
+
+        // find the symbol with the smallest scope
+        if (imagev1->GetVariable(params, cip_, sym)) {
+          // Add the [ back again
+          if (behindname != nullptr)
+            *behindname = '[';
+
+          printf("%s\t<%#8x>\t%s\t", (sym->vclass() & DISP_MASK) > 0 ? "loc" : "glb", (sym->vclass() & DISP_MASK) > 0 ? frm_ + sym->addr() : sym->addr(), params);
+          DisplayVariable(sym, idx, dim);
+          fputs("\n", stdout);
+        }
+        else {
+          fputs("\tSymbol not found, or not a variable\n", stdout);
+        }
+      }
+    }
+    else if (!stricmp(command, "set")) {
+      char varname[32];
+      char strvalue[1024];
+      uint32_t index;
+      cell_t value;
+      ke::AutoPtr<SmxV1Image::Symbol> sym;
+      strvalue[0] = '\0';
+      if (sscanf(params, " %[^[ ][%d] = %d", varname, &index, &value) != 3) {
+        index = 0;
+        if (sscanf(params, " %[^= ] = %d", varname, &value) != 2) {
+          varname[0] = '\0';
+          if (sscanf(params, " %[^= ] = \"%[^\"]\"", varname, strvalue) != 2) {
+            strvalue[0] = '\0';
+          }
+        }
+      }
+
+      if (varname[0] != '\0') {
+        // find the symbol with the given range with the smallest scope
+        SmxV1Image *imagev1 = (SmxV1Image *)image;
+        if (imagev1->GetVariable(varname, cip_, sym)) {
+          // user gave an integer as value
+          if (strvalue[0] == '\0') {
+            SetSymbolValue(sym, index, value);
+            if (index > 0)
+              printf("%s[%d] set to %d\n", varname, index, value);
+            else
+              printf("%s set to %d\n", varname, value);
+          }
+          // we have a string as value
+          else {
+            if ((sym->ident() != sp::IDENT_ARRAY
+              && sym->ident() != sp::IDENT_REFARRAY)
+              || sym->dimcount() != 1) {
+              printf("%s is not a string.\n", varname);
+            }
+            else {
+              SetSymbolString(sym, strvalue);
+              printf("%s set to \"%s\"\n", varname, strvalue);
+            }
+          }
+        }
+        else {
+          fputs("Symbol not found or not a variable\n", stdout);
+        }
+      }
+      else {
+        fputs("Invalid syntax for \"set\". Type \"? set\".\n", stdout);
+      }
+    }
+    else if (!stricmp(command, "files")) {
+      fputs("Source files:\n", stdout);
+      // browse through the file table
+      SmxV1Image *imagev1 = (SmxV1Image *)image;
+      for (unsigned int i = 0; i < imagev1->GetFileCount(); i++) {
+        if (imagev1->GetFileName(i) != nullptr) {
+          printf("%s\n", imagev1->GetFileName(i));
+        }
+      }
+    }
+    // Change display format of symbol
+    else if (!stricmp(command, "type")) {
+      char symname[32], *ptr;
+      for (ptr = params; *ptr != '\0' && *ptr != ' ' && *ptr != '\t'; ptr++)
+        /* nothing */;
+      int len = (int)(ptr - params);
+      if (len == 0 || len > 31) {
+        fputs("\tInvalid (or missing) symbol name\n", stdout);
+      }
+      else {
+        ke::AutoPtr<SmxV1Image::Symbol> sym;
+        strncpy(symname, params, len);
+        symname[len] = '\0';
+        params = skipwhitespace(ptr);
+
+        SmxV1Image *imagev1 = (SmxV1Image *)image;
+        if (imagev1->GetVariable(symname, cip_, sym)) {
+          assert(sym != nullptr);
+          if (!stricmp(params, "std")) {
+            sym->setVClass((sym->vclass() & DISP_MASK) | DISP_DEFAULT);
+          }
+          else if (!stricmp(params, "string")) {
+            // check array with single dimension
+            if (!(sym->ident() == sp::IDENT_ARRAY || sym->ident() == sp::IDENT_REFARRAY) ||
+              sym->dimcount() != 1)
+              fputs("\t\"string\" display type is only valid for arrays with one dimension\n", stdout);
+            else
+              sym->setVClass((sym->vclass() & DISP_MASK) | DISP_STRING);
+          }
+          else if (!stricmp(params, "bin")) {
+            sym->setVClass((sym->vclass() & DISP_MASK) | DISP_BIN);
+          }
+          else if (!stricmp(params, "hex")) {
+            sym->setVClass((sym->vclass() & DISP_MASK) | DISP_HEX);
+          }
+          else if (!stricmp(params, "float")) {
+            sym->setVClass((sym->vclass() & DISP_MASK) | DISP_FLOAT);
+          }
+          else {
+            fputs("\tUnknown (or missing) display type\n", stdout);
+          }
+          ListWatches();
+        }
+        else {
+          printf("\tUnknown symbol \"%s\"\n", symname);
+        }
+      }
+    }
+    else if (!stricmp(command, "pos")) {
+      printf("\tfile: %s", skippath(currentfile_));
+
+      const char *function = image->LookupFunction(cip_);
+      if (function != nullptr)
+        printf("\tfunction: %s", function);
+
+      printf("\tline: %d", lastline_);
+
+      if (selected_frame_ > 0)
+        printf("\tframe: %d", selected_frame_);
+
+      fputs("\n", stdout);
+    }
+    else if (!stricmp(command, "w") || !stricmp(command, "watch")) {
+      if (strlen(params) == 0) {
+        fputs("Missing variable name\n", stdout);
+        continue;
+      }
+      if (AddWatch(params))
+        ListWatches();
+      else
+        fputs("Invalid watch\n", stdout);
+    }
+    else if (!stricmp(command, "cw") || !stricmp(command, "cwatch")) {
+      if (strlen(params) == 0) {
+        fputs("Missing variable name\n", stdout);
+        continue;
+      }
+
+      if (*params == '*') {
+        ClearAllWatches();
+      }
+      else if (isdigit(*params)) {
+        // Delete watch by index
+        if (!ClearWatch(atoi(params)))
+          fputs("Bad watch number\n", stdout);
+      }
+      else {
+        if (!ClearWatch(params))
+          fputs("Variable not watched\n", stdout);
+      }
+      ListWatches();
+    }
+    else if (command[0] == 'x' || command[0] == 'X') {
+      char* fmt = command + 1;
+
+      if (strlen(params) == 0) {
+        fputs("Missing address.\n", stdout);
+        continue;
+      }
+
+      // Format is x/[count][format][size] <address>
+      if (*fmt != '/') {
+        fputs("Bad format specifier.\n", stdout);
+        continue;
+      }
+      fmt++;
+
+      char* count_str = fmt;
+      // Skip count number
+      while (isdigit(*fmt)) {
+        fmt++;
+      }
+
+      // Default count is 1.
+      int count = 1;
+      // Parse [count] number. The amount of stuff to display.
+      if (count_str != fmt) {
+        count = atoi(count_str);
+        if (count <= 0) {
+          fputs("Invalid count.\n", stdout);
+          continue;
+        }
+      }
+
+      // Format letters are o(octal), x(hex), d(decimal), u(unsigned decimal)
+      // t(binary), f(float), a(address), i(instruction), c(char) and s(string).
+      char* format = fmt++;
+      if (*format != 'o' && *format != 'x' && *format != 'd' &&
+        *format != 'u' && *format != 'f' && *format != 'c' &&
+        *format != 's') {
+        printf("Invalid format letter '%c'.\n", *format);
+        continue;
+      }
+
+      // Size letters are b(byte), h(halfword), w(word).
+      char* size_ltr = fmt;
+
+      unsigned int size;
+      unsigned int line_break;
+      unsigned int mask;
+      switch (*size_ltr) {
+      case 'b':
+        size = 1;
+        line_break = 8;
+        mask = 0x000000ff;
+        break;
+      case 'h':
+        size = 2;
+        line_break = 8;
+        mask = 0x0000ffff;
+        break;
+      case 'w':
+        // Default size is a word, if none was given.
+      case '\0':
+        size = 4;
+        line_break = 4;
+        mask = 0xffffffff;
+        break;
+      default:
+        printf("Invalid size letter '%c'.\n", *size_ltr);
+        continue;
+      }
+
+      // Skip the size letter.
+      if (*size_ltr != '\0')
+        fmt++;
+
+      if (*fmt) {
+        fputs("Invalid output format string.\n", stdout);
+        continue;
+      }
+
+      // Parse address.
+      // We support 3 "magic" addresses:
+      // $cip: instruction pointer
+      // $sp: stack pointer
+      // $hp: heap pointer
+      // $frm: frame pointer
+      cell_t address = 0;
+      if (*params == '$') {
+        if (!stricmp(params, "$cip")) {
+          address = cip_;
+        }
+        // TODO: adjust for selected frame like frm_.
+        else if (!stricmp(params, "$sp")) {
+          address = selected_context_->sp();
+        }
+        else if (!stricmp(params, "$hp")) {
+          address = selected_context_->hp();
+        }
+        else if (!stricmp(params, "$frm")) {
+          address = frm_;
+        }
+        else {
+          printf("Unknown address %s.\n", params);
+          continue;
+        }
+      }
+      // This is a raw address.
+      else {
+        address = (cell_t)strtol(params, NULL, 0);
+      }
+
+      if (((address >= selected_context_->hp()) && (address < selected_context_->sp())) ||
+        (address < 0) || ((ucell_t)address >= selected_context_->HeapSize())) {
+        fputs("Address out of plugin's bounds.\n", stdout);
+        continue;
+      }
+
+      // Print the memory
+      // Create a format string for the desired output format.
+      char fmt_string[16];
+      switch (*format) {
+      case 'd':
+      case 'u':
+        snprintf(fmt_string, sizeof(fmt_string), "%%%d%c", size * 2, *format);
+        break;
+      case 'o':
+        snprintf(fmt_string, sizeof(fmt_string), "0%%0%d%c", size * 2, *format);
+        break;
+      case 'x':
+        snprintf(fmt_string, sizeof(fmt_string), "0x%%0%d%c", size * 2, *format);
+        break;
+      case 's':
+        strncpy(fmt_string, "\"%s\"", sizeof(fmt_string));
+        break;
+      case 'c':
+        strncpy(fmt_string, "'%c'", sizeof(fmt_string));
+        break;
+      case 'f':
+        strncpy(fmt_string, "%.2f", sizeof(fmt_string));
+        break;
+      default:
+        continue;
+      }
+
+      cell_t *data;
+      for (int i = 0; i<count; i++) {
+
+        if (((address >= selected_context_->hp()) && (address < selected_context_->sp())) ||
+          (address < 0) || ((ucell_t)address >= selected_context_->HeapSize()))
+          break;
+
+        if (i % line_break == 0) {
+          if (i > 0)
+            fputs("\n", stdout);
+          printf("0x%x: ", address);
+        }
+
+        data = (cell_t *)(selected_context_->memory() + address);
+
+        switch (*format) {
+        case 'f':
+          printf(fmt_string, sp_ctof(*data));
+          break;
+        case 'd':
+        case 'u':
+        case 'o':
+        case 'x':
+          printf(fmt_string, *data & mask);
+          break;
+        case 's':
+          printf(fmt_string, (char*)data);
+          break;
+        default:
+          printf(fmt_string, *data);
+          break;
+        }
+
+        fputs("  ", stdout);
+
+        // Move to the next address based on the size;
+        address += size;
+      }
+
+      fputs("\n", stdout);
+    }
+    else {
+      printf("\tInvalid command \"%s\", use \"?\" to view all commands\n", command);
+    }
+  }
+}
+
+bool
+Debugger::CheckBreakpoint(cell_t cip)
+{
+  BreakpointMap::Result result = breakpoint_map_.find(cip);
+  if (!result.found())
+    return false;
+
+  // Remove the temporary breakpoint
+  if (result->value->temporary()) {
+    ClearBreakpoint(result->value);
+  }
+
+  return true;
+}
+
+Breakpoint *
+Debugger::AddBreakpoint(const char* file, uint32_t line, bool temporary)
+{
+  LegacyImage *image = context_->runtime()->image();
+  const char *targetfile = image->FindFileByPartialName(file);
+  if (targetfile == nullptr)
+    targetfile = currentfile_;
+
+  uint32_t addr;
+  if (!image->GetLineAddress(line, targetfile, &addr))
+    return nullptr;
+
+  Breakpoint *bp;
+  {
+    BreakpointMap::Insert p = breakpoint_map_.findForAdd(addr);
+    if (p.found())
+      return p->value;
+
+    bp = new Breakpoint(image, addr, nullptr, temporary);
+    breakpoint_map_.add(p, addr, bp);
+  }
+
+  return bp;
+}
+
+Breakpoint *
+Debugger::AddBreakpoint(const char* file, const char *function, bool temporary)
+{
+  LegacyImage *image = context_->runtime()->image();
+  const char *targetfile = image->FindFileByPartialName(file);
+  if (targetfile == nullptr)
+    return nullptr;
+
+  uint32_t addr;
+  if (!image->GetFunctionAddress(function, targetfile, &addr))
+    return nullptr;
+
+  Breakpoint *bp;
+  {
+    BreakpointMap::Insert p = breakpoint_map_.findForAdd(addr);
+    if (p.found())
+      return p->value;
+
+    const char *realname = image->LookupFunction(addr);
+
+    bp = new Breakpoint(image, addr, realname, temporary);
+    breakpoint_map_.add(p, addr, bp);
+  }
+
+  return bp;
+}
+
+bool
+Debugger::ClearBreakpoint(int number)
+{
+  if (number <= 0)
+    return false;
+
+  int i = 0;
+  for (BreakpointMap::iterator iter = breakpoint_map_.iter(); !iter.empty(); iter.next()) {
+    if (++i == number) {
+      iter.erase();
+      return true;
+    }
+  }
+  return false;
+}
+
+bool
+Debugger::ClearBreakpoint(Breakpoint * bp)
+{
+  BreakpointMap::Result res = breakpoint_map_.find(bp->addr());
+  if (!res.found())
+    return false;
+
+  breakpoint_map_.remove(res);
+  return true;
+}
+
+void
+Debugger::ClearAllBreakpoints()
+{
+  breakpoint_map_.clear();
+}
+
+int
+Debugger::FindBreakpoint(char *breakpoint)
+{
+  LegacyImage *image = context_->runtime()->image();
+  breakpoint = skipwhitespace(breakpoint);
+
+  // check if a filename precedes the breakpoint location
+  char *sep = strrchr(breakpoint, ':');
+  if (sep == nullptr && isdigit(*breakpoint))
+    return atoi(breakpoint);
+
+  const char *filename = currentfile_;
+  if (sep != nullptr) {
+    /* the user may have given a partial filename (e.g. without a path), so
+    * walk through all files to find a match
+    */
+    *sep = '\0';
+    filename = image->FindFileByPartialName(breakpoint);
+    if (filename == nullptr)
+      return -1;
+
+    // Skip past colon
+    breakpoint = sep + 1;
+  }
+
+  breakpoint = skipwhitespace(breakpoint);
+  Breakpoint *bp;
+  const char *fname;
+  uint32_t line;
+  uint32_t number = 0;
+  for (BreakpointMap::iterator iter = breakpoint_map_.iter(); !iter.empty(); iter.next()) {
+    bp = iter->value;
+    fname = image->LookupFile(bp->addr());
+    number++;
+
+    // Correct file?
+    if (fname != nullptr && !strcmp(fname, filename)) {
+      // A function breakpoint
+      if (bp->name() != nullptr && !strcmp(breakpoint, bp->name()))
+        return number;
+
+      // Line breakpoint
+      if (image->LookupLine(bp->addr(), &line) &&
+        line == strtoul(breakpoint, NULL, 10) - 1)
+        return number;
+    }
+  }
+  return -1;
+}
+
+void
+Debugger::ListBreakpoints()
+{
+  LegacyImage *image = context_->runtime()->image();
+
+  Breakpoint *bp;
+  uint32_t line;
+  const char *filename;
+  uint32_t number = 0;
+  for (BreakpointMap::iterator iter = breakpoint_map_.iter(); !iter.empty(); iter.next()) {
+    bp = iter->value;
+
+    printf("%2d  ", ++number);
+    line = bp->line();
+    if (line > 0) {
+      printf("line: %d", line);
+    }
+
+    if (bp->temporary())
+      printf("  (TEMP)");
+
+    filename = bp->filename();
+    if (filename != nullptr) {
+      printf("\tfile: %s", skippath(filename));
+    }
+
+    if (bp->name() != nullptr) {
+      printf("\tfunc: %s", bp->name());
+    }
+    printf("\n");
+  }
+}
+
+bool
+Debugger::AddWatch(const char* symname)
+{
+  WatchTable::Insert i = watch_table_.findForAdd(symname);
+  if (i.found())
+    return false;
+  watch_table_.add(i, symname);
+  return true;
+}
+
+bool
+Debugger::ClearWatch(const char* symname)
+{
+  WatchTable::Result r = watch_table_.find(symname);
+  if (!r.found())
+    return false;
+  watch_table_.remove(r);
+  return true;
+}
+
+bool
+Debugger::ClearWatch(uint32_t num)
+{
+  if (num < 1 || num > watch_table_.elements())
+    return false;
+
+  uint32_t index = 1;
+  for (WatchTable::iterator iter = WatchTable::iterator(&watch_table_); !iter.empty(); iter.next()) {
+    if (num == index++) {
+      iter.erase();
+      break;
+    }
+  }
+  return true;
+}
+
+void
+Debugger::ClearAllWatches()
+{
+  watch_table_.clear();
+}
+
+void
+Debugger::ListWatches()
+{
+  SmxV1Image *imagev1 = (SmxV1Image *)selected_context_->runtime()->image();
+  uint32_t num = 1;
+  AString symname;
+  int dim;
+  uint32_t idx[sDIMEN_MAX];
+  const char *indexptr;
+  char *behindname = nullptr;
+  for (WatchTable::iterator iter = WatchTable::iterator(&watch_table_); !iter.empty(); iter.next()) {
+    symname = *iter;
+
+    ke::AutoPtr<SmxV1Image::Symbol> sym;
+    indexptr = strchr(symname.chars(), '[');
+    behindname = nullptr;
+    dim = 0;
+    memset(idx, 0, sizeof(idx));
+    // Parse all [x][y] dimensions
+    while (indexptr != nullptr && dim < sDIMEN_MAX) {
+      if (behindname == nullptr)
+        behindname = (char *)indexptr;
+
+      indexptr++;
+      idx[dim++] = atoi(indexptr);
+      indexptr = strchr(indexptr, '[');
+    }
+
+    // End the string before the first [ temporarily, 
+    // so GetVariable only looks for the variable name.
+    if (behindname != nullptr)
+      *behindname = '\0';
+
+    // find the symbol with the smallest scope
+    if (imagev1->GetVariable(symname.chars(), cip_, sym)) {
+      // Add the [ back again
+      if (behindname != nullptr)
+        *behindname = '[';
+
+      printf("%d  %-12s ", num++, symname.chars());
+      DisplayVariable(sym, idx, dim);
+      printf("\n");
+    }
+    else {
+      printf("%d  %-12s (not in scope)\n", num++, symname.chars());
+    }
+  }
+}
+
+bool
+Debugger::GetSymbolValue(const SmxV1Image::Symbol* sym, int index, cell_t* value)
+{
+  cell_t *vptr;
+  cell_t base = sym->addr();
+  if (sym->vclass() & DISP_MASK)
+    base += frm_; // addresses of local vars are relative to the frame
+
+  // a reference
+  if (sym->ident() == sp::IDENT_REFERENCE || sym->ident() == sp::IDENT_REFARRAY) {
+    if (selected_context_->LocalToPhysAddr(base, &vptr) != SP_ERROR_NONE)
+      return false;
+
+    assert(vptr != nullptr);
+    base = *vptr;
+  }
+
+  if (selected_context_->LocalToPhysAddr(base + index*sizeof(cell_t), &vptr) != SP_ERROR_NONE)
+    return false;
+
+  if (vptr != nullptr)
+    *value = *vptr;
+  return vptr != nullptr;
+}
+
+bool
+Debugger::SetSymbolValue(const SmxV1Image::Symbol* sym, int index, cell_t value)
+{
+  cell_t *vptr;
+  cell_t base = sym->addr();
+  if (sym->vclass() & DISP_MASK)
+    base += frm_; // addresses of local vars are relative to the frame
+
+  // a reference
+  if (sym->ident() == sp::IDENT_REFERENCE || sym->ident() == sp::IDENT_REFARRAY) {
+    selected_context_->LocalToPhysAddr(base, &vptr);
+    assert(vptr != nullptr);
+    base = *vptr;
+  }
+
+  selected_context_->LocalToPhysAddr(base + index*sizeof(cell_t), &vptr);
+  assert(vptr != nullptr);
+  *vptr = value;
+  return true;
+}
+
+bool
+Debugger::SetSymbolString(const SmxV1Image::Symbol* sym, char* str)
+{
+  assert(sym->ident() == sp::IDENT_ARRAY || sym->ident() == sp::IDENT_REFARRAY);
+  assert(sym->dimcount() == 1);
+
+  SmxV1Image *image = (SmxV1Image *)selected_context_->runtime()->image();
+
+  cell_t *vptr;
+  cell_t base = sym->addr();
+  if (sym->vclass() & DISP_MASK)
+    base += frm_; // addresses of local vars are relative to the frame
+
+  // a reference
+  if (sym->ident() == sp::IDENT_REFERENCE || sym->ident() == sp::IDENT_REFARRAY) {
+    selected_context_->LocalToPhysAddr(base, &vptr);
+    assert(vptr != nullptr);
+    base = *vptr;
+  }
+
+  ke::AutoPtr<ke::Vector<SmxV1Image::ArrayDim *>> dims;
+  dims = image->GetArrayDimensions(sym);
+  return selected_context_->StringToLocalUTF8(base, dims->at(0)->size(), str, NULL) == SP_ERROR_NONE;
+}
+
+char *
+Debugger::GetString(SmxV1Image::Symbol* sym)
+{
+  assert(sym->ident() == sp::IDENT_ARRAY || sym->ident() == sp::IDENT_REFARRAY);
+  assert(sym->dimcount() == 1);
+
+  // get the starting address and the length of the string
+  cell_t *addr;
+  cell_t base = sym->addr();
+  if (sym->vclass())
+    base += frm_; // addresses of local vars are relative to the frame
+  if (sym->ident() == sp::IDENT_REFARRAY) {
+    selected_context_->LocalToPhysAddr(base, &addr);
+    assert(addr != nullptr);
+    base = *addr;
+  }
+
+  char *str;
+  if (selected_context_->LocalToStringNULL(base, &str) != SP_ERROR_NONE)
+    return nullptr;
+  return str;
+}
+
+void
+Debugger::PrintValue(long value, int disptype)
+{
+  switch (disptype)
+  {
+  case DISP_FLOAT:
+    printf("%f", sp_ctof(value));
+    break;
+  case DISP_HEX:
+    printf("%lx", value);
+    break;
+  case DISP_BOOL:
+    switch (value)
+    {
+    case 0:
+      fputs("false", stdout);
+      break;
+    case 1:
+      fputs("true", stdout);
+      break;
+    default:
+      printf("%ld (false)", value);
+      break;
+    }
+    break;
+  default:
+    printf("%ld", value);
+    break;
+  }
+}
+
+void
+Debugger::DisplayVariable(SmxV1Image::Symbol *sym, uint32_t index[], int idxlevel)
+{
+  cell_t value;
+  ke::AutoPtr<ke::Vector<SmxV1Image::ArrayDim *>> symdims;
+  SmxV1Image *image = (SmxV1Image *)selected_context_->runtime()->image();
+
+  assert(index != NULL);
+
+  // first check whether the variable is visible at all
+  if ((uint32_t)cip_ < sym->codestart() || (uint32_t)cip_ > sym->codeend()) {
+    fputs("(not in scope)", stdout);
+    return;
+  }
+
+  // set default display type for the symbol (if none was set)
+  if ((sym->vclass() & ~DISP_MASK) == 0) {
+    const char *tagname = image->GetTagName(sym->tagid());
+    if (tagname != nullptr) {
+      if (!stricmp(tagname, "bool")) {
+        sym->setVClass(sym->vclass() | DISP_BOOL);
+      }
+      else if (!stricmp(tagname, "float")) {
+        sym->setVClass(sym->vclass() | DISP_FLOAT);
+      }
+    }
+    if ((sym->vclass() & ~DISP_MASK) == 0 &&
+      (sym->ident() == sp::IDENT_ARRAY || sym->ident() == sp::IDENT_REFARRAY) &&
+      sym->dimcount() == 1)
+    {
+      /* untagged array with a single dimension, walk through all elements
+      * and check whether this could be a string
+      */
+      char *ptr = GetString(sym);
+      if (ptr != nullptr)
+      {
+        uint32_t i;
+        for (i = 0; i < MAXLINELENGTH - 1 && ptr[i] != '\0'; i++) {
+          if ((ptr[i] < ' ' && ptr[i] != '\n' && ptr[i] != '\r' && ptr[i] != '\t') ||
+            ptr[i] >= 128)
+            break; // non-ASCII character
+          if (i == 0 && !isalpha(ptr[i]))
+            break; // want a letter at the start
+        }
+        if (i > 0 && i < MAXLINELENGTH - 1 && ptr[i] == '\0')
+          sym->setVClass(sym->vclass() | DISP_STRING);
+      }
+    }
+  }
+
+  if (sym->ident() == sp::IDENT_ARRAY || sym->ident() == sp::IDENT_REFARRAY) {
+    int dim;
+    symdims = image->GetArrayDimensions(sym);
+    // check whether any of the indices are out of range
+    assert(symdims != nullptr);
+    for (dim = 0; dim < idxlevel; dim++) {
+      if (symdims->at(dim)->size() > 0 && index[dim] >= symdims->at(dim)->size())
+        break;
+    }
+    if (dim < idxlevel) {
+      fputs("(index out of range)", stdout);
+      return;
+    }
+  }
+
+  if ((sym->ident() == sp::IDENT_ARRAY || sym->ident() == sp::IDENT_REFARRAY) &&
+    idxlevel == 0)
+  {
+    if ((sym->vclass() & ~DISP_MASK) == DISP_STRING) {
+      char *str = GetString(sym);
+      if (str != nullptr)
+        printf("\"%s\"", str); // TODO: truncate to 40 chars
+      else
+        fputs("NULL_STRING", stdout);
+    }
+    else if (sym->dimcount() == 1) {
+      assert(symdims != nullptr); // set in the previous block
+      uint32_t len = symdims->at(0)->size();
+      if (len > 5)
+        len = 5;
+      else if (len == 0)
+        len = 1; // unknown array length, assume at least 1 element
+
+      fputs("{", stdout);
+      uint32_t i;
+      for (i = 0; i < len; i++) {
+        if (i > 0)
+          fputs(",", stdout);
+        if (GetSymbolValue(sym, i, &value))
+          PrintValue(value, (sym->vclass() & ~DISP_MASK));
+        else
+          fputs("?", stdout);
+      }
+      if (len < symdims->at(0)->size() || symdims->at(0)->size() == 0)
+        fputs(",...", stdout);
+      fputs("}", stdout);
+    }
+    else {
+      fputs("(multi-dimensional array)", stdout);
+    }
+  }
+  else if (sym->ident() != sp::IDENT_ARRAY && sym->ident() != sp::IDENT_REFARRAY && idxlevel > 0) {
+    // index used on a non-array
+    fputs("(invalid index, not an array)", stdout);
+  }
+  else {
+    // simple variable, or indexed array element
+    assert(idxlevel > 0 || index[0] == 0); // index should be zero if non-array
+    int dim;
+    int base = 0;
+    for (dim = 0; dim < idxlevel - 1; dim++) {
+      base += index[dim];
+      if (!GetSymbolValue(sym, base, &value))
+        break;
+      base += value / sizeof(cell_t);
+    }
+
+    if (GetSymbolValue(sym, base + index[dim], &value) &&
+      sym->dimcount() == idxlevel)
+      PrintValue(value, (sym->vclass() & ~DISP_MASK));
+    else if (sym->dimcount() != idxlevel)
+      fputs("(invalid number of dimensions)", stdout);
+    else
+      fputs("?", stdout);
+  }
+}
+
+void
+Debugger::DumpStack()
+{
+  FrameIterator &iter = *frames_;
+
+  iter.Reset();
+
+  uint32_t index = 0;
+  for (; !iter.Done(); iter.Next(), index++) {
+    if (index == selected_frame_) {
+      fputs("->", stdout);
+    }
+    else {
+      fputs("  ", stdout);
+    }
+    
+    const char *name = iter.FunctionName();
+    if (!name) {
+      name = "<unknown function>";
+    }
+
+    if (iter.IsNativeFrame()) {
+      fprintf(stdout, "[%d] %s", index, name);
+      continue;
+    }
+
+    if (iter.IsScriptedFrame()) {
+      const char *file = iter.FilePath();
+      if (!file)
+        file = "<unknown>";
+      fprintf(stdout, "[%d] Line %d, %s::%s\n", index, iter.LineNumber(), file, name);
+    }
+  }
+}
+
+} // namespace sp
+
+namespace SourcePawn {
+
+using namespace sp;
+
+bool
+ConsoleDebugger::StartDebugger(const IPluginContext *ctx) {
+  PluginContext *context = (PluginContext *)ctx;
+  return context->StartDebugger();
+}
+
+ke::Vector<IBreakpoint *> *
+ConsoleDebugger::GetBreakpoints(const IPluginContext *ctx) {
+  PluginContext *context = (PluginContext *)ctx;
+  Debugger *debugger = context->GetDebugger();
+  
+  if (!debugger->active())
+    return nullptr;
+
+  ke::Vector<IBreakpoint *> *breakpoints = new ke::Vector<IBreakpoint *>();
+  Breakpoint *bp;
+  for (Debugger::BreakpointMap::iterator iter = debugger->breakpoint_map_.iter(); !iter.empty(); iter.next()) {
+    bp = iter->value;
+
+    breakpoints->append((IBreakpoint *)bp);
+  }
+  return breakpoints;
+}
+
+IBreakpoint *
+ConsoleDebugger::AddBreakpoint(const IPluginContext *ctx, const char *line, bool temporary) {
+  PluginContext *context = (PluginContext *)ctx;
+  Debugger *debugger = context->GetDebugger();
+
+  // check if a filename precedes the breakpoint location
+  char *sep;
+  const char *filename = nullptr;
+  if ((sep = (char *)strchr(line, ':')) != nullptr) {
+    /* the user may have given a partial filename (e.g. without a path), so
+    * walk through all files to find a match
+    */
+    *sep = '\0';
+    filename = context->runtime()->image()->FindFileByPartialName(line);
+    if (filename == nullptr) {
+      // invalid filename
+      return nullptr;
+    }
+
+    // Skip colon and settle before line number
+    line = sep + 1;
+  }
+
+  // User didn't specify a filename. 
+  // Use the main source file by default (last one in the list).
+  SmxV1Image *imagev1 = (SmxV1Image *)context->runtime()->image();
+  if (imagev1->GetFileCount() <= 0)
+    return nullptr;
+  filename = imagev1->GetFileName(imagev1->GetFileCount() - 1);
+
+  line = skipwhitespace((char *)line);
+
+  Breakpoint *bp;
+  // User specified a line number
+  if (isdigit(*line)) {
+    bp = debugger->AddBreakpoint(filename, strtol(line, NULL, 10) - 1, temporary);
+  }
+  // User specified a function name
+  else {
+    bp = debugger->AddBreakpoint(filename, line, temporary);
+  }
+  return (IBreakpoint *)bp;
+}
+
+bool
+ConsoleDebugger::ClearBreakpoint(const IPluginContext *ctx, int bpnum) {
+  PluginContext *context = (PluginContext *)ctx;
+  Debugger *debugger = context->GetDebugger();
+
+  return debugger->ClearBreakpoint(bpnum);
+}
+
+} // namespace SourcePawn

--- a/vm/console-debugger.cpp
+++ b/vm/console-debugger.cpp
@@ -1719,6 +1719,9 @@ ConsoleDebugger::AddBreakpoint(const IPluginContext *ctx, const char *line, bool
   PluginContext *context = (PluginContext *)ctx;
   Debugger *debugger = context->GetDebugger();
 
+  if (!debugger->active())
+    return nullptr;
+
   // check if a filename precedes the breakpoint location
   char *sep;
   const char *filename = nullptr;
@@ -1762,6 +1765,9 @@ bool
 ConsoleDebugger::ClearBreakpoint(const IPluginContext *ctx, int bpnum) {
   PluginContext *context = (PluginContext *)ctx;
   Debugger *debugger = context->GetDebugger();
+
+  if (!debugger->active())
+    return false;
 
   return debugger->ClearBreakpoint(bpnum);
 }

--- a/vm/console-debugger.cpp
+++ b/vm/console-debugger.cpp
@@ -18,16 +18,15 @@
 #include "sp_typeutil.h"
 #include "plugin-context.h"
 #include "environment.h"
-#include "jit.h"
 #include "watchdog_timer.h"
 
 #if defined __GNUC__
 #include <unistd.h>
 #endif
-#if defined __linux__
+#if defined KE_POSIX
 #include <termios.h>
 #endif
-#if defined WIN32
+#if defined KE_WINDOWS
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
@@ -47,7 +46,7 @@ enum {
 
   // Convince debugging console to act more like an
   // interactive input.
-#if defined __linux__
+#if defined KE_POSIX
 tcflag_t GetTerminalLocalMode()
 {
   struct termios term;
@@ -76,9 +75,7 @@ void ResetTerminalEcho(tcflag_t flag)
 {
   SetTerminalLocalMode(flag);
 }
-#endif
-
-#if defined WIN32
+#elif defined KE_WINDOWS
 DWORD EnableTerminalEcho()
 {
   DWORD mode, old_mode;
@@ -857,7 +854,7 @@ Debugger::HandleBreakpointCmd(char *command, char *params)
       uint32_t bpline = 0;
       LegacyImage *image = selected_context_->runtime()->image();
       image->LookupLine(bp->addr(), &bpline);
-      printf("Set breakpoint %d in file %s on line %d", breakpoint_map_.elements(), SkipPath(filename), bpline);
+      printf("Set breakpoint %zu in file %s on line %d", breakpoint_map_.elements(), SkipPath(filename), bpline);
       if (bp->name() != nullptr)
         printf(" in function %s", bp->name());
       fputs("\n", stdout);

--- a/vm/console-debugger.cpp
+++ b/vm/console-debugger.cpp
@@ -429,10 +429,10 @@ Debugger::SkipPath(const char *str)
 }
 
 void
-Debugger::ListCommands(char *command)
+Debugger::ListCommands(const char *command)
 {
-  if (command == nullptr)
-    command = (char *)"";
+  if (!command)
+    command = "";
 
   if (strlen(command) == 0 || !strcmp(command, "?")) {
     printf("At the prompt, you can type debug commands. For example, the word \"step\" is a\n"
@@ -674,13 +674,13 @@ Debugger::HandleInput(cell_t cip, bool isBp)
 }
 
 void
-Debugger::HandleHelpCmd(char *line)
+Debugger::HandleHelpCmd(const char *line)
 {
   char command[32];
   // See if there is a command specified after the "?".
   int result = sscanf(line, "%*s %30s", command);
   // Display general or special help for the command.
-  ListCommands(result ? command : nullptr);
+  ListCommands(result == 1 ? command : nullptr);
 }
 
 void
@@ -1925,7 +1925,7 @@ Debugger::DumpStack()
     }
 
     if (iter.IsNativeFrame()) {
-      fprintf(stdout, "[%d] %s", index, name);
+      fprintf(stdout, "[%d] %s\n", index, name);
       continue;
     }
 

--- a/vm/console-debugger.cpp
+++ b/vm/console-debugger.cpp
@@ -1691,6 +1691,21 @@ namespace SourcePawn {
 using namespace sp;
 
 bool
+ConsoleDebugger::IsEnabled() {
+  return enabled_;
+}
+
+bool
+ConsoleDebugger::SetEnabled(bool enable) {
+  ke::AutoLock lock(Environment::get()->lock());
+  if (Environment::get()->HasRuntimesRegistered())
+    return false;
+
+  enabled_ = enable;
+  return true;
+}
+
+bool
 ConsoleDebugger::StartDebugger(const IPluginContext *ctx) {
   PluginContext *context = (PluginContext *)ctx;
   return context->StartDebugger();

--- a/vm/console-debugger.h
+++ b/vm/console-debugger.h
@@ -125,6 +125,23 @@ public:
   void HandleInput(cell_t cip, bool isBp);
   void ListCommands(char *command);
 
+private:
+  void HandleHelpCmd(char *line);
+  void HandleQuitCmd();
+  bool HandleGoCmd(char *params);
+  void HandleFunctionListCmd();
+  void HandleFrameCmd(char *params);
+  void HandleBreakpointCmd(char *command, char *params);
+  void HandleClearBreakpointCmd(char *params);
+  void HandleVariableDisplayCmd(char *params);
+  void HandleSetVariableCmd(char *params);
+  void HandleFilesListCmd();
+  void HandleDisplayFormatChangeCmd(char *params);
+  void HandlePrintPositionCmd();
+  void HandleWatchCmd(char *params);
+  void HandleClearWatchCmd(char *params);
+  void HandleDumpMemoryCmd(char *command, char *params);
+
 public:
   struct BreakpointMapPolicy {
 

--- a/vm/console-debugger.h
+++ b/vm/console-debugger.h
@@ -178,10 +178,20 @@ private:
 
 namespace SourcePawn {
   class ConsoleDebugger : IConsoleDebugger {
+  public:
+    ConsoleDebugger() 
+      : enabled_(false)
+    {}
+
+    bool IsEnabled();
+    bool SetEnabled(bool enable);
     bool StartDebugger(const IPluginContext *ctx) override;
     ke::Vector<IBreakpoint *> *GetBreakpoints(const IPluginContext *ctx) override;
     IBreakpoint *AddBreakpoint(const IPluginContext *ctx, const char *line, bool temporary) override;
     bool ClearBreakpoint(const IPluginContext *ctx, int bpnum) override;
+
+  private:
+    bool enabled_;
   };
 }
 #endif	/* _include_sourcepawn_vm_console_debugger_h_ */

--- a/vm/console-debugger.h
+++ b/vm/console-debugger.h
@@ -208,6 +208,7 @@ namespace SourcePawn {
       : enabled_(false)
     {}
 
+    int ApiVersion();
     bool IsEnabled();
     bool SetEnabled(bool enable);
     bool StartDebugger(const IPluginContext *ctx) override;

--- a/vm/console-debugger.h
+++ b/vm/console-debugger.h
@@ -1,0 +1,188 @@
+// vim: set sts=2 ts=8 sw=2 tw=99 et:
+// 
+// Copyright (C) 2006-2015 AlliedModders LLC
+// 
+// This file is part of SourcePawn. SourcePawn is free software: you can
+// redistribute it and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License along with
+// SourcePawn. If not, see http://www.gnu.org/licenses/.
+//
+#ifndef _include_sourcepawn_vm_console_debugger_h_
+#define _include_sourcepawn_vm_console_debugger_h_
+
+#include "sp_vm_api.h"
+#include "sp_vm_debug_api.h"
+#include "plugin-context.h"
+#include <smx/smx-headers.h>
+#include <smx/smx-v1.h>
+#include "smx-v1-image.h"
+#include "stack-frames.h"
+
+#if !defined snprintf
+#define snprintf _snprintf
+#endif
+
+namespace sp {
+
+using namespace SourcePawn;
+
+int InvokeDebugger(PluginContext *ctx);
+
+static const uint32_t MAXLINELENGTH = 128;
+
+class Breakpoint : IBreakpoint {
+public:
+  Breakpoint(LegacyImage *image, ucell_t addr, const char *name, bool temporary = false)
+    : image_(image),
+    addr_(addr),
+    name_(name),
+    temporary_(temporary)
+  {}
+
+  ucell_t addr() {
+    return addr_;
+  }
+  const char *name() override {
+    return name_;
+  }
+  bool temporary() override {
+    return temporary_;
+  }
+  const char *filename() override {
+    return image_->LookupFile(addr_);
+  }
+  uint32_t line() override {
+    uint32_t line;
+    if (image_->LookupLine(addr_, &line))
+      return line;
+    return 0;
+  }
+private:
+  LegacyImage *image_; /* file image of plugin the address is in */
+  ucell_t addr_; /* address (in code or data segment) */
+  const char *name_; /* name of the symbol (function) */
+  bool temporary_; /* delete breakpoint when hit? */
+};
+
+enum Runmode {
+  STEPPING, /* step into functions */
+  STEPOVER, /* step over functions */
+  STEPOUT, /* run until the function returns */
+  RUNNING, /* just run */
+};
+
+class Debugger {
+public:
+  Debugger(PluginContext *context);
+  bool Initialize();
+  bool active();
+  void Activate();
+  void Deactivate();
+
+  void ReportError(const IErrorReport &report, FrameIterator &iter);
+
+public:
+  Breakpoint *AddBreakpoint(const char *file, unsigned int line, bool temporary);
+  Breakpoint *AddBreakpoint(const char *file, const char *function, bool temporary);
+  bool ClearBreakpoint(int number);
+  bool ClearBreakpoint(Breakpoint *);
+  void ClearAllBreakpoints();
+  bool CheckBreakpoint(cell_t cip);
+  int FindBreakpoint(char *breakpoint);
+  void ListBreakpoints();
+
+  bool AddWatch(const char *symname);
+  bool ClearWatch(const char *symname);
+  bool ClearWatch(uint32_t num);
+  void ClearAllWatches();
+  void ListWatches();
+
+  bool GetSymbolValue(const SmxV1Image::Symbol *sym, int index, cell_t *value);
+  bool SetSymbolValue(const SmxV1Image::Symbol *sym, int index, cell_t value);
+  bool SetSymbolString(const SmxV1Image::Symbol* sym, char* str);
+  char *GetString(SmxV1Image::Symbol *sym);
+  void PrintValue(long value, int disptype);
+  void DisplayVariable(SmxV1Image::Symbol *sym, uint32_t index[], int idxlevel);
+  void DumpStack();
+
+public:
+  Runmode runmode();
+  void SetRunmode(Runmode runmode);
+  cell_t lastframe();
+  void SetLastFrame(cell_t lastfrm);
+  uint32_t lastline();
+  void SetLastLine(uint32_t line);
+  uint32_t breakcount();
+  void SetBreakCount(uint32_t breakcount);
+  const char *currentfile();
+  void SetCurrentFile(const char *file);
+
+public:
+  void HandleInput(cell_t cip, bool isBp);
+  void ListCommands(char *command);
+
+public:
+  struct BreakpointMapPolicy {
+
+    static inline uint32_t hash(ucell_t value) {
+      return ke::HashInteger<4>(value);
+    }
+
+    static inline bool matches(ucell_t a, ucell_t b) {
+      return a == b;
+    }
+  };
+  typedef ke::HashMap<ucell_t, Breakpoint *, BreakpointMapPolicy> BreakpointMap;
+
+  BreakpointMap breakpoint_map_;
+
+private:
+  PluginContext *context_;
+  Runmode runmode_;
+  cell_t lastfrm_;
+  uint32_t lastline_;
+  uint32_t breakcount_;
+  const char *currentfile_;
+  bool active_;
+
+  // Temporary variables to use inside command loop
+  cell_t cip_;
+  cell_t frm_;
+  FrameIterator *frames_;
+  uint32_t frame_count_;
+  uint32_t selected_frame_;
+  PluginContext *selected_context_;
+
+  
+
+  struct WatchTablePolicy {
+    typedef AString Payload;
+
+    static uint32_t hash(const char *str) {
+      return ke::HashCharSequence(str, strlen(str));
+    }
+
+    static bool matches(const char *key, Payload str) {
+      return str.compare(key) == 0;
+    }
+  };
+  typedef ke::HashTable<WatchTablePolicy> WatchTable;
+
+  WatchTable watch_table_;
+};
+
+} // namespace sp
+
+namespace SourcePawn {
+  class ConsoleDebugger : IConsoleDebugger {
+    bool StartDebugger(const IPluginContext *ctx) override;
+    ke::Vector<IBreakpoint *> *GetBreakpoints(const IPluginContext *ctx) override;
+    IBreakpoint *AddBreakpoint(const IPluginContext *ctx, const char *line, bool temporary) override;
+    bool ClearBreakpoint(const IPluginContext *ctx, int bpnum) override;
+  };
+}
+#endif	/* _include_sourcepawn_vm_console_debugger_h_ */
+

--- a/vm/console-debugger.h
+++ b/vm/console-debugger.h
@@ -21,10 +21,6 @@
 #include "smx-v1-image.h"
 #include "stack-frames.h"
 
-#if !defined snprintf
-#define snprintf _snprintf
-#endif
-
 namespace sp {
 
 using namespace SourcePawn;

--- a/vm/console-debugger.h
+++ b/vm/console-debugger.h
@@ -93,6 +93,7 @@ public:
   bool CheckBreakpoint(cell_t cip);
   int FindBreakpoint(char *breakpoint);
   void ListBreakpoints();
+  char *ParseBreakpointLine(char *input, const char **filename);
 
   bool AddWatch(const char *symname);
   bool ClearWatch(const char *symname);

--- a/vm/console-debugger.h
+++ b/vm/console-debugger.h
@@ -87,7 +87,7 @@ public:
 
 public:
   void HandleInput(cell_t cip, bool isBp);
-  void ListCommands(char *command);
+  void ListCommands(const char *command);
 
   // String/Path helpers
   static const char *SkipPath(const char *str);
@@ -95,7 +95,7 @@ public:
   static char *TrimString(char *string);
 
 private:
-  void HandleHelpCmd(char *line);
+  void HandleHelpCmd(const char *line);
   void HandleQuitCmd();
   bool HandleGoCmd(char *params);
   void HandleFunctionListCmd();

--- a/vm/console-debugger.h
+++ b/vm/console-debugger.h
@@ -201,19 +201,26 @@ namespace SourcePawn {
   class ConsoleDebugger : IConsoleDebugger {
   public:
     ConsoleDebugger() 
-      : enabled_(false)
+      : enabled_(false),
+        debugNext_(false)
     {}
 
-    int ApiVersion();
-    bool IsEnabled();
-    bool SetEnabled(bool enable);
+  public: //IConsoleDebugger
+    int ApiVersion() override;
+    bool IsEnabled() override;
+    bool SetEnabled(bool enable) override;
+    bool DebugNextLoadedPlugin() override;
     bool StartDebugger(const IPluginContext *ctx) override;
     ke::Vector<IBreakpoint *> *GetBreakpoints(const IPluginContext *ctx) override;
     IBreakpoint *AddBreakpoint(const IPluginContext *ctx, const char *line, bool temporary) override;
     bool ClearBreakpoint(const IPluginContext *ctx, int bpnum) override;
 
+  public:
+    bool ShouldDebugNextLoadedPlugin();
+    void ResetDebugNextLoadedPlugin();
   private:
     bool enabled_;
+    bool debugNext_;
   };
 }
 #endif  /* _include_sourcepawn_vm_console_debugger_h_ */

--- a/vm/dll_exports.cpp
+++ b/vm/dll_exports.cpp
@@ -47,8 +47,10 @@ GetSourcePawnFactory(int apiVersion)
 }
 
 EXPORTFUNC IConsoleDebugger *
-GetConsoleDebugger()
+GetConsoleDebugger(int apiVersion)
 {
+	if (apiVersion > SOURCEPAWN_API_VERSION)
+		return nullptr;
 	return Environment::get()->consoledebugger();
 }
 

--- a/vm/dll_exports.cpp
+++ b/vm/dll_exports.cpp
@@ -46,6 +46,12 @@ GetSourcePawnFactory(int apiVersion)
 	return &sFactory;
 }
 
+EXPORTFUNC IConsoleDebugger *
+GetConsoleDebugger()
+{
+	return Environment::get()->consoledebugger();
+}
+
 #if defined __linux__ || defined __APPLE__
 # if !defined(_GLIBCXX_USE_NOEXCEPT)
 #  define _GLIBCXX_USE_NOEXCEPT

--- a/vm/environment.cpp
+++ b/vm/environment.cpp
@@ -23,6 +23,7 @@
 #include "jit.h"
 #endif
 #include "interpreter.h"
+#include "console-debugger.h"
 #include <stdarg.h>
 
 using namespace sp;
@@ -80,6 +81,7 @@ Environment::Initialize()
   api_v2_ = new SourcePawnEngine2();
   watchdog_timer_ = new WatchdogTimer(this);
   code_alloc_ = new CodeAllocator();
+  console_debugger_ = (IConsoleDebugger *)new ConsoleDebugger();
   code_stubs_ = new CodeStubs(this);
 
   // Safe to initialize code now that we have the code cache.
@@ -405,6 +407,10 @@ Environment::DispatchReport(const ErrorReport &report)
   // For now, we always report exceptions even if they might be handled.
   if (debugger_)
     debugger_->ReportError(report, iter);
+
+  // See if the plugin is being debugged
+  if (top_ && top_->cx()->GetDebugger()->active())
+    top_->cx()->GetDebugger()->ReportError(report, iter);
 }
 
 void

--- a/vm/environment.cpp
+++ b/vm/environment.cpp
@@ -204,6 +204,13 @@ Environment::DeregisterRuntime(PluginRuntime *rt)
   runtimes_.remove(rt);
 }
 
+bool
+Environment::HasRuntimesRegistered()
+{
+  mutex_.AssertCurrentThreadOwns();
+  return !runtimes_.empty();
+}
+
 static inline void
 SwapLoopEdge(uint8_t *code, LoopEdge &e)
 {

--- a/vm/environment.h
+++ b/vm/environment.h
@@ -81,6 +81,7 @@ class Environment : public ISourcePawnEnvironment
   // Runtime management.
   void RegisterRuntime(PluginRuntime *rt);
   void DeregisterRuntime(PluginRuntime *rt);
+  bool HasRuntimesRegistered();
   void PatchAllJumpsForTimeout();
   void UnpatchAllJumpsFromTimeout();
   ke::Mutex *lock() {

--- a/vm/environment.h
+++ b/vm/environment.h
@@ -14,6 +14,7 @@
 #define _include_sourcepawn_vm_environment_h_
 
 #include <sp_vm_api.h>
+#include <sp_vm_debug_api.h>
 #include <amtl/am-cxx.h>
 #include <amtl/am-inlinelist.h>
 #include <amtl/am-thread-utils.h>
@@ -112,6 +113,10 @@ class Environment : public ISourcePawnEnvironment
     return debugger_;
   }
 
+  IConsoleDebugger *consoledebugger() const {
+    return console_debugger_;
+  }
+
   WatchdogTimer *watchdog() const {
     return watchdog_timer_;
   }
@@ -163,6 +168,8 @@ class Environment : public ISourcePawnEnvironment
   ke::AutoPtr<ISourcePawnEngine2> api_v2_;
   ke::AutoPtr<WatchdogTimer> watchdog_timer_;
   ke::Mutex mutex_;
+
+  ke::AutoPtr<IConsoleDebugger> console_debugger_;
 
   IDebugListener *debugger_;
   ExceptionHandler *eh_top_;

--- a/vm/interpreter.cpp
+++ b/vm/interpreter.cpp
@@ -1033,6 +1033,13 @@ Interpreter::visitSTRADJUST_PRI()
 }
 
 bool
+Interpreter::visitBREAK()
+{
+  // InvokeDebugger(rt_);
+  return true;
+}
+
+bool
 Interpreter::visitHALT(cell_t value)
 {
   // We don't support this. It's included in the bytestream by default, but it

--- a/vm/interpreter.cpp
+++ b/vm/interpreter.cpp
@@ -22,6 +22,7 @@
 #include "pcode-reader.h"
 #include "runtime-helpers.h"
 #include "watchdog_timer.h"
+#include "console-debugger.h"
 #include <amtl/am-algorithm.h>
 #include <amtl/am-float.h>
 #include <fenv.h>
@@ -1035,7 +1036,14 @@ Interpreter::visitSTRADJUST_PRI()
 bool
 Interpreter::visitBREAK()
 {
-  // InvokeDebugger(rt_);
+  if (!env_->get()->consoledebugger()->IsEnabled())
+    return true;
+  
+  int err = InvokeDebugger(rt_->GetBaseContext());
+  if (err != SP_ERROR_NONE) {
+    cx_->ReportErrorNumber(err);
+    return false;
+  }
   return true;
 }
 

--- a/vm/interpreter.h
+++ b/vm/interpreter.h
@@ -148,6 +148,7 @@ class Interpreter final : public PcodeVisitor
   bool visitTRACKER_PUSH_C(cell_t amount) override;
   bool visitTRACKER_POP_SETHEAP() override;
   bool visitSTRADJUST_PRI() override;
+  bool visitBREAK() override;
   bool visitHALT(cell_t value) override;
 
  private:

--- a/vm/jit.cpp
+++ b/vm/jit.cpp
@@ -137,6 +137,9 @@ CompilerBase::emit()
   emitThrowPathIfNeeded(SP_ERROR_HEAPMIN);
   emitThrowPathIfNeeded(SP_ERROR_INTEGER_OVERFLOW);
   emitThrowPathIfNeeded(SP_ERROR_INVALID_NATIVE);
+  
+  // Common path for invoking debugger.
+  emitDebugBreakHandler();
 
   // This has to come very, very last, since it checks whether return paths
   // are used.

--- a/vm/jit.h
+++ b/vm/jit.h
@@ -72,6 +72,7 @@ class CompilerBase : public PcodeVisitor
   virtual void emitThrowPath(int err) = 0;
   virtual void emitErrorHandlers() = 0;
   virtual void emitOutOfBoundsErrorPath(OutOfBoundsErrorPath* path) = 0;
+  virtual void emitDebugBreakHandler() = 0;
 
   // Helpers.
   static int CompileFromThunk(PluginContext* cx, cell_t pcode_offs, void **addrp, uint8_t* pc);
@@ -121,6 +122,9 @@ class CompilerBase : public PcodeVisitor
   Label throw_error_code_[SP_MAX_ERROR_CODES];
   Label report_error_;
   Label return_reported_error_;
+  
+  // Debugging.
+  Label debug_break_;
 
   ke::Vector<BackwardJump> backward_jumps_;
   ke::Vector<CipMapEntry> cip_map_;

--- a/vm/legacy-image.h
+++ b/vm/legacy-image.h
@@ -58,6 +58,11 @@ class LegacyImage
   virtual const char *LookupFile(uint32_t code_offset) = 0;
   virtual const char *LookupFunction(uint32_t code_offset) = 0;
   virtual bool LookupLine(uint32_t code_offset, uint32_t *line) = 0;
+
+  // Additional information for interactive debugging.
+  virtual bool GetFunctionAddress(const char *function, const char *file, uint32_t *addr) = 0;
+  virtual bool GetLineAddress(const uint32_t line, const char *file, uint32_t *addr) = 0;
+  virtual const char *FindFileByPartialName(const char *partialname) = 0;
 };
 
 class EmptyImage : public LegacyImage
@@ -125,6 +130,15 @@ class EmptyImage : public LegacyImage
   }
   bool LookupLine(uint32_t code_offset, uint32_t *line) override {
     return false;
+  }
+  bool GetFunctionAddress(const char *function, const char *file, uint32_t *addr) override {
+    return false;
+  }
+  bool GetLineAddress(const uint32_t line, const char *file, uint32_t *addr) override {
+    return false;
+  }
+  const char *FindFileByPartialName(const char *partialname) override {
+    return nullptr;
   }
 
  private:

--- a/vm/pcode-reader.h
+++ b/vm/pcode-reader.h
@@ -87,11 +87,9 @@ class PcodeReader
     case OP_NOP:
       return true;
 
-    // This opcode is used to note where line breaks occur. We don't support
-    // live debugging, and if we did, we could build this map from the lines
-    // table. So we don't do any callbacks here.
+    // This opcode is used to note where line breaks occur.
     case OP_BREAK:
-      return true;
+      return visitor_->visitBREAK();
 
     case OP_LOAD_PRI:
     case OP_LOAD_ALT:

--- a/vm/pcode-visitor.h
+++ b/vm/pcode-visitor.h
@@ -46,6 +46,7 @@ static_assert(sizeof(CaseTableEntry) == sizeof(cell_t) * 2,
 class PcodeVisitor
 {
  public:
+  virtual bool visitBREAK() = 0;
   virtual bool visitLOAD(PawnReg dest, cell_t srcaddr) = 0;
   virtual bool visitLOAD_S(PawnReg dest, cell_t srcoffs) = 0;
   virtual bool visitLREF_S(PawnReg dest, cell_t srcoffs) = 0;
@@ -138,6 +139,10 @@ class PcodeVisitor
 class IncompletePcodeVisitor : public PcodeVisitor
 {
  public:
+  virtual bool visitBREAK() override {
+    assert(false);
+    return false;
+  }
   virtual bool visitLOAD(PawnReg dest, cell_t srcaddr) override {
     assert(false);
     return false;

--- a/vm/plugin-context.cpp
+++ b/vm/plugin-context.cpp
@@ -897,6 +897,9 @@ PluginContext::StartDebugger()
   if (runtime()->IsPaused())
     return false;
 
+  if (!Environment::get()->consoledebugger()->IsEnabled())
+    return false;
+
   debugger_->Activate();
   debugger_->SetRunmode(STEPPING);
 

--- a/vm/plugin-context.h
+++ b/vm/plugin-context.h
@@ -36,6 +36,7 @@ static const cell_t STACK_MARGIN = 64; // 16 parameters of safety, I guess
 
 class Environment;
 class PluginContext;
+class Debugger;
 
 class PluginContext : public BasePluginContext
 {
@@ -72,6 +73,10 @@ class PluginContext : public BasePluginContext
 
   bool Invoke(funcid_t fnid, const cell_t *params, unsigned int num_params, cell_t *result);
 
+  // Console debugging.
+  Debugger *GetDebugger();
+  bool StartDebugger();
+
   size_t HeapSize() const {
     return mem_size_;
   }
@@ -101,7 +106,7 @@ class PluginContext : public BasePluginContext
     return offsetof(PluginContext, memory_);
   }
 
-  int32_t *addressOfSp() {
+  cell_t *addressOfSp() {
     return &sp_;
   }
   cell_t *addressOfFrm() {
@@ -144,6 +149,7 @@ class PluginContext : public BasePluginContext
 
  private:
   PluginRuntime *m_pRuntime;
+  Debugger *debugger_;
   uint8_t *memory_;
   uint32_t data_size_;
   uint32_t mem_size_;

--- a/vm/smx-v1-image.cpp
+++ b/vm/smx-v1-image.cpp
@@ -678,7 +678,7 @@ SmxV1Image::getFunctionAddress(const SymbolType *syms, const char *name, uint32_
     }
 
     if (i == *index)
-      *index++;
+      (*index)++;
     i++;
   }
   return false;

--- a/vm/smx-v1-image.cpp
+++ b/vm/smx-v1-image.cpp
@@ -418,6 +418,18 @@ SmxV1Image::validateTags()
   return true;
 }
 
+SmxV1Image::SymbolIterator
+SmxV1Image::symboliterator() {
+  if (debug_syms_) {
+    SmxV1Image::SymbolIterator iter((uint8_t *)debug_syms_, debug_symbols_section_->size, true);
+    return iter;
+  }
+  else {
+    SmxV1Image::SymbolIterator iter((uint8_t *)debug_syms_unpacked_, debug_symbols_section_->size, false);
+    return iter;
+  }
+}
+
 auto
 SmxV1Image::DescribeCode() const -> Code
 {
@@ -645,4 +657,245 @@ SmxV1Image::LookupLine(uint32_t addr, uint32_t *line)
   // Since the CIP occurs BEFORE the line, we have to add one.
   *line = debug_lines_[low].line + 1;
   return true;
+}
+
+template <typename SymbolType, typename DimType>
+bool
+SmxV1Image::getFunctionAddress(const SymbolType *syms, const char *name, uint32_t *addr, uint32_t *index)
+{
+  unsigned int i = 0;
+  SymbolIterator iter = symboliterator();
+  while (!iter.Done()) {
+    Symbol sym = iter.Next();
+
+    if (i >= *index &&
+      sym.ident() == sp::IDENT_FUNCTION &&
+      sym.name() < debug_names_section_->size &&
+      !strcmp(debug_names_ + sym.name(), name))
+    {
+      *addr = sym.addr();
+      return true;
+    }
+
+    if (i == *index)
+      *index++;
+    i++;
+  }
+  return false;
+}
+
+bool
+SmxV1Image::GetFunctionAddress(const char *function, const char *file, uint32_t *funcaddr)
+{
+  uint32_t index = 0;
+  const char *tgtfile;
+  *funcaddr = 0;
+  for (;;) {
+    // find (next) matching function
+    if (debug_syms_) {
+      getFunctionAddress<sp_fdbg_symbol_t, sp_fdbg_arraydim_t>(debug_syms_, function, funcaddr, &index);
+    }
+    else {
+      getFunctionAddress<sp_u_fdbg_symbol_t, sp_u_fdbg_arraydim_t>(debug_syms_unpacked_, function, funcaddr, &index);
+    }
+
+    if (index >= debug_info_->num_syms)
+      return false;
+
+    // verify that this function is defined in the apprpriate file
+    tgtfile = LookupFile(*funcaddr);
+    if (tgtfile != nullptr && strcmp(file, tgtfile) == 0)
+      break;
+    index++;
+  }
+  assert(index < debug_info_->num_syms);
+
+  // now find the first line in the function where we can "break" on
+  for (index = 0; index < debug_info_->num_lines && debug_lines_[index].addr < *funcaddr; index++)
+    /* nothing */;
+
+  if (index >= debug_info_->num_lines)
+    return false;
+
+  *funcaddr = debug_lines_[index].addr;
+  return true;
+}
+
+bool
+SmxV1Image::GetLineAddress(const uint32_t line, const char *filename, uint32_t *addr)
+{
+  /* Find a suitable "breakpoint address" close to the indicated line (and in
+   * the specified file). The address is moved up to the next "breakable" line
+   * if no "breakpoint" is available on the specified line. You can use function
+   * LookupLine() to find out at which precise line the breakpoint was set.
+   *
+   * The filename comparison is strict (case sensitive and path sensitive).
+   */
+  *addr = 0;
+
+  uint32_t bottomaddr, topaddr;
+  uint32_t file;
+  uint32_t index = 0;
+  for (file = 0; file < debug_info_->num_files; file++) {
+    // find the (next) matching instance of the file
+    if (debug_files_[file].name >= debug_names_section_->size ||
+      strcmp(debug_names_ + debug_files_[file].name, filename) != 0)
+    {
+      continue;
+    }
+
+    // get address range for the current file
+    bottomaddr = debug_files_[file].addr;
+    topaddr = (file + 1 < debug_info_->num_files) ? debug_files_[file + 1].addr : (uint32_t)-1;
+    
+    // go to the starting address in the line table
+    while (index < debug_info_->num_lines && debug_lines_[index].addr < bottomaddr)
+      index++;
+
+    // browse until the line is found or until the top address is exceeded
+    while (index < debug_info_->num_lines &&
+      debug_lines_[index].line < line &&
+      debug_lines_[index].addr < topaddr)
+    {
+      index++;
+    }
+
+    if (index >= debug_info_->num_lines)
+      return false;
+    if (debug_lines_[index].line >= line)
+      break;
+
+    // if not found (and the line table is not yet exceeded) try the next
+    // instance of the same file (a file may appear twice in the file table)
+  }
+  if (file >= debug_info_->num_files)
+    return false;
+
+  assert(index < debug_info_->num_lines);
+  *addr = debug_lines_[index].addr;
+  return true;
+}
+
+const char *
+SmxV1Image::FindFileByPartialName(const char *partialname)
+{
+  // the user may have given a partial filename (e.g. without a path), so
+  // walk through all files to find a match.
+  int len = strlen(partialname);
+  int offs;
+  const char *filename;
+  for (uint32_t i = 0; i < debug_info_->num_files; i++) {
+    // Invalid name offset?
+    if (debug_files_[i].name >= debug_names_section_->size)
+      continue;
+
+    filename = debug_names_ + debug_files_[i].name;
+    offs = strlen(filename) - len;
+    if (offs >= 0 &&
+      !strncmp(filename + offs, partialname, len))
+    {
+      return filename;
+    }
+  }
+  return nullptr;
+}
+
+const char *
+SmxV1Image::GetTagName(uint32_t tag)
+{
+  unsigned int index;
+  for (index = 0; index < tags_.length() && tags_[index].tag_id != tag; index++)
+    /* nothing */;
+  if (index >= tags_.length())
+    return nullptr;
+
+  return names_ + tags_[index].name;
+}
+
+bool
+SmxV1Image::GetVariable(const char *symname, uint32_t scopeaddr, ke::AutoPtr<Symbol> &sym)
+{
+  uint32_t codestart = 0;
+  uint32_t codeend = 0;
+
+  sym = nullptr;
+
+  SymbolIterator iter = symboliterator();
+  while (!iter.Done()) {
+    ke::AutoPtr<Symbol> symbol;
+    // find (next) matching variable
+    while (!iter.Done()) {
+      symbol = iter.Next();
+      
+      if (symbol->codestart() <= scopeaddr &&
+        symbol->codeend() >= scopeaddr &&
+        symbol->ident() != sp::IDENT_FUNCTION &&
+        strcmp(debug_names_ + symbol->name(), symname) == 0)
+      {
+        break;
+      }
+    }
+
+    // check the range, keep a pointer to the symbol with the smallest range
+    if (!strcmp(debug_names_ + symbol->name(), symname) &&
+        ((codestart == 0 && codeend == 0) ||
+         (symbol->codestart() >= codestart &&
+          symbol->codeend() <= codeend)))
+    {
+      sym = new Symbol(symbol);
+      codestart = symbol->codestart();
+      codeend = symbol->codeend();
+    }
+  }
+
+  return *sym != nullptr;
+}
+
+const char *
+SmxV1Image::GetDebugName(uint32_t nameoffs)
+{
+  if (nameoffs >= debug_names_section_->size)
+    return nullptr;
+  return debug_names_ + nameoffs;
+}
+
+const char *
+SmxV1Image::GetFileName(uint32_t index)
+{
+  if (debug_files_[index].name >= debug_names_section_->size)
+    return nullptr;
+  return debug_names_ + debug_files_[index].name;
+}
+
+uint32_t
+SmxV1Image::GetFileCount()
+{
+  return debug_info_->num_files;
+}
+
+ke::Vector<SmxV1Image::ArrayDim *> *
+SmxV1Image::GetArrayDimensions(const Symbol *sym)
+{
+  if (sym->ident() != sp::IDENT_ARRAY && sym->ident() != IDENT_REFARRAY)
+    return nullptr;
+
+  assert(sym->dimcount() > 0); // array must have at least one dimension
+
+  // find he end of the symbol name
+  const char *ptr;
+  for (ptr = debug_names_ + sym->name(); *ptr != '\0'; ptr++)
+    /* nothing */;
+
+  ke::Vector<ArrayDim *> *dims = new ke::Vector<ArrayDim *>();
+  for (int i = 0; i < sym->dimcount(); i++) {
+    if (sym->packed()) {
+      dims->append(new ArrayDim((sp_fdbg_arraydim_t *)ptr));
+      ptr += sizeof(sp_fdbg_arraydim_t);
+    }
+    else {
+      dims->append(new ArrayDim((sp_u_fdbg_arraydim_t *)ptr));
+      ptr += sizeof(sp_u_fdbg_arraydim_t);
+    }
+  }
+  return dims;
 }

--- a/vm/smx-v1-image.h
+++ b/vm/smx-v1-image.h
@@ -74,8 +74,6 @@ class SmxV1Image
    {
    public:
      Symbol(sp_fdbg_symbol_t *sym) :
-       sym_(sym),
-       unpacked_sym_(nullptr),
        addr_(sym->addr),
        tagid_(sym->tagid),
        codestart_(sym->codestart),
@@ -83,12 +81,12 @@ class SmxV1Image
        ident_(sym->ident),
        vclass_(sym->vclass),
        dimcount_(sym->dimcount),
-       name_(sym->name)
+       name_(sym->name),
+       sym_(sym),
+       unpacked_sym_(nullptr)
      {}
 
      Symbol(sp_u_fdbg_symbol_t *sym) :
-       sym_(nullptr),
-       unpacked_sym_(sym),
        addr_(sym->addr),
        tagid_(sym->tagid),
        codestart_(sym->codestart),
@@ -96,12 +94,12 @@ class SmxV1Image
        ident_(sym->ident),
        vclass_(sym->vclass),
        dimcount_(sym->dimcount),
-       name_(sym->name)
+       name_(sym->name),
+       sym_(nullptr),
+       unpacked_sym_(sym)
      {}
 
      Symbol(Symbol *sym) :
-       sym_(sym->sym_),
-       unpacked_sym_(sym->unpacked_sym_),
        addr_(sym->addr_),
        tagid_(sym->tagid_),
        codestart_(sym->codestart_),
@@ -109,7 +107,9 @@ class SmxV1Image
        ident_(sym->ident_),
        vclass_(sym->vclass_),
        dimcount_(sym->dimcount_),
-       name_(sym->name_)
+       name_(sym->name_),
+       sym_(sym->sym_),
+       unpacked_sym_(sym->unpacked_sym_)
      {}
 
      const int32_t addr() const {

--- a/vm/stack-frames.cpp
+++ b/vm/stack-frames.cpp
@@ -242,6 +242,12 @@ FrameIterator::nextInvokeFrame()
   }
 }
 
+cell_t
+FrameIterator::cip() const
+{
+  return frame_cursor_->cip();
+}
+
 void
 FrameIterator::Next()
 {

--- a/vm/stack-frames.h
+++ b/vm/stack-frames.h
@@ -229,6 +229,9 @@ class FrameIterator : public SourcePawn::IFrameIterator
   unsigned LineNumber() const override;
   IPluginContext *Context() const override;
   bool IsInternalFrame() const override;
+  
+ public:
+  cell_t cip() const;
 
  private:
   void nextInvokeFrame();

--- a/vm/watchdog_timer.h
+++ b/vm/watchdog_timer.h
@@ -40,6 +40,8 @@ class WatchdogTimer
   bool NotifyTimeoutReceived();
   bool HandleInterrupt();
 
+  void SetIgnore(bool ignore);
+
  private:
   // Watchdog thread.
   void Run();
@@ -50,6 +52,7 @@ class WatchdogTimer
   bool terminate_;
   size_t timeout_ms_;
   ke::ThreadId mainthread_;
+  bool ignore_timeout_;
 
   ke::AutoPtr<ke::Thread> thread_;
   ke::ConditionVariable cv_;

--- a/vm/x86/jit_x86.cpp
+++ b/vm/x86/jit_x86.cpp
@@ -1590,6 +1590,7 @@ Compiler::emitDebugBreakHandler()
   // Get the context pointer and call the debugging break handler.
   __ push(intptr_t(rt_->GetBaseContext()));
   __ call(ExternalAddress((void *)InvokeDebugger));
+  __ addl(esp, 4);
   __ leaveExitFrame();
   __ testl(eax, eax);
   jumpOnError(not_zero);

--- a/vm/x86/jit_x86.cpp
+++ b/vm/x86/jit_x86.cpp
@@ -1083,8 +1083,11 @@ Compiler::visitTRACKER_POP_SETHEAP()
 bool
 Compiler::visitBREAK()
 {
-  __ call(&debug_break_);
-  emitCipMapping(op_cip_);
+  // Only emit calls, if debugging is enabled in general.
+  if (env_->get()->consoledebugger()->IsEnabled()) {
+    __ call(&debug_break_);
+    emitCipMapping(op_cip_);
+  }
   return true;
 }
 
@@ -1576,6 +1579,10 @@ Compiler::emitThrowPath(int err)
 void
 Compiler::emitDebugBreakHandler()
 {
+  // No need for this chunk, if debugging is disabled.
+  if (!env_->consoledebugger()->IsEnabled())
+    return;
+
   // Get and store the current stack pointer.
   __ movl(tmp, stk);
   __ movl(frm, stk);

--- a/vm/x86/jit_x86.cpp
+++ b/vm/x86/jit_x86.cpp
@@ -1583,14 +1583,14 @@ Compiler::emitDebugBreakHandler()
   if (!env_->consoledebugger()->IsEnabled())
     return;
 
-  // Get and store the current stack pointer.
-  __ movl(tmp, stk);
-  __ movl(frm, stk);
-  __ subl(tmp, dat);
-  __ movl(Operand(spAddr()), tmp);
-
   // Common path for invoking debugger.
   __ bind(&debug_break_);
+
+  // Get and store the current stack pointer.
+  __ movl(tmp, stk);
+  __ subl(tmp, dat);
+  __ movl(Operand(spAddr()), tmp);
+  
   // Enter the exit frame. This aligns the stack.
   __ enterExitFrame(ExitFrameType::Helper, 0);
 

--- a/vm/x86/jit_x86.cpp
+++ b/vm/x86/jit_x86.cpp
@@ -43,6 +43,7 @@
 #include "outofline-asm.h"
 #include "method-info.h"
 #include "runtime-helpers.h"
+#include "console-debugger.h"
 
 #define __ masm.
 
@@ -1080,6 +1081,14 @@ Compiler::visitTRACKER_POP_SETHEAP()
 }
 
 bool
+Compiler::visitBREAK()
+{
+  __ call(&debug_break_);
+  emitCipMapping(op_cip_);
+  return true;
+}
+
+bool
 Compiler::visitHALT(cell_t value)
 {
   // We don't support this. It's included in the bytestream by default, but it
@@ -1562,6 +1571,29 @@ Compiler::emitThrowPath(int err)
 {
   __ movl(eax, err);
   __ jmp(&report_error_);
+}
+
+void
+Compiler::emitDebugBreakHandler()
+{
+  // Get and store the current stack pointer.
+  __ movl(tmp, stk);
+  __ movl(frm, stk);
+  __ subl(tmp, dat);
+  __ movl(Operand(spAddr()), tmp);
+
+  // Common path for invoking debugger.
+  __ bind(&debug_break_);
+  // Enter the exit frame. This aligns the stack.
+  __ enterExitFrame(ExitFrameType::Helper, 0);
+
+  // Get the context pointer and call the debugging break handler.
+  __ push(intptr_t(rt_->GetBaseContext()));
+  __ call(ExternalAddress((void *)InvokeDebugger));
+  __ leaveExitFrame();
+  __ testl(eax, eax);
+  jumpOnError(not_zero);
+  __ ret();
 }
 
 void

--- a/vm/x86/jit_x86.h
+++ b/vm/x86/jit_x86.h
@@ -44,6 +44,7 @@ class Compiler : public CompilerBase
   Compiler(PluginRuntime *rt, cell_t pcode_offs);
   ~Compiler();
 
+  bool visitBREAK() override;
   bool visitLOAD(PawnReg dest, cell_t srcaddr) override;
   bool visitLOAD_S(PawnReg dest, cell_t srcoffs) override;
   bool visitLREF_S(PawnReg dest, cell_t srcoffs) override;
@@ -143,6 +144,7 @@ class Compiler : public CompilerBase
   void emitThrowPath(int err) override;
   void emitErrorHandlers() override;
   void emitOutOfBoundsErrorPath(OutOfBoundsErrorPath* path) override;
+  void emitDebugBreakHandler() override;
 
   void emitLegacyNativeCall(uint32_t native_index, NativeEntry* native);
   void emitGenArray(bool autozero);


### PR DESCRIPTION
Adds a console debugger within a local "shell" to debug plugins.
It's based on pawndbg, the Pawn debugger, by ITB CompuPhase.

A new exported function is added to grab the debugger interface to avoid changing any existing interface. This helps to keep the interface and structure as flexible as possible until we settle on a design.

``` cpp
IConsoleDebugger *GetConsoleDebugger(int apiVersion);
```

The debugger is disabled completely by default, until it is activated through that interface before any plugin is loaded. (Mapped to a config option in core.cfg in SourceMod)
When enabled, it adds code to break on every dbgbreak plugin opcode. If the plugin is marked as being debugged, it breaks on exceptions and set break points.
Normal execution is paused and the user is prompted with a debug shell to show and change values of variables, step through the plugin, dump plugin memory and walk through the stack trace. General options to manage break points and watched variables are available too.

I've tried to abstract the symbols to support packed and unpacked symbols in old plugin binaries, but that could be done more generally in the future, if we'd add a new smxv2 file format.

The sourcepawn watchdog is set to ignore timeouts while the debugger shell is running, to avoid instant timeouts when continuing execution after working in the debugger shell.

Calling into the debugger to check for breakpoints on every dbgbreak instruction for all plugins is quite expensive. We should only patch in the call when debugging is enabled on the plugin and don't slow down all plugins. But this debugger should only enabled in general on development servers, so performance isn't that much of an issue here.

Basic commands as listed by the `?` command:

```
At the prompt, you can type debug commands. For example, the word "step" is a
command to execute a single line in the source code. The commands that you will
use most frequently may be abbreviated to a single letter: instead of the full
word "step", you can also type the letter "s" followed by the enter key.

Available commands:
    B(ack)T(race)       display the stack trace
    BREAK       set breakpoint at line number or variable name
    CBREAK      remove breakpoint
    CW(atch)    remove a "watchpoint"
    D(isp)      display the value of a variable, list variables
    FILES       list all files that this program is composed off
    F(rame)     Select a frame from the back trace to operate on
    FUNCS       display functions
    G(o)        run program (until breakpoint)
    N(ext)      Run until next line, step over functions
    POS     Show current file and line
    QUIT        exit debugger
    SET     Set a variable to a value
    S(tep)      single step, step into functions
    TYPE        set the "display type" of a symbol
    W(atch)     set a "watchpoint" on a variable
    X       examine plugin memory: x/FMT ADDRESS

    Use "? <command name>" to view more information on a command
```
