### PR TITLE
Remove ungenerated LIDX.B and IDXADDR.B opcodes.

### DIFF
--- a/compiler/sc7-in.scp
+++ b/compiler/sc7-in.scp
@@ -370,6 +370,10 @@ static SEQUENCE sequences_cmp[] = {
   /* Array indexing can merit from special instructions.
    * Simple indexed array lookup can be optimized quite
    * a bit.
+   *
+   * NOTE: These are documented as using idxaddr.b/lidx.b
+   * variants which we no longer generate.
+   *
    *    addr.pri n1             addr.alt n1
    *    push.pri                load.s.pri n2
    *    load.s.pri n2           bounds n3
@@ -428,29 +432,6 @@ static SEQUENCE sequences_cmp[] = {
       "const.alt %1!load.s.pri %2!lidx!",
     seqsize(7,3) - seqsize(3,2)
   },
-#endif
-  /* loading from array, not "cell" shifted */
-  {
-      "addr.pri %1!push.pri!load.s.pri %2!bounds %3!shl.c.pri %4!pop.alt!add!load.i!",
-      "addr.alt %1!load.s.pri %2!bounds %3!lidx.b %4!",
-    seqsize(8,4) - seqsize(4,4)
-  },
-  {
-      "const.pri %1!push.pri!load.s.pri %2!bounds %3!shl.c.pri %4!pop.alt!add!load.i!",
-      "const.alt %1!load.s.pri %2!bounds %3!lidx.b %4!",
-    seqsize(8,4) - seqsize(4,4)
-  },
-  {
-      "addr.pri %1!push.pri!load.s.pri %2!shl.c.pri %3!pop.alt!add!load.i!",
-      "addr.alt %1!load.s.pri %2!lidx.b %3!",
-    seqsize(7,3) - seqsize(3,3)
-  },
-  {
-      "const.pri %1!push.pri!load.s.pri %2!shl.c.pri %3!pop.alt!add!load.i!",
-      "const.alt %1!load.s.pri %2!lidx.b %3!",
-    seqsize(7,3) - seqsize(3,3)
-  },
-#if !defined BIT16
   /* array index calculation for storing a value, "cell" aligned */
   {
       "addr.pri %1!push.pri!load.s.pri %2!bounds %3!shl.c.pri 2!pop.alt!add!",
@@ -472,29 +453,6 @@ static SEQUENCE sequences_cmp[] = {
       "const.alt %1!load.s.pri %2!idxaddr!",
     seqsize(6,3) - seqsize(3,2)
   },
-#endif
-  /* array index calculation for storing a value, not "cell" packed */
-  {
-      "addr.pri %1!push.pri!load.s.pri %2!bounds %3!shl.c.pri %4!pop.alt!add!",
-      "addr.alt %1!load.s.pri %2!bounds %3!idxaddr.b %4!",
-    seqsize(7,4) - seqsize(4,4)
-  },
-  {
-      "const.pri %1!push.pri!load.s.pri %2!bounds %3!shl.c.pri %4!pop.alt!add!",
-      "const.alt %1!load.s.pri %2!bounds %3!idxaddr.b %4!",
-    seqsize(7,4) - seqsize(4,4)
-  },
-  {
-      "addr.pri %1!push.pri!load.s.pri %2!shl.c.pri %3!pop.alt!add!",
-      "addr.alt %1!load.s.pri %2!idxaddr.b %3!",
-    seqsize(6,3) - seqsize(3,3)
-  },
-  {
-      "const.pri %1!push.pri!load.s.pri %2!shl.c.pri %3!pop.alt!add!",
-      "const.alt %1!load.s.pri %2!idxaddr.b %3!",
-    seqsize(6,3) - seqsize(3,3)
-  },
-#if !defined BIT16
   /* the shorter array indexing sequences, see above for comments */
   {
       "shl.c.pri 2!pop.alt!add!loadi!",
@@ -507,16 +465,6 @@ static SEQUENCE sequences_cmp[] = {
     seqsize(3,1) - seqsize(2,0)
   },
 #endif
-  {
-      "shl.c.pri %1!pop.alt!add!loadi!",
-      "pop.alt!lidx.b %1!",
-    seqsize(4,1) - seqsize(2,1)
-  },
-  {
-      "shl.c.pri %1!pop.alt!add!",
-      "pop.alt!idxaddr.b %1!",
-    seqsize(3,1) - seqsize(2,1)
-  },
   /* For packed arrays, there is another case (packed arrays
    * do not take advantage of the LIDX or IDXADDR instructions).
    *    addr.pri n1             addr.alt n1

--- a/include/smx/smx-v1-opcodes.h
+++ b/include/smx/smx-v1-opcodes.h
@@ -95,9 +95,9 @@ namespace sp {
   _G(STOR_I,         "stor.i")         \
   _G(STRB_I,         "strb.i")         \
   _G(LIDX,           "lidx")           \
-  _G(LIDX_B,         "lidx.b")         \
+  _U(LIDX_B,         "lidx.b")         \
   _G(IDXADDR,        "idxaddr")        \
-  _G(IDXADDR_B,      "idxaddr.b")      \
+  _U(IDXADDR_B,      "idxaddr.b")      \
   _U(ALIGN_PRI,      "align.pri")      \
   _U(ALIGN_ALT,      "align.alt")      \
   _U(LCTRL,          "lctrl")          \

--- a/vm/method-verifier.cpp
+++ b/vm/method-verifier.cpp
@@ -173,19 +173,6 @@ MethodVerifier::verifyOp(OPCODE op)
     return true;
   }
 
-  case OP_LIDX_B:
-  case OP_IDXADDR_B:
-  {
-    cell_t val;
-    if (!readCell(&val))
-      return false;
-    if (val != 1 && val != 2) {
-      reportError(SP_ERROR_INVALID_INSTRUCTION);
-      return false;
-    }
-    return true;
-  }
-
   case OP_PUSH_C:
   case OP_PUSH2_C:
   case OP_PUSH3_C:

--- a/vm/pcode-reader.h
+++ b/vm/pcode-reader.h
@@ -163,20 +163,8 @@ class PcodeReader
     case OP_LIDX:
       return visitor_->visitLIDX();
 
-    case OP_LIDX_B:
-    {
-      cell_t val = readCell();
-      return visitor_->visitLIDX_B(val);
-    }
-
     case OP_IDXADDR:
       return visitor_->visitIDXADDR();
-
-    case OP_IDXADDR_B:
-    {
-      cell_t val = readCell();
-      return visitor_->visitIDXADDR_B(val);
-    }
 
     case OP_MOVE_PRI:
       return visitor_->visitMOVE(PawnReg::Pri);

--- a/vm/pcode-visitor.h
+++ b/vm/pcode-visitor.h
@@ -59,9 +59,7 @@ class PcodeVisitor
   virtual bool visitSTOR_I() = 0;
   virtual bool visitSTRB_I(cell_t width) = 0;
   virtual bool visitLIDX() = 0;
-  virtual bool visitLIDX_B(cell_t width) = 0;
   virtual bool visitIDXADDR() = 0;
-  virtual bool visitIDXADDR_B(cell_t width) = 0;
   virtual bool visitMOVE(PawnReg reg) = 0;
   virtual bool visitXCHG() = 0;
   virtual bool visitPUSH(PawnReg src) = 0;

--- a/vm/x86/jit_x86.cpp
+++ b/vm/x86/jit_x86.cpp
@@ -239,14 +239,6 @@ Compiler::visitPROC()
 }
 
 bool
-Compiler::visitIDXADDR_B(cell_t width)
-{
-  __ shll(pri, width);
-  __ addl(pri, alt);
-  return true;
-}
-
-bool
 Compiler::visitSHL()
 {
   __ movl(ecx, alt);
@@ -542,20 +534,6 @@ bool
 Compiler::visitLIDX()
 {
   __ lea(pri, Operand(alt, pri, ScaleFour));
-  __ movl(pri, Operand(dat, pri, NoScale));
-  return true;
-}
-
-bool
-Compiler::visitLIDX_B(cell_t width)
-{
-  if (width >= 0 && width <= 3) {
-    __ lea(pri, Operand(alt, pri, Scale(width)));
-  } else {
-    __ shll(pri, width);
-    __ addl(pri, alt);
-  }
-  emitCheckAddress(pri);
   __ movl(pri, Operand(dat, pri, NoScale));
   return true;
 }

--- a/vm/x86/jit_x86.h
+++ b/vm/x86/jit_x86.h
@@ -57,9 +57,7 @@ class Compiler : public CompilerBase
   bool visitSTOR_I() override;
   bool visitSTRB_I(cell_t width) override;
   bool visitLIDX() override;
-  bool visitLIDX_B(cell_t width) override;
   bool visitIDXADDR() override;
-  bool visitIDXADDR_B(cell_t width) override;
   bool visitMOVE(PawnReg reg) override;
   bool visitXCHG() override;
   bool visitPUSH(PawnReg src) override;


### PR DESCRIPTION
An analysis of every .smx file on the forums and webcompiler cache reveals no instances of IDXADDR.B or LIDX.B.

These opcodes are only present in the peephole optimizer. They usually sequence from "shl.c.pri; load.i" pairs, which are never generated. If we're going to shift by a weird amount and then load, we always generate LODB.I.

This patch removes them.