### PR TITLE
Add out-of-line codepath abstraction

### DIFF
--- a/vm/AMBuilder
+++ b/vm/AMBuilder
@@ -48,6 +48,7 @@ library.sources += [
   'watchdog_timer.cpp',
   'jit.cpp',
   'linking.cpp',
+  'pool-allocator.cpp',
 ]
 
 if builder.options.arch == 'x86':

--- a/vm/compiled-function.cpp
+++ b/vm/compiled-function.cpp
@@ -13,9 +13,6 @@
 #include "compiled-function.h"
 #include "environment.h"
 #include <amtl/am-platform.h>
-#if defined(KE_ARCH_X86)
-# include "x86/jit_x86.h"
-#endif
 
 using namespace sp;
 
@@ -32,22 +29,6 @@ CompiledFunction::CompiledFunction(const CodeChunk& code,
 
 CompiledFunction::~CompiledFunction()
 {
-}
-
-CompiledFunction *
-CompiledFunction::Compile(PluginRuntime *prt, cell_t pcode_offs, int *err)
-{
-  Compiler cc(prt, pcode_offs);
-  CompiledFunction *fun = cc.emit(err);
-  if (!fun)
-    return nullptr;
-
-  // Grab the lock before linking code in, since the watchdog timer will look
-  // at this list on another thread.
-  ke::AutoLock lock(Environment::get()->lock());
-
-  prt->AddJittedFunction(fun);
-  return fun;
 }
 
 static int cip_map_entry_cmp(const void *a1, const void *aEntry)

--- a/vm/compiled-function.h
+++ b/vm/compiled-function.h
@@ -52,8 +52,6 @@ class CompiledFunction
                    FixedArray<CipMapEntry> *cip_map);
   ~CompiledFunction();
 
