### PR TITLE
Fix stack alignment issues on error paths.

### DIFF
--- a/vm/jit.cpp
+++ b/vm/jit.cpp
@@ -198,6 +198,7 @@ CompilerBase::emitErrorPath(ErrorPath* path)
 
   // If there's no error code, it should be in eax. Otherwise we'll jump to
   // a path that sets eax to a hardcoded value.
+  __ alignStack();
   if (path->err == 0)
     __ call(&report_error_);
   else

--- a/vm/x86/assembler-x86.h
+++ b/vm/x86/assembler-x86.h
@@ -540,6 +540,13 @@ class Assembler : public AssemblerBase
   void testl(Register op1, Register op2) {
     emit1(0x85, op2.code, op1.code);
   }
+  void testl(Register op1, int32_t imm) {
+    if (op1 == eax)
+      emit1(0xa9);
+    else
+      emit1(0xf7, 0, op1.code);
+    writeInt32(imm);
+  }
   void set(ConditionCode cc, const Operand &dest) {
     emit2(0x0f, 0x90 + uint8_t(cc), 0, dest);
   }
@@ -776,7 +783,7 @@ class Assembler : public AssemblerBase
   void call(const Operand &target) {
     emit1(0xff, 2, target);
   }
-  void call(ExternalAddress address) {
+  void call(const AddressValue& address) {
     emit1(0xe8);
     writeInt32(address.value());
     if (!external_refs_.append(pc()))

--- a/vm/x86/macro-assembler-x86.h
+++ b/vm/x86/macro-assembler-x86.h
@@ -66,6 +66,25 @@ class MacroAssembler : public Assembler
     push(return_address);
     enterExitFrame(type, payload);
   }
+
+  void alignStack() {
+    andl(esp, 0xfffffff0);
+  }
+  void assertStackAligned() {
+#if defined(DEBUG)
+    Label ok;
+    testl(esp, 0xf);
+    j(equal, &ok);
+    breakpoint();
+    bind(&ok);
+#endif
+  }
+
+  template <typename T>
+  void callWithABI(const T& target) {
+    assertStackAligned();
+    call(target);
+  }
 };
 
 } // namespace sp


### PR DESCRIPTION
When we take an error path, we don't guarantee that the stack is 16-byte aligned. Normally this isn't an issue, but CompileFromThunk leaves an extra word on the stack (it floats a return address), and if it reports an error, the formatting routine can crash if it hits a MOVAPS or something else that relies on ABI alignment.

This patch forces the stack to be aligned on error paths. Since we don't really care about the exact stack contents (just the ability to walk frames), it shouldn't be a problem. I also added a debug-only trap that will fire if the stack is unaligned before a call.