### PR TITLE
Use monospace font for enum values

### DIFF
--- a/exp/docgen/www/template/enum.php
+++ b/exp/docgen/www/template/enum.php
@@ -35,7 +35,7 @@ if ($PageEnum['entries']) {
             <?php
                 foreach ($PageEnum['entries'] as $EnumValue) {
                     echo '<tr>';
-                    echo '<td class="col-md-2">' . htmlspecialchars($EnumValue['name']) . '</td>';
+                    echo '<td class="col-md-2 mono">' . htmlspecialchars($EnumValue['name']) . '</td>';
                     echo '<td>';
                     RenderDescription($EnumValue['brief']);
                     echo '</td>';


### PR DESCRIPTION
Other values across the site use monospace font.