### PR TITLE
Fix stack alignment in out-of-bounds reporting.

### DIFF
--- a/tests/exceptions/array-out-of-bounds.out
+++ b/tests/exceptions/array-out-of-bounds.out
@@ -1,2 +1,2 @@
 Exception thrown: Array index out-of-bounds (index 25, limit 22)
-  [1] array-out-of-bounds.sp::main, line 0
+  [1] array-out-of-bounds.sp::main, line 8

--- a/vm/x86/macro-assembler-x86.h
+++ b/vm/x86/macro-assembler-x86.h
@@ -66,6 +66,11 @@ class MacroAssembler : public Assembler
     push(return_address);
     enterExitFrame(type, payload);
   }
+  void leaveInlineExitFrame() {
+    // Note: no ret, the frame is inline. We add 4 to esp isntead.
+    leaveExitFrame();
+    addl(esp, 4);
+  }
 
   void alignStack() {
     andl(esp, 0xfffffff0);


### PR DESCRIPTION
This also fixes CIP mapping - unfortunately this gets handled quite manually right now.