### PR TITLE
Fix an unused arg warning.

### DIFF
--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -223,6 +223,7 @@ typedef struct s_symbol {
 #define uMISSING  0x080
 #define uFORWARD  0x100
 #define uSTRUCT	  0x200 /* :TODO: make this an ident */
+#define uCALLBACK 0x400 /* Used as a callback */
 /* uRETNONE is not stored in the "usage" field of a symbol. It is
  * used during parsing a function, to detect a mix of "return;" and
  * "return value;" in a few special cases.

--- a/compiler/sc2.cpp
+++ b/compiler/sc2.cpp
@@ -2938,7 +2938,7 @@ int refer_symbol(symbol *entry,symbol *bywhom)
 void markusage(symbol *sym,int usage)
 {
   assert(sym!=NULL);
-  sym->usage |= (char)usage;
+  sym->usage |= usage;
   if ((usage & uWRITTEN)!=0)
     sym->lnumber=fline;
   /* check if (global) reference must be added to the symbol */

--- a/compiler/sc3.cpp
+++ b/compiler/sc3.cpp
@@ -2360,6 +2360,7 @@ restart:
     }
 
     funcenum_t *fe = funcenum_for_symbol(sym);
+    markusage(sym, uCALLBACK);
 
     // Get address into pri.
     load_glbfn(sym);

--- a/compiler/tests/ok-no-warning-on-unused-param.sp
+++ b/compiler/tests/ok-no-warning-on-unused-param.sp
@@ -1,0 +1,14 @@
+// sp: -E
+typedef OnEggFn = function void(int a);
+
+native void Do(OnEggFn egg);
+
+public main()
+{
+  Do(Crab);
+}
+
+void Crab(int a)
+{
+}
+

--- a/compiler/tests/runtests.py
+++ b/compiler/tests/runtests.py
@@ -1,4 +1,5 @@
 # vim: set ts=4 sw=4 tw=99 et:
+import re
 import os, sys
 import argparse
 import subprocess
@@ -21,8 +22,17 @@ def run_tests(args):
         elif test.startswith('ok-'):
             kind = 'pass'
 
+        infile = os.path.join(testdir, test + '.sp')
+        with open(infile, 'r') as fp:
+            firstLine = fp.readline()
+        m = re.match("^// sp: (.*)$", firstLine)
+        if m is not None:
+            extra_args = m.group(1).split(' ')
+        else:
+            extra_args = []
+
         try:
-            argv = [os.path.abspath(args.spcomp), os.path.join(testdir, test + '.sp')]
+            argv = [os.path.abspath(args.spcomp), infile] + extra_args
             p = subprocess.Popen(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             stdout, stderr = p.communicate()
             stdout = stdout.decode('utf-8')

--- a/exp/compiler/pool-allocator.cpp
+++ b/exp/compiler/pool-allocator.cpp
@@ -123,7 +123,7 @@ PoolAllocationPolicy::reportAllocationOverflow()
 }
 
 void *
-PoolAllocationPolicy::malloc(size_t bytes)
+PoolAllocationPolicy::am_malloc(size_t bytes)
 {
   void *p = CurrentCompileContext->pool().rawAllocate(bytes);
   if (!p)
@@ -132,7 +132,7 @@ PoolAllocationPolicy::malloc(size_t bytes)
 }
 
 void
-PoolAllocationPolicy::free(void *ptr)
+PoolAllocationPolicy::am_free(void *ptr)
 {
 }
 

--- a/exp/compiler/pool-allocator.h
+++ b/exp/compiler/pool-allocator.h
@@ -163,8 +163,8 @@ class PoolAllocationPolicy
   void reportOutOfMemory();
 
  public:
-  void *malloc(size_t bytes);
-  void free(void *ptr);
+  void *am_malloc(size_t bytes);
+  void am_free(void *ptr);
 };
 
 template <typename T>


### PR DESCRIPTION
This is a quick, surgical fix: A new usage flag, uCALLBACK, which tells doarg to treat callback arguments as if the function were public.