### PR TITLE
Fix references as dimension sizes and get rid of a couple unused variables (bug 6452)

### DIFF
--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -1874,6 +1874,7 @@ static void declloc(int tokid)
               case iEXPRESSION:
               case iARRAYCELL:
               case iCONSTEXPR:
+              case iREFERENCE:  
                 break;
               default:
                 error(29);
@@ -2886,7 +2887,7 @@ static void parse_old_array_dims(declinfo_t *decl, int flags)
         &sym, 0, &val
       );
 
-      if (ident == iVARIABLE || ident == iEXPRESSION || ident == iARRAYCELL) {
+      if (ident == iVARIABLE || ident == iEXPRESSION || ident == iARRAYCELL || ident == iREFERENCE) {
         type->size = -1;
         type->dim[type->numdim] = 0;
       } else if (ident == iCONSTEXPR) {

--- a/compiler/tests/ok-ref-as-index.sp
+++ b/compiler/tests/ok-ref-as-index.sp
@@ -1,0 +1,14 @@
+
+public void OnPluginStart()
+{
+	int desiredEggs = 3;
+	Egg(desiredEggs);
+}
+
+void Egg(int &cntEggs)
+{
+	int[] MYEGGS = new int[cntEggs];
+
+	// Avoid "unused" warning
+	MYEGGS[0] = 1;
+}


### PR DESCRIPTION
gcc 4.9 yelled at me about the variables.