### PR TITLE
Fix counting of unspecified final dimensions of arrays.

### DIFF
--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -2286,26 +2286,24 @@ static void initials2(int ident,int tag,cell *size,int dim[],int numdim,
           err++;
         } /* if */
       } /* for */
-      if (numdim>1 && dim[numdim-1]==0) {
+      if (numdim>1 && dim[numdim-1]==0 && !errorfound && err==0) {
         /* also look whether, by any chance, all "counted" final dimensions are
-         * the same value; if so, we can store this
+         *  the same value; if so, we can store this
          */
         constvalue *ld=lastdim.next;
-        int d,match;
-        for (d=0; d<dim[numdim-2]; d++) {
-          if (!ld) {
-            error(108);
-            err++;
-            break;
-          }
-          assert(strtol(ld->name,NULL,16)==d);
-          if (d==0)
-            match=ld->value;
+        int count=0,match,total,d;
+        for (ld=lastdim.next; ld!=NULL; ld=ld->next) {
+          assert(strtol(ld->name,NULL,16)==count % dim[numdim-2]);  /* index is stored in the name, it should match the sequence */
+          if (count==0)
+            match=(int)ld->value;
           else if (match!=ld->value)
             break;
-          ld=ld->next;
-        } /* for */
-        if (d==dim[numdim-2])
+          count++;
+        }
+        total=dim[numdim-2];
+        for (d=numdim-3; d>=0; d--)
+          total*=dim[d];
+        if (count>0 && count==total)
           dim[numdim-1]=match;
       } /* if */
       /* after all arrays have been initalized, we know the (major) dimensions

--- a/compiler/sc3.cpp
+++ b/compiler/sc3.cpp
@@ -1707,7 +1707,7 @@ static int hier2(value *lval)
         lval->constval=array_levelsize(sym,level);
       }
       if (lval->constval==0 && strchr((char *)lptr,PREPROC_TERM)==NULL)
-        error(163,st);          /* indeterminate array size in "sizeof" expression */
+        error(163,sym->name);          /* indeterminate array size in "sizeof" expression */
     } /* if */
     ldconst(lval->constval,sPRI);
     while (paranthese--)
@@ -1761,7 +1761,7 @@ static int hier2(value *lval)
         lval->constval=array_levelsize(sym,level);
       }
       if (lval->constval==0 && strchr((char *)lptr,PREPROC_TERM)==NULL)
-        error(163,st);          /* indeterminate array size in "sizeof" expression */
+        error(163,sym->name);          /* indeterminate array size in "sizeof" expression */
     } /* if */
     ldconst(lval->constval,sPRI);
     while (paranthese--)

--- a/compiler/tests/fail-jagged-sizeof.sp
+++ b/compiler/tests/fail-jagged-sizeof.sp
@@ -1,0 +1,15 @@
+char arr[8][2][] = 
+{
+	{"Blue", "0 0 255"},
+	{"Red", "255 0 0"},
+	{"Green", "0 255 0"},
+	{"Orange", "255 170 0"},
+	{"Yellow", "220 255 0"},
+	{"Cyan", "0 255 255"},
+	{"Pink", "255 0 255"},
+	{"Purple", "125 0 255"},
+}  
+
+public int main() {
+	return sizeof(arr[][]);
+}

--- a/compiler/tests/fail-jagged-sizeof.txt
+++ b/compiler/tests/fail-jagged-sizeof.txt
@@ -1,0 +1,1 @@
+(14) : error 163: indeterminate array size in "sizeof" expression (symbol "arr")


### PR DESCRIPTION
This change is from upstream.

The old code only considered the first innermost array when counting the size of the final dimension.  This breaks in cases like this:

```
char arr[3][2][] = {
  {"123", "123"},
  {"1234","1234"},
  {"123", "123"}
}
```
The compiler would assume the last dimension was sized one cell/four chars and not indeterminate.  This results in the indirection vectors being wrong.

I'll add some tests before merging.