-  static CompiledFunction* Compile(PluginRuntime* prt, cell_t pcode_offs, int* err);
-
  public:
   void *GetEntryAddress() const {
     return code_.address();

--- a/vm/environment.cpp
+++ b/vm/environment.cpp
@@ -16,6 +16,7 @@
 #include "code-stubs.h"
 #include "watchdog_timer.h"
 #include "plugin-context.h"
+#include "pool-allocator.h"
 #include <stdarg.h>
 
 using namespace sp;
@@ -64,6 +65,7 @@ Environment::get()
 bool
 Environment::Initialize()
 {
+  PoolAllocator::InitDefault();
   api_v1_ = new SourcePawnEngine();
   api_v2_ = new SourcePawnEngine2();
   code_stubs_ = new CodeStubs(this);
@@ -83,6 +85,7 @@ Environment::Shutdown()
   watchdog_timer_->Shutdown();
   code_stubs_ = nullptr;
   code_alloc_ = nullptr;
+  PoolAllocator::FreeDefault();
 
   assert(sEnvironment == this);
   sEnvironment = nullptr;

--- a/vm/outofline-asm.h
+++ b/vm/outofline-asm.h
@@ -1,0 +1,47 @@
+// vim: set ts=8 sts=2 sw=2 tw=99 et:
+//
+// This file is part of SourcePawn.
+// 
+// SourcePawn is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// SourcePawn is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with SourcePawn.  If not, see <http://www.gnu.org/licenses/>.
+#ifndef _include_sourcepawn_outofline_asm_h__
+#define _include_sourcepawn_outofline_asm_h__
+
+#include <assert.h>
+#include "pool-allocator.h"
+
+namespace sp {
+
+class Compiler;
+
+class OutOfLinePath : public PoolObject
+{
+public:
+  virtual ~OutOfLinePath() {
+    // Pool objects are not destructed.
+    assert(false);
+  }
+
+  virtual bool emit(Compiler* cc) = 0;
+
+  Label* label() {
+    return &label_;
+  }
+
+private:
+  Label label_;
+};
+
+} // namespace sp
+
+#endif // _include_sourcepawn_outofline_asm_h__

--- a/vm/plugin-context.cpp
+++ b/vm/plugin-context.cpp
@@ -19,6 +19,7 @@
 #include "watchdog_timer.h"
 #include "environment.h"
 #include "compiled-function.h"
+#include "jit.h"
 
 using namespace sp;
 using namespace SourcePawn;
@@ -443,7 +444,7 @@ PluginContext::Invoke(funcid_t fnid, const cell_t *params, unsigned int num_para
       fn = m_pRuntime->GetJittedFunctionByOffset(cfun->Public()->code_offs);
       if (!fn) {
         int err = SP_ERROR_NONE;
-        if ((fn = CompiledFunction::Compile(m_pRuntime, cfun->Public()->code_offs, &err)) == NULL) {
+        if ((fn = CompilerBase::Compile(m_pRuntime, cfun->Public()->code_offs, &err)) == NULL) {
           ReportErrorNumber(err);
           return false;
         }

--- a/vm/pool-allocator.cpp
+++ b/vm/pool-allocator.cpp
@@ -1,0 +1,186 @@
+/* vim: set ts=2 sw=2 tw=99 et:
+ *
+ * Copyright (C) 2012-2013 David Anderson
+ *
+ * This file is part of SourcePawn.
+ *
+ * SourcePawn is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ * 
+ * SourcePawn is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * SourcePawn. If not, see http://www.gnu.org/licenses/.
+ */
+#include <assert.h>
+#include <stdlib.h>
+#include <new>
+#include <amtl/am-threadlocal.h>
+#include "pool-allocator.h"
+
+using namespace ke;
+using namespace sp;
+
+ThreadLocal<PoolAllocator*> sAllocatorTLS;
+
+PoolAllocator::PoolAllocator()
+ : reserved_(nullptr),
+   last_(nullptr),
+   scope_depth_(0)
+{
+}
+
+PoolAllocator::~PoolAllocator()
+{
+  assert(!scope_depth_);
+
+  unwind(nullptr);
+  if (reserved_)
+    free(reserved_);
+}
+
+void
+PoolAllocator::InitDefault()
+{
+  assert(!sAllocatorTLS);
+  sAllocatorTLS.set(new PoolAllocator());
+}
+
+PoolAllocator&
+PoolAllocator::DefaultForThread()
+{
+  assert(sAllocatorTLS.get());
+  return *sAllocatorTLS.get();
+}
+
+void
+PoolAllocator::FreeDefault()
+{
+  if (!sAllocatorTLS)
+    return;
+  delete sAllocatorTLS.get();
+  sAllocatorTLS = nullptr;
+}
+
+char *
+PoolAllocator::enter()
+{
+  scope_depth_++;
+  if (!last_)
+    return nullptr;
+  return last_->ptr;
+}
+
+void
+PoolAllocator::leave(char *pos)
+{
+  assert(scope_depth_);
+  unwind(pos);
+  scope_depth_--;
+}
+
+void
+PoolAllocator::unwind(char *pos)
+{
+  while (last_) {
+    if (pos && pos >= last_->base && pos < last_->end)
+      break;
+    Pool *prev = last_->prev;
+    {
+      if (last_->size() <= kMaxReserveSize &&
+        (!reserved_ || reserved_->size() < last_->size()))
+      {
+        if (reserved_)
+          free(reserved_);
+        reserved_ = last_;
+      } else {
+        free(last_);
+      }
+    }
+    last_ = prev;
+  }
+
+  if (!last_) {
+    assert(!pos);
+    return;
+  }
+
+  last_->ptr = pos;
+}
+
+void *
+PoolAllocator::slowAllocate(size_t actualBytes)
+{
+  size_t bytesNeeded = actualBytes + sizeof(Pool);
+  if (bytesNeeded < kDefaultPoolSize)
+    bytesNeeded = kDefaultPoolSize;
+
+  Pool *pool;
+  if (reserved_ && reserved_->size() >= bytesNeeded) {
+    pool = reserved_;
+    reserved_ = nullptr;
+  } else {
+    pool = (Pool *)malloc(bytesNeeded);
+    if (!pool) {
+      fprintf(stderr, "OUT OF POOL MEMORY\n");
+      abort();
+      return nullptr;
+    }
+    pool->base = (char *)(pool + 1);
+    pool->end = (char *)pool + bytesNeeded;
+  }
+  pool->ptr = pool->base + actualBytes;
+  pool->prev = last_;
+  last_ = pool;
+  return pool->base;
+}
+
+PoolScope::PoolScope()
+ : pool_(PoolAllocator::DefaultForThread()),
+   position_(pool_.enter())
+{
+}
+
+PoolScope::PoolScope(PoolAllocator& allocator)
+ : pool_(allocator),
+   position_(pool_.enter())
+{
+}
+
+PoolScope::~PoolScope()
+{
+  pool_.leave(position_);
+}
+
+void
+PoolAllocationPolicy::reportOutOfMemory()
+{
+  fprintf(stderr, "OUT OF POOL MEMORY\n");
+  abort();
+}
+
+void
+PoolAllocationPolicy::reportAllocationOverflow()
+{
+  fprintf(stderr, "OUT OF POOL MEMORY\n");
+  abort();
+}
+
+void *
+PoolAllocationPolicy::am_malloc(size_t bytes)
+{
+  void *p = sAllocatorTLS.get()->rawAllocate(bytes);
+  if (!p)
+    reportOutOfMemory();
+  return p;
+}
+
+void
+PoolAllocationPolicy::am_free(void *ptr)
+{
+}
+

--- a/vm/pool-allocator.h
+++ b/vm/pool-allocator.h
@@ -1,0 +1,181 @@
+// vim: set sts=2 ts=8 sw=2 tw=99 et:
+//
+// Copyright (C) 2012-2014 David Anderson
+//
+// This file is part of SourcePawn.
+//
+// SourcePawn is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+// 
+// SourcePawn is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// SourcePawn. If not, see http://www.gnu.org/licenses/.
+#ifndef _include_jitcraft_pool_allocator_h_
+#define _include_jitcraft_pool_allocator_h_
+
+#include <new>
+#include <stddef.h>
+#include <stdio.h>
+#include <limits.h>
+#include <am-vector.h>
+#include <am-fixedarray.h>
+
+namespace sp {
+
+using namespace ke;
+
+// Allocates memory in chunks that are not freed until the entire allocator
+// is freed. This is intended for use with large, temporary data structures.
+class PoolAllocator
+{
+  struct Pool {
+    char *base;
+    char *ptr;
+    char *end;
+    Pool *prev;
+
+    size_t size() const {
+      return size_t(end - base);
+    }
+  };
+
+  static const size_t kDefaultPoolSize = 8 * 1024;
+  static const size_t kMaxReserveSize = 64 * 1024;
+
+ private:
+  Pool *reserved_;
+  Pool *last_;
+  size_t scope_depth_;
+
+ private:
+  void unwind(char *pos);
+  void *slowAllocate(size_t actualBytes);
+
+ public:
+  PoolAllocator();
+  ~PoolAllocator();
+
+  static void InitDefault();
+  static PoolAllocator& DefaultForThread();
+  static void FreeDefault();
+
+  void memoryUsage(size_t *allocated, size_t *reserved, size_t *bookkeeping) const {
+    *allocated = 0;
+    *reserved = 0;
+    *bookkeeping = 0;
+    for (Pool *cursor = last_; cursor; cursor = cursor->prev) {
+      *allocated += size_t(cursor->ptr - cursor->base);
+      *reserved += size_t(cursor->end - cursor->base);
+      *bookkeeping += sizeof(Pool);
+    }
+    if (reserved_) {
+      *reserved += size_t(reserved_->end - reserved_->base);
+      *bookkeeping += sizeof(Pool);
+    }
+  }
+
+  void *rawAllocate(size_t bytes) {
+    // Guarantee malloc alignment.
+    size_t actualBytes = Align(bytes, kMallocAlignment);
+    if (!last_ || (size_t(last_->end - last_->ptr) < actualBytes))
+      return slowAllocate(actualBytes);
+    char *ptr = last_->ptr;
+    last_->ptr += actualBytes;
+    return ptr;
+  }
+
+  template <typename T>
+  T *alloc(size_t count = 1) {
+    if (!IsUintPtrMultiplySafe(count, sizeof(T))) {
+      fprintf(stderr, "allocation overflow\n");
+      return nullptr;
+    }
+    void *ptr = rawAllocate(count * sizeof(T));
+    if (!ptr)
+      return nullptr;
+
+    return reinterpret_cast<T *>(ptr);
+  }
+
+  char *enter();
+  void leave(char *position);
+};
+
+class PoolScope
+{
+ public:
+  PoolScope();
+  PoolScope(PoolAllocator& allocator);
+  ~PoolScope();
+
+ private:
+  PoolScope(const PoolScope &other) = delete;
+  PoolScope &operator =(const PoolScope &other) = delete;
+
+ private:
+  PoolAllocator& pool_;
+  char* position_;
+};
+
+class PoolObject
+{
+ public:
+  void *operator new(size_t size, PoolAllocator &pool) {
+    return pool.rawAllocate(size);
+  }
+  void *operator new [](size_t size, PoolAllocator &pool) {
+    return pool.rawAllocate(size);
+  }
+  
+  // Using delete on pool-allocated objects is illegal.
+  void operator delete(void *ptr, PoolAllocator &pool) {
+    assert(false);
+  }
+  void operator delete [](void *ptr, PoolAllocator &pool) {
+    assert(false);
+  }
+};
+
+class PoolAllocationPolicy
+{
+ protected:
+  void reportAllocationOverflow();
+  void reportOutOfMemory();
+
+ public:
+  void *am_malloc(size_t bytes);
+  void am_free(void *ptr);
+};
+
+template <typename T>
+class PoolList
+ : public Vector<T, PoolAllocationPolicy>,
+   public PoolObject
+{
+ public:
+  PoolList()
+    : Vector<T, PoolAllocationPolicy>(PoolAllocationPolicy())
+  {
+  }
+};
+
+template <typename T>
+class FixedPoolList
+ : public FixedArray<T, PoolAllocationPolicy>,
+   public PoolObject
+{
+ public:
+  FixedPoolList(size_t length)
+    : FixedArray<T, PoolAllocationPolicy>(length, PoolAllocationPolicy())
+  {
+  }
+};
+
+} // namespace ke
+
+#endif // _include_jitcraft_pool_allocator_h_

--- a/vm/pool-allocator.h
+++ b/vm/pool-allocator.h
@@ -125,6 +125,12 @@ class PoolScope
 class PoolObject
 {
  public:
+  void *operator new(size_t size) {
+    return PoolAllocator::DefaultForThread().rawAllocate(size);
+  }
+  void *operator new [](size_t size) {
+    return PoolAllocator::DefaultForThread().rawAllocate(size);
+  }
   void *operator new(size_t size, PoolAllocator &pool) {
     return pool.rawAllocate(size);
   }
@@ -133,6 +139,12 @@ class PoolObject
   }
   
   // Using delete on pool-allocated objects is illegal.
+  void operator delete(void *ptr) {
+    assert(false);
+  }
+  void operator delete [](void *ptr) {
+    assert(false);
+  }
   void operator delete(void *ptr, PoolAllocator &pool) {
     assert(false);
   }

--- a/vm/x86/jit_x86.cpp
+++ b/vm/x86/jit_x86.cpp
@@ -1533,13 +1533,11 @@ void
 Compiler::jumpOnError(ConditionCode cc, int err)
 {
   // Note: we accept 0 for err. In this case we expect the error to be in eax.
-  {
-    ErrorPath path(op_cip_, err);
-    error_paths_.append(path);
-  }
+  // :TODO: handle OOM.
+  ErrorPath* path = new ErrorPath(op_cip_, err);
+  ool_paths_.append(path);
 
-  ErrorPath &path = error_paths_.back();
-  __ j(cc, &path.label);
+  __ j(cc, path->label());
 }
 
 void

--- a/vm/x86/jit_x86.h
+++ b/vm/x86/jit_x86.h
@@ -59,7 +59,6 @@ class Compiler : public CompilerBase
   bool emitSwitch();
   void emitGenArray(bool autozero);
   void emitCheckAddress(Register reg);
-  void emitErrorPath(Label *dest, int code);
   void emitFloatCmp(ConditionCode cc);
   void emitCallThunk(CallThunk* thunk);
   void jumpOnError(ConditionCode cc, int err = 0);

--- a/vm/x86/jit_x86.h
+++ b/vm/x86/jit_x86.h
@@ -33,20 +33,12 @@ namespace sp {
 class LegacyImage;
 class Environment;
 class CompiledFunction;
-
-struct CallThunk
-{
-  SilentLabel call;
-  cell_t pcode_offset;
-
-  CallThunk(cell_t pcode_offset)
-    : pcode_offset(pcode_offset)
-  {
-  }
-};
+class CallThunk;
 
 class Compiler : public CompilerBase
 {
+  friend class CallThunk;
+
  public:
   Compiler(PluginRuntime *rt, cell_t pcode_offs);
   ~Compiler();
@@ -56,7 +48,6 @@ class Compiler : public CompilerBase
   bool emitOp(sp::OPCODE op) override;
 
  private:
-  void emitCallThunks() override;
   void emitThrowPath(int err) override;
   void emitErrorHandlers() override;
 
@@ -70,6 +61,7 @@ class Compiler : public CompilerBase
   void emitCheckAddress(Register reg);
   void emitErrorPath(Label *dest, int code);
   void emitFloatCmp(ConditionCode cc);
+  void emitCallThunk(CallThunk* thunk);
   void jumpOnError(ConditionCode cc, int err = 0);
 
   ExternalAddress hpAddr() {
@@ -81,9 +73,6 @@ class Compiler : public CompilerBase
   ExternalAddress spAddr() {
     return ExternalAddress(context_->addressOfSp());
   }
-
- private:
-  ke::Vector<CallThunk> call_thunks_;
 };
 
 const Register pri = eax;


### PR DESCRIPTION
This is a quick and dirty abstraction to replace the manual CallThunk/ErrorPath machinery that does delayed codegen in the JIT. This will make it much easier to add more custom error messaging, for example, recording BOUNDS instructions without yet another one-off vector of specialized structs.