### PR TITLE
Validate .tags section.

### DIFF
--- a/vm/smx-v1-image.h
+++ b/vm/smx-v1-image.h
@@ -1,5 +1,5 @@
 // vim: set sts=2 ts=8 sw=2 tw=99 et:
-// 
+//
 // Copyright (C) 2004-2015 AlliedModers LLC
 //
 // This file is part of SourcePawn. SourcePawn is licensed under the GNU
@@ -169,6 +169,7 @@ class SmxV1Image
   bool validatePubvars();
   bool validateNatives();
   bool validateDebugInfo();
+  bool validateTags();
 
  private:
   template <typename SymbolType, typename DimType>
@@ -188,6 +189,7 @@ class SmxV1Image
   List<sp_file_publics_t> publics_;
   List<sp_file_natives_t> natives_;
   List<sp_file_pubvars_t> pubvars_;
+  List<sp_file_tag_t> tags_;
 
   const Section *debug_names_section_;
   const char *debug_names_;


### PR DESCRIPTION
This breaks a couple of increasingly-common binary modifications to deter Lysis.

I'm thinking we should also be more opinionated here and require *all* the sections we expect to exist, and start warning on load for v1.0 SMX versions (without any debug info) - with the aim to eventually kill those off as well.

Review: @dvander @KyleSanderson
CC: @GoD-Tony @peace-maker 