### PR TITLE
Detect jumps past the end of the function

### DIFF
--- a/vm/method-verifier.h
+++ b/vm/method-verifier.h
@@ -64,6 +64,7 @@ class MethodVerifier final
   const cell_t* method_;
   const cell_t* cip_;
   const cell_t* stop_at_;
+  const cell_t* highest_jump_target_;
   ExternalFuncRefCallback collect_func_refs_;
   int error_;
 };


### PR DESCRIPTION
It's not allowed to jump outside the function. The end of the function
is only known after it has been completely verified, so add a check for
the highest jump target after we know the end.