### PR TITLE
Make casting a void function illegal, make returning a value from a void function illegal (bug 6492)

### DIFF
--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -6369,6 +6369,8 @@ static void doreturn(void)
   symbol *sym,*sub;
 
   if (!matchtoken(tTERM)) {
+    if (curfunc->tag == pc_tag_void)
+      error(88);
     /* "return <value>" */
     if ((rettype & uRETNONE)!=0)
       error(78);                        /* mix "return;" and "return value;" */

--- a/compiler/sc3.cpp
+++ b/compiler/sc3.cpp
@@ -1647,6 +1647,8 @@ static int hier2(value *lval)
     } else if ((tag & FUNCTAG) != (lval->tag & FUNCTAG)) {
       // Warn: unsupported cast.
       error(237);
+    } else if (lval->sym && lval->sym->tag == pc_tag_void) {
+      error(89);
     }
     lval->tag = tag;
     return lvalue;

--- a/compiler/sc5-in.scp
+++ b/compiler/sc5-in.scp
@@ -109,7 +109,7 @@ static const char *errmsg[] = {
 /*085*/  "unused85\n",
 /*086*/  "unused86\n",
 /*087*/  "unused87\n",
-/*088*/  "unused88\n",
+/*088*/  "cannot return a value from a void function\n",
 /*089*/  "casting a void function is illegal\n",
 /*090*/  "public functions may not return arrays (symbol \"%s\")\n",
 /*091*/  "ambiguous constant; tag override is required (symbol \"%s\")\n",

--- a/compiler/sc5-in.scp
+++ b/compiler/sc5-in.scp
@@ -110,7 +110,7 @@ static const char *errmsg[] = {
 /*086*/  "unused86\n",
 /*087*/  "unused87\n",
 /*088*/  "unused88\n",
-/*089*/  "unused89\n",
+/*089*/  "casting a void function is illegal\n",
 /*090*/  "public functions may not return arrays (symbol \"%s\")\n",
 /*091*/  "ambiguous constant; tag override is required (symbol \"%s\")\n",
 /*092*/  "number of arguments does not match definition\n",


### PR DESCRIPTION
Not sure if this is all that's necessary.