### PR TITLE
Allow blaming an IPF for an error.

### DIFF
--- a/include/sp_vm_api.h
+++ b/include/sp_vm_api.h
@@ -23,8 +23,8 @@
 #include "sp_vm_types.h"
 
 /** SourcePawn Engine API Versions */
-#define SOURCEPAWN_ENGINE2_API_VERSION 0xA
-#define SOURCEPAWN_API_VERSION   0x020A
+#define SOURCEPAWN_ENGINE2_API_VERSION 0xB
+#define SOURCEPAWN_API_VERSION   0x020B
 
 namespace SourceMod {
   struct IdentityToken_t;
@@ -254,6 +254,13 @@ namespace SourcePawn
      * @return        True on success, false on error.
      */
     virtual bool Invoke(cell_t *rval = nullptr) = 0;
+    
+    /**
+     * @brief Returns a name to identify this function for debugging purposes.
+	 *
+	 * @return       String name.
+     */
+    virtual const char *DebugName() = 0;
   };
 
 
@@ -948,6 +955,12 @@ namespace SourcePawn
      * @param number       Error number.
      */
     virtual void ReportErrorNumber(int error) = 0;
+
+    /**
+     * @brief Report a error caused by a plugin, specifying a function
+     * as the cause.  
+     */
+    virtual cell_t BlamePluginError(IPluginFunction *pf, const char *msg, ...) = 0;
   };
 
   /**
@@ -982,6 +995,20 @@ namespace SourcePawn
      * @return          Plugin context.
      */
     virtual IPluginContext *Context() const = 0;
