### PR TITLE
Enhance runtime testing.

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -10,6 +10,8 @@ def main():
   parser = argparse.ArgumentParser()
   parser.add_argument('test', type=str, nargs='?', default=None,
                       help="Optional test folder or test file")
+  parser.add_argument('--disable-phopt', default=False, action='store_true',
+                      help="Disable the peephole optimizer when compiling")
   parser.add_argument('--spcomp', type=str, help="Path to spcomp", required=True)
   parser.add_argument('--shell', type=str, help="Path to shell", required=True)
   args = parser.parse_args()
@@ -82,6 +84,7 @@ class Test(object):
 class TestRunner(object):
   def __init__(self, args, tempFolder):
     super(TestRunner, self).__init__()
+    self.args = args
     self.spcomp = os.path.abspath(args.spcomp)
     self.shell = os.path.abspath(args.shell)
     self.tmp_folder = tempFolder
@@ -153,11 +156,17 @@ class TestRunner(object):
 
   def run_compiler(self, test):
     self.out("  [SMX] ")
+
     argv = [
       self.spcomp,
       '-i' + self.inc_folder,
+    ]
+    if self.args.disable_phopt:
+      argv += ['-O0']
+    argv += [
       test.path,
     ]
+
     p = subprocess.Popen(argv, stdout = subprocess.PIPE, stderr = subprocess.PIPE)
     stdout, stderr = p.communicate()
     stdout = stdout.decode('utf-8')

--- a/tools/testing/test-runtime.bat.in
+++ b/tools/testing/test-runtime.bat.in
@@ -1,3 +1,6 @@
 
 echo "Running shell tests..."
 python "{source}\tests\runtests.py" --spcomp "{spcomp}" --shell "{spshell}"
+
+echo "Running shell tests with no optimizer..."
+python "{source}\tests\runtests.py" --disable-phopt --spcomp "{spcomp}" --shell "{spshell}"

--- a/tools/testing/test-runtime.sh.in
+++ b/tools/testing/test-runtime.sh.in
@@ -2,3 +2,5 @@
 
 echo "Running shell tests..."
 python {source}/tests/runtests.py --spcomp "{spcomp}" --shell "{spshell}"
+echo "Running shell tests with no optimizer..."
+python {source}/tests/runtests.py --disable-phopt --spcomp "{spcomp}" --shell "{spshell}"

--- a/vm/plugin-runtime.cpp
+++ b/vm/plugin-runtime.cpp
@@ -144,6 +144,24 @@ PluginRuntime::SetupFloatNativeRemapping()
   }
 }
 
+static cell_t
+NativeMustBeReplaced(IPluginContext* cx, const cell_t* params)
+{
+  cx->ThrowNativeError("This native was not replaced");
+  return 0;
+}
+
+void
+PluginRuntime::InstallBuiltinNatives()
+{
+  for (size_t i = 0; i < image_->NumNatives(); i++) {
+    if (!float_table_[i].found)
+      continue;
+
+    UpdateNativeBinding(i, NativeMustBeReplaced, 0, nullptr);
+  }
+}
+
 unsigned
 PluginRuntime::GetNativeReplacement(size_t index)
 {

--- a/vm/plugin-runtime.h
+++ b/vm/plugin-runtime.h
@@ -93,6 +93,9 @@ class PluginRuntime
     return full_name_.chars();
   }
 
+  // Mark builtin natives as bound.
+  void InstallBuiltinNatives();
+
   // Return the method if it was previously analyzed; null otherwise.
   RefPtr<MethodInfo> GetMethod(cell_t pcode_offset) const;
 

--- a/vm/shell.cpp
+++ b/vm/shell.cpp
@@ -169,12 +169,15 @@ static cell_t ReportError(IPluginContext* cx, const cell_t *params)
 static int Execute(const char *file)
 {
   char error[255];
-  AutoPtr<IPluginRuntime> rt(sEnv->APIv2()->LoadBinaryFromFile(file, error, sizeof(error)));
-  if (!rt) {
+  AutoPtr<IPluginRuntime> rtb(sEnv->APIv2()->LoadBinaryFromFile(file, error, sizeof(error)));
+  if (!rtb) {
     fprintf(stderr, "Could not load plugin %s: %s\n", file, error);
     return 1;
   }
 
+  PluginRuntime* rt = PluginRuntime::FromAPI(rtb);
+
+  rt->InstallBuiltinNatives();
   BindNative(rt, "print", Print);
   BindNative(rt, "printnum", PrintNum);
   BindNative(rt, "printnums", PrintNums);


### PR DESCRIPTION
Some quick changes to runtime testing. First, a hack to enable float opcodes in the shell. Later on we'll just tear these out of SM and hoist them into SP directly, but for now we just mark the natives as bound so replacement will work.

Next, some opcodes are only generated when not using the peephole optimizer. We should test -O0 as well just for better coverage.