### PR TITLE
Fix compiler crash on inline arrays in conditions

### DIFF
--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -5926,8 +5926,10 @@ static int test(int label,int parens,int invert)
   if (endtok!=0)
     needtoken(endtok);
   if (ident==iARRAY || ident==iREFARRAY) {
-    const char *ptr=sym->name;
-    error(33,ptr);              /* array must be indexed */
+    if (sym)
+      error(33, sym->name); /* array must be indexed */
+    else
+      error(29);                /* invalid expression */
   } /* if */
   if (ident==iCONSTEXPR) {      /* constant expression */
     int testtype=0;


### PR DESCRIPTION
Code like:

`if ("") // blabla`
or
`if ({1,2}) // bla`

causes an "array must be indexed" error and crashes when it tries to
print the variable name of the array - because there is none for a
constant inline array.

This patch just prints nothing for the variable name.