+
+    /**
+     * @brief Return the error code of the error report.
+     *
+     * @return          Integer code.
+     */
+    virtual int Code() const = 0;
+
+    /**
+     * @brief Return the specific plugin function that caused the error.
+     *
+     * @return          Blamed function.
+     */
+    virtual IPluginFunction *Blame() const = 0;
   };
 
   /**

--- a/include/sp_vm_api.h
+++ b/include/sp_vm_api.h
@@ -997,13 +997,6 @@ namespace SourcePawn
     virtual IPluginContext *Context() const = 0;
 
     /**
-     * @brief Return the error code of the error report.
-     *
-     * @return          Integer code.
-     */
-    virtual int Code() const = 0;
-
-    /**
      * @brief Return the specific plugin function that caused the error.
      *
      * @return          Blamed function.

--- a/vm/base-context.cpp
+++ b/vm/base-context.cpp
@@ -223,3 +223,13 @@ BasePluginContext::GetLastNativeError()
     return SP_ERROR_NONE;
   return env->getPendingExceptionCode();
 }
+
+cell_t
+BasePluginContext::BlamePluginError(SourcePawn::IPluginFunction *pf, const char *msg, ...)
+{
+  va_list ap;
+  va_start(ap, msg);
+  env_->BlamePluginErrorVA(pf, msg, ap);
+  va_end(ap);
+  return 0;
+}

--- a/vm/base-context.h
+++ b/vm/base-context.h
@@ -39,6 +39,7 @@ public:
   cell_t ThrowNativeErrorEx(int error, const char *msg, ...) override;
   cell_t ThrowNativeError(const char *msg, ...) override;
   int GetLastNativeError() override;
+  cell_t BlamePluginError(SourcePawn::IPluginFunction *pf, const char *msg, ...) override;
 
   // Removed functions.
   int PushCell(cell_t value) override;

--- a/vm/environment.cpp
+++ b/vm/environment.cpp
@@ -250,60 +250,56 @@ Environment::ReportError(int code)
   }
 }
 
-class ErrorReport : public SourcePawn::IErrorReport
-{
- public:
-  ErrorReport(int code, const char *message, PluginContext *cx, SourcePawn::IPluginFunction *pf)
+ErrorReport::ErrorReport(int code, const char *message, PluginContext *cx, SourcePawn::IPluginFunction *pf)
    : code_(code),
      message_(message),
      context_(cx),
      blame_(pf)
   {}
 
-  const char *Message() const override {
-    return message_;
-  }
+const char *
+ErrorReport::Message() const {
+  return message_;
+}
 
-  int Code() const override {
-    return code_;
-  }
+IPluginFunction *
+ErrorReport::Blame() const {
+  return blame_;
+}
 
-  IPluginFunction *Blame() const override {
-    return blame_;
+bool
+ErrorReport::IsFatal() const {
+  switch (code_) {
+    case SP_ERROR_HEAPLOW:
+    case SP_ERROR_INVALID_ADDRESS:
+    case SP_ERROR_STACKLOW:
+    case SP_ERROR_INVALID_INSTRUCTION:
+    case SP_ERROR_MEMACCESS:
+    case SP_ERROR_STACKMIN:
+    case SP_ERROR_HEAPMIN:
+    case SP_ERROR_INSTRUCTION_PARAM:
+    case SP_ERROR_STACKLEAK:
+    case SP_ERROR_HEAPLEAK:
+    case SP_ERROR_TRACKER_BOUNDS:
+    case SP_ERROR_PARAMS_MAX:
+    case SP_ERROR_ABORTED:
+    case SP_ERROR_OUT_OF_MEMORY:
+    case SP_ERROR_FATAL:
+      return true;
+    default:
+      return false;
   }
+}
 
-  bool IsFatal() const override {
-    switch (code_) {
-      case SP_ERROR_HEAPLOW:
-      case SP_ERROR_INVALID_ADDRESS:
-      case SP_ERROR_STACKLOW:
-      case SP_ERROR_INVALID_INSTRUCTION:
-      case SP_ERROR_MEMACCESS:
-      case SP_ERROR_STACKMIN:
-      case SP_ERROR_HEAPMIN:
-      case SP_ERROR_INSTRUCTION_PARAM:
-      case SP_ERROR_STACKLEAK:
-      case SP_ERROR_HEAPLEAK:
-      case SP_ERROR_TRACKER_BOUNDS:
-      case SP_ERROR_PARAMS_MAX:
-      case SP_ERROR_ABORTED:
-      case SP_ERROR_OUT_OF_MEMORY:
-      case SP_ERROR_FATAL:
-        return true;
-      default:
-        return false;
-    }
-  }
-  IPluginContext *Context() const override {
-    return context_;
-  }
+IPluginContext *
+ErrorReport::Context() const {
+  return context_;
+}
 
- private:
-  int code_;
-  const char *message_;
-  PluginContext *context_;
-  IPluginFunction *blame_;
-};
+int 
+ErrorReport::Code() const {
+  return code_;
+}
 
 void
 Environment::ReportErrorVA(const char *fmt, va_list ap)
@@ -346,7 +342,7 @@ void Environment::BlamePluginErrorVA(SourcePawn::IPluginFunction *pf, const char
 }
 
 void
-Environment::DispatchReport(const IErrorReport &report)
+Environment::DispatchReport(const ErrorReport &report)
 {
   FrameIterator iter;
 

--- a/vm/environment.h
+++ b/vm/environment.h
@@ -28,6 +28,7 @@ using namespace SourcePawn;
 class PluginRuntime;
 class CodeStubs;
 class WatchdogTimer;
+class ErrorReport;
 
 // An Environment encapsulates everything that's needed to load and run
 // instances of plugins on a single thread. There can be at most one
@@ -161,7 +162,7 @@ class Environment : public ISourcePawnEnvironment
   bool Initialize();
 
  private:
-  void DispatchReport(const IErrorReport &report);
+  void DispatchReport(const ErrorReport &report);
   ke::AutoPtr<ISourcePawnEngine> api_v1_;
   ke::AutoPtr<ISourcePawnEngine2> api_v2_;
   ke::AutoPtr<WatchdogTimer> watchdog_timer_;
@@ -201,6 +202,25 @@ class EnterProfileScope
     if (Environment::get()->IsProfilingEnabled())
       Environment::get()->profiler()->LeaveScope();
   }
+};
+
+class ErrorReport : public SourcePawn::IErrorReport
+{
+  public:
+  ErrorReport(int code, const char *message, PluginContext *cx, SourcePawn::IPluginFunction *pf);
+  int Code() const;
+
+  public: //IErrorReport
+  const char *Message() const override;
+  IPluginFunction *Blame() const override;
+  bool IsFatal() const override;
+  IPluginContext *Context() const override;
+
+ private:
+  int code_;
+  const char *message_;
+  PluginContext *context_;
+  IPluginFunction *blame_;
 };
 
 } // namespace sp

--- a/vm/environment.h
+++ b/vm/environment.h
@@ -67,6 +67,7 @@ class Environment : public ISourcePawnEnvironment
   void ReportErrorFmt(int code, const char *message, ...);
   void ReportErrorVA(const char *fmt, va_list ap);
   void ReportErrorVA(int code, const char *fmt, va_list ap);
+  void BlamePluginErrorVA(SourcePawn::IPluginFunction *pf, const char *fmt, va_list ap);
 
   // Allocate and free executable memory.
   CodeChunk AllocateCode(size_t size);
@@ -160,6 +161,7 @@ class Environment : public ISourcePawnEnvironment
   bool Initialize();
 
  private:
+  void DispatchReport(const IErrorReport &report);
   ke::AutoPtr<ISourcePawnEngine> api_v1_;
   ke::AutoPtr<ISourcePawnEngine2> api_v2_;
   ke::AutoPtr<WatchdogTimer> watchdog_timer_;

--- a/vm/plugin-context.cpp
+++ b/vm/plugin-context.cpp
@@ -434,7 +434,7 @@ PluginContext::Invoke(funcid_t fnid, const cell_t *params, unsigned int num_para
     result = &ignore_result;
 
   /* We got this far.  It's time to start profiling. */
-  EnterProfileScope scriptScope("SourcePawn", cfun->FullName());
+  EnterProfileScope scriptScope("SourcePawn", cfun->DebugName());
 
   /* See if we have to compile the callee. */
   CompiledFunction *fn = nullptr;

--- a/vm/scripted-invoker.h
+++ b/vm/scripted-invoker.h
@@ -65,11 +65,11 @@ class ScriptedInvoker : public IPluginFunction
     unsigned int num_params, 
     cell_t *result);
   IPluginRuntime *GetParentRuntime();
-
- public:
-  const char *FullName() const {
+  const char *DebugName() {
     return full_name_;
   }
+
+ public:
   sp_public_t *Public() const {
     return public_;
   }


### PR DESCRIPTION
This modifies a few interfaces, so I bumped both versions.  I have no idea if both need bumping.

IPluginFunction: adds const char \*DebugName()
IErrorReport: adds int Code() and IPF \*Blame()
IPluginContext: adds BlamePluginError(IPF\*, const char\*, ...)

ScriptedInvoker's existing FullName() was changed to DebugName().  It lost some constness since no other IPluginFunction stuff was.

There'll be another PR for SM to use this instead of ThrowNativeError where applicable and update DebugReporter.