### PR TITLE
Allow forward declarations of methodmaps.

### DIFF
--- a/compiler/sc2.cpp
+++ b/compiler/sc2.cpp
@@ -2879,7 +2879,7 @@ void delete_symbols(symbol *root,int level,int delete_labels,int delete_function
        */
       if (sym->ident==iFUNCTN && (sym->usage & uDEFINE)==0)
         sym->usage |= uMISSING;
-      if (sym->ident==iFUNCTN || sym->ident==iVARIABLE || sym->ident==iARRAY)
+      if (sym->ident==iFUNCTN || sym->ident==iVARIABLE || sym->ident==iARRAY || sym->ident==iMETHODMAP)
         sym->usage &= ~uDEFINE; /* clear "defined" flag */
       /* for user defined operators, also remove the "prototyped" flag, as
        * user-defined operators *must* be declared before use

--- a/compiler/tests/ok-methodmap-forward-decl-no-semis.sp
+++ b/compiler/tests/ok-methodmap-forward-decl-no-semis.sp
@@ -1,0 +1,20 @@
+methodmap MM1
+methodmap MM2
+
+methodmap MM1
+{
+	public MM1()
+	{
+		return view_as<MM2>(1)
+	}
+}
+
+methodmap MM2
+{
+	public MM2()
+	{
+		return view_as<MM1>(2)
+	}
+}
+
+public void main() {}

--- a/compiler/tests/ok-methodmap-forward-decl.sp
+++ b/compiler/tests/ok-methodmap-forward-decl.sp
@@ -1,0 +1,22 @@
+#pragma semicolon 1
+
+methodmap MM1;
+methodmap MM2;
+
+methodmap MM1
+{
+	public MM1()
+	{
+		return view_as<MM2>(1);
+	}
+};
+
+methodmap MM2
+{
+	public MM2()
+	{
+		return view_as<MM1>(2);
+	}
+};
+
+public void main() {}


### PR DESCRIPTION
This involved a huge amount of flailing around.

You can forward declare a methodmap with just the following:

`methodmap <identifier>;`

If a symbol has `ident` `iMETHODMAP` and `usage` doesn't have `uDEFINE` set, it is considered to be forward declared.  Parsing is a little wonky (https://github.com/alliedmodders/sourcepawn/pull/65/commits/56cea7bf223b6daf8f4df51ff5cd3f15f3afa69f#diff-eac7f772819ea504cece6ddb406c66b3R3658) because if semicolons are not required we have to tell the difference between just `methodmap Foo\n` as a forward declaration and `methodmap Foo\n{` as a definition.

It does compile all of SM's base plugins.  I'll poke it some more to see if I find problems and I'll add a test later.
