### PR TITLE
Factor JIT-specific information out of methods and frames.

### DIFF
--- a/vm/AMBuilder
+++ b/vm/AMBuilder
@@ -34,7 +34,6 @@ library.sources += [
   'api.cpp',
   'base-context.cpp',
   'code-allocator.cpp',
-  'code-stubs.cpp',
   'compiled-function.cpp',
   'environment.cpp',
   'file-utils.cpp',
@@ -46,12 +45,18 @@ library.sources += [
   'stack-frames.cpp',
   'smx-v1-image.cpp',
   'watchdog_timer.cpp',
-  'jit.cpp',
-  'linking.cpp',
   'pool-allocator.cpp',
   'method-verifier.cpp',
   'method-info.cpp',
 ]
+
+if SP.arch in ['x86']:
+  library.sources += [
+    'code-stubs.cpp',
+    'jit.cpp',
+    'linking.cpp',
+  ]
+  library.compiler.defines += ['SP_HAS_JIT']
 
 if SP.arch == 'x86':
   library.sources += [

--- a/vm/AMBuilder
+++ b/vm/AMBuilder
@@ -50,6 +50,7 @@ library.sources += [
   'linking.cpp',
   'pool-allocator.cpp',
   'method-verifier.cpp',
+  'method-info.cpp',
 ]
 
 if SP.arch == 'x86':

--- a/vm/api.cpp
+++ b/vm/api.cpp
@@ -284,7 +284,11 @@ SourcePawnEngine2::LoadBinaryFromFile(const char *file, char *error, size_t maxl
 SPVM_NATIVE_FUNC
 SourcePawnEngine2::CreateFakeNative(SPVM_FAKENATIVE_FUNC callback, void *pData)
 {
+#if defined(SP_HAS_JIT)
   return Environment::get()->stubs()->CreateFakeNativeStub(callback, pData);
+#else
+  return nullptr;
+#endif
 }
 
 void

--- a/vm/environment.h
+++ b/vm/environment.h
@@ -72,9 +72,12 @@ class Environment : public ISourcePawnEnvironment
 
   // Allocate and free executable memory.
   CodeChunk AllocateCode(size_t size);
+
+#if defined(SP_HAS_JIT)
   CodeStubs *stubs() {
     return code_stubs_;
   }
+#endif
 
   // Runtime management.
   void RegisterRuntime(PluginRuntime *rt);
@@ -99,8 +102,7 @@ class Environment : public ISourcePawnEnvironment
   void EnableProfiling();
   void DisableProfiling();
 
-  void SetJitEnabled(bool enabled) {
-  }
+  void SetJitEnabled(bool enabled);
   bool IsJitEnabled() const {
     return jit_enabled_;
   }
@@ -178,11 +180,13 @@ class Environment : public ISourcePawnEnvironment
   bool profiling_enabled_;
 
   ke::AutoPtr<CodeAllocator> code_alloc_;
+#if defined(SP_HAS_JIT)
+  ke::AutoPtr<CodeStubs> code_stubs_;
+#endif
+
   ke::InlineList<PluginRuntime> runtimes_;
 
   uintptr_t frame_id_;
-
-  ke::AutoPtr<CodeStubs> code_stubs_;
 
   InvokeFrame *top_;
   intptr_t* exit_fp_;

--- a/vm/environment.h
+++ b/vm/environment.h
@@ -87,7 +87,8 @@ class Environment : public ISourcePawnEnvironment
   ke::Mutex *lock() {
     return &mutex_;
   }
-  int Invoke(PluginRuntime *runtime, CompiledFunction *fn, cell_t *result);
+
+  int Invoke(PluginContext* cx, CompiledFunction* fn, cell_t* result);
 
   // Helpers.
   void SetProfiler(IProfilingTool *profiler) {
@@ -128,15 +129,10 @@ class Environment : public ISourcePawnEnvironment
   bool RunningCode() const {
     return !!top_;
   }
-  void enterInvoke(InvokeFrame *frame) {
-    if (!top_)
-      frame_id_++;
-    top_ = frame;
-  }
-  void leaveInvoke() {
-    exit_fp_ = top_->prev_exit_fp();
-    top_ = top_->prev();
-  }
+
+  void enterInvoke(InvokeFrame *frame);
+  void leaveJitInvoke(JitInvokeFrame* frame);
+  void leaveInvoke();
 
   InvokeFrame *top() const {
     return top_;

--- a/vm/jit.cpp
+++ b/vm/jit.cpp
@@ -269,10 +269,12 @@ void*
 CompilerBase::find_entry_fp()
 {
   void *fp = nullptr;
-  for (FrameIterator iter; !iter.Done(); iter.Next()) {
-    if (iter.IsEntryFrame())
+
+  for (JitFrameIterator iter(Environment::get()); !iter.done(); iter.next()) {
+    FrameLayout* frame = iter.frame();
+    if (frame->frame_type == JitFrameType::Entry)
       break;
-    fp = iter.Frame()->prev_fp;
+    fp = frame->prev_fp;
   }
 
   assert(fp);

--- a/vm/jit.h
+++ b/vm/jit.h
@@ -25,6 +25,7 @@
 #include "pool-allocator.h"
 #include "outofline-asm.h"
 #include "pcode-visitor.h"
+#include "compiled-function.h"
 
 namespace sp {
 

--- a/vm/method-info.cpp
+++ b/vm/method-info.cpp
@@ -1,0 +1,53 @@
+// vim: set sts=2 ts=8 sw=2 tw=99 et:
+// 
+// Copyright (C) 2006-2015 AlliedModders LLC
+// 
+// This file is part of SourcePawn. SourcePawn is free software: you can
+// redistribute it and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License along with
+// SourcePawn. If not, see http://www.gnu.org/licenses/.
+//
+#include "environment.h"
+#include "compiled-function.h"
+#include "method-info.h"
+#include "method-verifier.h"
+
+namespace sp {
+
+MethodInfo::MethodInfo(PluginRuntime* rt, uint32_t codeOffset)
+ : rt_(rt),
+   pcode_offset_(codeOffset),
+   checked_(false),
+   validation_error_(SP_ERROR_NONE)
+{
+}
+
+MethodInfo::~MethodInfo()
+{
+}
+
+void
+MethodInfo::setCompiledFunction(CompiledFunction* fun)
+{
+  assert(!jit_);
+
+  // Grab the lock before linking code in, since the watchdog timer will look
+  // at this on another thread.
+  ke::AutoLock lock(Environment::get()->lock());
+  jit_ = fun;
+}
+
+void
+MethodInfo::InternalValidate()
+{
+  MethodVerifier verifier(rt_, pcode_offset_);
+  if (!verifier.verify())
+    validation_error_ = verifier.error();
+
+  checked_ = true;
+}
+
+} // namespace sp

--- a/vm/method-info.h
+++ b/vm/method-info.h
@@ -1,0 +1,57 @@
+// vim: set sts=2 ts=8 sw=2 tw=99 et:
+// 
+// Copyright (C) 2006-2015 AlliedModders LLC
+// 
+// This file is part of SourcePawn. SourcePawn is free software: you can
+// redistribute it and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License along with
+// SourcePawn. If not, see http://www.gnu.org/licenses/.
+//
+#ifndef _INCLUDE_SOURCEPAWN_VM_METHOD_INFO_H_
+#define _INCLUDE_SOURCEPAWN_VM_METHOD_INFO_H_
+
+#include <sp_vm_types.h>
+#include <amtl/am-refcounting.h>
+#include <amtl/am-utility.h>
+
+namespace sp {
+
+class PluginRuntime;
+class CompiledFunction;
+
+class MethodInfo final : public ke::Refcounted<MethodInfo>
+{
+ public:
+  MethodInfo(PluginRuntime* rt, uint32_t codeOffset);
+  ~MethodInfo();
+
+  int Validate() {
+    if (!checked_)
+      InternalValidate();
+    return validation_error_;
+  }
+
+  void setCompiledFunction(CompiledFunction* fun);
+
+  CompiledFunction* jit() const {
+    return jit_;
+  }
+
+ private:
+  void InternalValidate();
+
+ private:
+  PluginRuntime* rt_;
+  uint32_t pcode_offset_;
+  ke::AutoPtr<CompiledFunction> jit_;
+
+  bool checked_;
+  int validation_error_;
+};
+
+} // namespace sp
+
+#endif //_INCLUDE_SOURCEPAWN_VM_METHOD_INFO_H_

--- a/vm/null-frame-layout.h
+++ b/vm/null-frame-layout.h
@@ -1,0 +1,55 @@
+// vim: set ts=8 sts=2 sw=2 tw=99 et:
+//
+// This file is part of SourcePawn.
+// 
+// SourcePawn is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// SourcePawn is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with SourcePawn.  If not, see <http://www.gnu.org/licenses/>.
+#ifndef _include_sourcepawn_jit_null_frames_h_
+#define _include_sourcepawn_jit_null_frames_h_
+
+#include <sp_vm_types.h>
+#include <amtl/am-platform.h>
+#if defined(SP_HAS_JIT)
+# error "Wrong architecture!"
+#endif
+
+namespace sp {
+
+using namespace SourcePawn;
+
+// We create x86 stack frames like:
+//   [return address]
+//   [prev_ebp]
+//       ^--- ebp is captured here.
+//   [frame_type]
+//   [function_id]
+//
+struct FrameLayout
+{
+  intptr_t function_id;
+  intptr_t frame_type;
+  intptr_t* prev_fp;
+  void* return_address;
+
+  // This is -offsetof(FrameLayout, prev_ebp).
+  static const intptr_t kOffsetFromFp = 0;
+
+  static inline FrameLayout* FromFp(intptr_t *fp) {
+    return nullptr;
+  }
+};
+
+} // namespace sp
+
+#endif // _include_sourcepawn_jit_null_frames_h_
+

--- a/vm/plugin-context.cpp
+++ b/vm/plugin-context.cpp
@@ -20,7 +20,9 @@
 #include "environment.h"
 #include "compiled-function.h"
 #include "method-info.h"
-#include "jit.h"
+#if defined(SP_HAS_JIT)
+# include "jit.h"
+#endif
 
 using namespace sp;
 using namespace SourcePawn;
@@ -446,6 +448,7 @@ PluginContext::Invoke(funcid_t fnid, const cell_t *params, unsigned int num_para
 
   CompiledFunction *fn = nullptr;
   if (env_->IsJitEnabled()) {
+#if defined(SP_HAS_JIT)
     /* We might not have to - check pcode offset. */
     if ((fn = method->jit()) == nullptr) {
       int err = SP_ERROR_NONE;
@@ -454,6 +457,7 @@ PluginContext::Invoke(funcid_t fnid, const cell_t *params, unsigned int num_para
         return false;
       }
     }
+#endif
   } else {
     ReportError("JIT is not enabled!");
     return false;

--- a/vm/plugin-context.cpp
+++ b/vm/plugin-context.cpp
@@ -476,12 +476,7 @@ PluginContext::Invoke(funcid_t fnid, const cell_t *params, unsigned int num_para
     sp[i + 1] = params[i];
 
   // Enter the execution engine.
-  int ir;
-  {
-    InvokeFrame ivkframe(this, fn->GetCodeOffset()); 
-    Environment *env = env_;
-    ir = env->Invoke(m_pRuntime, fn, result);
-  }
+  int ir = env_->Invoke(this, fn, result);
 
   if (ir == SP_ERROR_NONE) {
     // Verify that our state is still sane.

--- a/vm/scripted-invoker.cpp
+++ b/vm/scripted-invoker.cpp
@@ -17,6 +17,7 @@
 #include "plugin-runtime.h"
 #include "environment.h"
 #include "plugin-context.h"
+#include "method-info.h"
 
 /********************
 * FUNCTION CALLING *
@@ -30,8 +31,7 @@ ScriptedInvoker::ScriptedInvoker(PluginRuntime *runtime, funcid_t id, uint32_t p
    context_(runtime->GetBaseContext()),
    m_curparam(0),
    m_errorstate(SP_ERROR_NONE),
-   m_FnId(id),
-   cc_function_(nullptr)
+   m_FnId(id)
 {
   runtime->GetPublicByIndex(pub_id, &public_);
 
@@ -352,3 +352,10 @@ ScriptedInvoker::SetError(int err)
   return err;
 }
 
+RefPtr<MethodInfo>
+ScriptedInvoker::AcquireMethod()
+{
+  if (!method_)
+    method_ = context_->runtime()->AcquireMethod(public_->code_offs);
+  return method_;
+}

--- a/vm/scripted-invoker.h
+++ b/vm/scripted-invoker.h
@@ -15,14 +15,17 @@
 
 #include <sp_vm_api.h>
 #include <am-utility.h>
+#include <amtl/am-refcounting.h>
 
 namespace sp {
 
+using namespace ke;
 using namespace SourcePawn;
 
 class PluginRuntime;
 class PluginContext;
 class CompiledFunction;
+class MethodInfo;
 
 struct ParamInfo
 {
@@ -74,12 +77,8 @@ class ScriptedInvoker : public IPluginFunction
     return public_;
   }
 
-  CompiledFunction *cachedCompiledFunction() const {
-    return cc_function_;
-  }
-  void setCachedCompiledFunction(CompiledFunction *fn) {
-    cc_function_ = fn;
-  }
+  // Helper for pRuntime->AcquireMethod that caches the result.
+  RefPtr<MethodInfo> AcquireMethod();
 
  private:
   int _PushString(const char *string, int sz_flags, int cp_flags, size_t len);
@@ -95,7 +94,7 @@ class ScriptedInvoker : public IPluginFunction
   funcid_t m_FnId;
   ke::AutoArray<char> full_name_;
   sp_public_t *public_;
-  CompiledFunction *cc_function_;
+  RefPtr<MethodInfo> method_;
 };
 
 } // namespace sp

--- a/vm/stack-frames.cpp
+++ b/vm/stack-frames.cpp
@@ -16,6 +16,7 @@
 #include "stack-frames.h"
 #include "x86/frames-x86.h"
 #include "compiled-function.h"
+#include "method-info.h"
 
 using namespace ke;
 using namespace sp;
@@ -96,7 +97,11 @@ FrameIterator::function_cip() const
 cell_t
 FrameIterator::findCip() const
 {
-  CompiledFunction *fn = runtime_->GetJittedFunctionByOffset(function_cip());
+  RefPtr<MethodInfo> method = runtime_->GetMethod(function_cip());
+  if (!method)
+    return 0;
+
+  CompiledFunction *fn = method->jit();
   if (!fn)
     return 0;
 

--- a/vm/stack-frames.cpp
+++ b/vm/stack-frames.cpp
@@ -51,67 +51,66 @@ JitInvokeFrame::~JitInvokeFrame()
   Environment::get()->leaveJitInvoke(this);
 }
 
-FrameIterator::FrameIterator()
- : ivk_(Environment::get()->top()),
-   cur_frame_(nullptr),
-   runtime_(nullptr),
-   cip_(kInvalidCip),
-   pc_(nullptr)
+// This constructor is for find_entry_fp() in the JIT.
+JitFrameIterator::JitFrameIterator(Environment* env)
+ : JitFrameIterator(env->top()->cx()->runtime(), env->exit_fp())
 {
-  if (!ivk_)
-    return;
-
-  nextInvokeFrame(Environment::get()->exit_fp());
 }
 
-void
-FrameIterator::nextInvokeFrame(intptr_t* exit_fp)
+JitFrameIterator::JitFrameIterator(PluginRuntime* rt, intptr_t* exit_fp)
+ : rt_(rt),
+   cur_frame_(FrameLayout::FromFp(exit_fp))
 {
-  cur_frame_ = FrameLayout::FromFp(exit_fp);
   assert(cur_frame_->frame_type == JitFrameType::Exit);
   assert(cur_frame_->return_address);
   assert(cur_frame_->prev_fp);
 
-  runtime_ = ivk_->cx()->runtime();
   pc_ = nullptr;
   cip_ = kInvalidCip;
 }
 
-void
-FrameIterator::Next()
+bool
+JitFrameIterator::done() const
 {
-  if (cur_frame_->frame_type == JitFrameType::Entry) {
-    // Done with this InvokeFrame, so jump to the next.
-    intptr_t* next_fp = ivk_->AsJitInvokeFrame()->prev_exit_fp();
-    ivk_ = ivk_->prev();
-    if (!ivk_)
-      return;
-    nextInvokeFrame(next_fp);
-    return;
-  }
+  return cur_frame_->frame_type == JitFrameType::Entry;
+}
+
+void
+JitFrameIterator::next()
+{
+  assert(!done());
 
   pc_ = cur_frame_->return_address;
   cip_ = kInvalidCip;
   cur_frame_ = FrameLayout::FromFp(cur_frame_->prev_fp);
 }
 
-void
-FrameIterator::Reset()
+FrameType
+JitFrameIterator::type() const
 {
-  *this = FrameIterator();
+  switch ((JitFrameType)cur_frame_->frame_type) {
+  case JitFrameType::Scripted:
+    return FrameType::Scripted;
+  case JitFrameType::Exit:
+    if (GetExitFrameType(cur_frame_->function_id) == ExitFrameType::Native)
+      return FrameType::Native;
+    return FrameType::Internal;
+  default:
+    return FrameType::Internal;
+  }
 }
 
 cell_t
-FrameIterator::function_cip() const
+JitFrameIterator::function_cip() const
 {
   assert(cur_frame_->frame_type == JitFrameType::Scripted);
   return cur_frame_->function_id;
 }
 
 cell_t
-FrameIterator::findCip() const
+JitFrameIterator::cip() const
 {
-  RefPtr<MethodInfo> method = runtime_->GetMethod(function_cip());
+  RefPtr<MethodInfo> method = rt_->GetMethod(function_cip());
   if (!method)
     return 0;
 
@@ -128,13 +127,65 @@ FrameIterator::findCip() const
   return cip_;
 }
 
+uint32_t
+JitFrameIterator::native_index() const
+{
+  assert(type() == FrameType::Native);
+  return GetExitFramePayload(cur_frame_->function_id);
+}
+
+FrameIterator::FrameIterator()
+ : ivk_(nullptr),
+   runtime_(nullptr),
+   next_exit_fp_(nullptr)
+{
+  Reset();
+}
+
+void
+FrameIterator::nextInvokeFrame()
+{
+  runtime_ = ivk_->cx()->runtime();
+  if (JitInvokeFrame* jvk = ivk_->AsJitInvokeFrame()) {
+    frame_cursor_ = new JitFrameIterator(runtime_, next_exit_fp_);
+    next_exit_fp_ = jvk->prev_exit_fp();
+  }
+}
+
+void
+FrameIterator::Next()
+{
+  if (frame_cursor_->done()) {
+    frame_cursor_ = nullptr;
+
+    ivk_ = ivk_->prev();
+    if (ivk_)
+      nextInvokeFrame();
+    return;
+  }
+
+  frame_cursor_->next();
+}
+
+void
+FrameIterator::Reset()
+{
+  ivk_ = Environment::get()->top();
+  runtime_ = nullptr;
+  next_exit_fp_ = Environment::get()->exit_fp();
+  frame_cursor_ = nullptr;
+
+  if (ivk_)
+    nextInvokeFrame();
+}
+
 unsigned
 FrameIterator::LineNumber() const
 {
   if (!IsScriptedFrame())
     return 0;
 
-  ucell_t cip = findCip();
+  ucell_t cip = frame_cursor_->cip();
   if (cip == kInvalidCip)
     return 0;
 
@@ -151,9 +202,9 @@ FrameIterator::FilePath() const
   if (!IsScriptedFrame())
     return nullptr;
 
-  ucell_t cip = findCip();
+  ucell_t cip = frame_cursor_->cip();
   if (cip == kInvalidCip)
-    return runtime_->image()->LookupFile(function_cip());
+    return runtime_->image()->LookupFile(frame_cursor_->function_cip());
 
   return runtime_->image()->LookupFile(cip);
 }
@@ -163,15 +214,17 @@ FrameIterator::FunctionName() const
 {
   assert(ivk_);
   if (IsNativeFrame()) {
-    uint32_t native_index = GetExitFramePayload(cur_frame_->function_id);
+    uint32_t native_index = frame_cursor_->native_index();
     const sp_native_t *native = runtime_->GetNative(native_index);
     if (!native)
       return nullptr;
     return native->name;
   }
 
-  if (IsScriptedFrame())
-    return runtime_->image()->LookupFunction(function_cip());
+  if (IsScriptedFrame()) {
+    cell_t function_cip = frame_cursor_->function_cip();
+    return runtime_->image()->LookupFunction(function_cip);
+  }
 
   return nullptr;
 }
@@ -179,26 +232,13 @@ FrameIterator::FunctionName() const
 bool
 FrameIterator::IsNativeFrame() const
 {
-  return cur_frame_->frame_type == JitFrameType::Exit &&
-         GetExitFrameType(cur_frame_->function_id) == ExitFrameType::Native;
+  return frame_cursor_->type() == FrameType::Native;
 }
 
 bool
 FrameIterator::IsScriptedFrame() const
 {
-  return cur_frame_->frame_type == JitFrameType::Scripted;
-}
-
-bool
-FrameIterator::IsEntryFrame() const
-{
-  return cur_frame_->frame_type == JitFrameType::Entry;
-}
-
-FrameLayout*
-FrameIterator::Frame() const
-{
-  return cur_frame_;
+  return frame_cursor_->type() == FrameType::Scripted;
 }
 
 IPluginContext *
@@ -212,5 +252,5 @@ FrameIterator::Context() const
 bool
 FrameIterator::IsInternalFrame() const
 {
-  return !(IsScriptedFrame() || IsNativeFrame());
+  return frame_cursor_->type() == FrameType::Internal;
 }

--- a/vm/stack-frames.cpp
+++ b/vm/stack-frames.cpp
@@ -14,9 +14,13 @@
 #include "plugin-runtime.h"
 #include "plugin-context.h"
 #include "stack-frames.h"
-#include "x86/frames-x86.h"
 #include "compiled-function.h"
 #include "method-info.h"
+#if defined(KE_ARCH_X86)
+# include "x86/frames-x86.h"
+#elif !defined(SP_HAS_JIT)
+# include "null-frame-layout.h"
+#endif
 
 using namespace ke;
 using namespace sp;

--- a/vm/x86/code-stubs-x86.cpp
+++ b/vm/x86/code-stubs-x86.cpp
@@ -38,7 +38,7 @@ bool
 CodeStubs::CompileInvokeStub()
 {
   MacroAssembler masm;
-  __ enterFrame(FrameType::Entry, 0);
+  __ enterFrame(JitFrameType::Entry, 0);
 
   __ push(esi);
   __ push(edi);

--- a/vm/x86/jit_x86.cpp
+++ b/vm/x86/jit_x86.cpp
@@ -223,7 +223,7 @@ Compiler::visitSUB_ALT()
 bool
 Compiler::visitPROC()
 {
-  __ enterFrame(FrameType::Scripted, pcode_start_);
+  __ enterFrame(JitFrameType::Scripted, pcode_start_);
 
   // Push the old frame onto the stack.
   __ movl(tmp, Operand(frmAddr()));

--- a/vm/x86/jit_x86.cpp
+++ b/vm/x86/jit_x86.cpp
@@ -41,6 +41,7 @@
 #include "linking.h"
 #include "frames-x86.h"
 #include "outofline-asm.h"
+#include "method-info.h"
 
 #if defined USE_UNGEN_OPCODES
 #include "ungen_opcodes.h"
@@ -1233,8 +1234,8 @@ class CallThunk : public OutOfLinePath
 bool
 Compiler::visitCALL(cell_t offset)
 {
-  CompiledFunction *fun = rt_->GetJittedFunctionByOffset(offset);
-  if (!fun) {
+  RefPtr<MethodInfo> method = rt_->GetMethod(offset);
+  if (!method || !method->jit()) {
     // Need to emit a delayed thunk.
     CallThunk* thunk = new CallThunk(offset);
     __ callWithABI(thunk->label());
@@ -1244,7 +1245,7 @@ Compiler::visitCALL(cell_t offset)
     }
   } else {
     // Function is already emitted, we can do a direct call.
-    __ callWithABI(ExternalAddress(fun->GetEntryAddress()));
+    __ callWithABI(ExternalAddress(method->jit()->GetEntryAddress()));
   }
 
   // Map the return address to the cip that started this call.

--- a/vm/x86/macro-assembler-x86.h
+++ b/vm/x86/macro-assembler-x86.h
@@ -43,7 +43,7 @@ namespace sp {
 class MacroAssembler : public Assembler
 {
  public:
-  void enterFrame(FrameType type, uintptr_t function_id) {
+  void enterFrame(JitFrameType type, uintptr_t function_id) {
     push(ebp);
     movl(ebp, esp);
     push(uint32_t(type));
@@ -53,7 +53,7 @@ class MacroAssembler : public Assembler
     leave();
   }
   void enterExitFrame(ExitFrameType type, uintptr_t payload) {
-    enterFrame(FrameType::Exit, EncodeExitFrameId(type, payload));
+    enterFrame(JitFrameType::Exit, EncodeExitFrameId(type, payload));
     movl(Operand(ExternalAddress(Environment::get()->addressOfExit())), ebp);
   }
   void leaveExitFrame() {


### PR DESCRIPTION
These patches have two main refactorings. One, a new "MethodInfo" class sits in between PluginRuntime and CompiledFunction. This lets us cache method stuff not specific to the JIT, such as invalidation results.

Second, FrameIterator is now understands that there may be multiple execution engines. It only knows how to iterate over InvokeFrames, which can be subclassed. To iterate over inline frames (i.e., function calls), it allocates an instance of InlineFrameIterator which is specific to the invocation type. A JitInvokeFrame's contents can be iterated with a JitFrameIterator.