### PR TITLE
Fix crash in ThrowNativeErrorEx with msg = NULL

### DIFF
--- a/vm/base-context.cpp
+++ b/vm/base-context.cpp
@@ -200,7 +200,10 @@ BasePluginContext::ThrowNativeErrorEx(int error, const char *msg, ...)
 {
   va_list ap;
   va_start(ap, msg);
-  env_->ReportErrorVA(error, msg, ap);
+  if (msg)
+    env_->ReportErrorVA(error, msg, ap);
+  else
+    env_->ReportError(error);
   va_end(ap);
   return 0;
 }


### PR DESCRIPTION
SourceMod uses it e.g. to indicate parameter count mismatches in
forwards like `pContext->ThrowNativeErrorEx(SP_ERROR_PARAMS_MAX, NULL);`

sprintf doesn't like the msg/format string to be NULL.