### PR TITLE
Fix parameter count validation

### DIFF
--- a/vm/method-verifier.cpp
+++ b/vm/method-verifier.cpp
@@ -399,7 +399,7 @@ MethodVerifier::verifyOp(OPCODE op)
     cell_t ndims;
     if (!readCell(&ndims))
       return false;
-    return verifyParamCount(ndims);
+    return verifyDimensionCount(ndims);
   }
 
   case OP_SWITCH:
@@ -531,11 +531,19 @@ MethodVerifier::verifyJumpOffset(cell_t offset)
 }
 
 bool
+MethodVerifier::verifyDimensionCount(cell_t ndims)
+{
+  if (ndims <= 0 || ndims > sDIMEN_MAX) {
+    reportError(SP_ERROR_INSTRUCTION_PARAM);
+    return false;
+  }
+  return true;
+}
+
+bool
 MethodVerifier::verifyParamCount(cell_t nparams)
 {
-  // This is a rough estimate, we just make sure it definitely
-  // won't go out of the heap.
-  if (nparams < 0 || size_t(nparams) >= heapSize_) {
+  if (nparams < 0 || nparams > SP_MAX_EXEC_PARAMS) {
     reportError(SP_ERROR_INSTRUCTION_PARAM);
     return false;
   }

--- a/vm/method-verifier.h
+++ b/vm/method-verifier.h
@@ -46,6 +46,7 @@ class MethodVerifier final
   bool verifyDatOffset(cell_t offset);
   bool verifyJumpOffset(cell_t offset);
   bool verifyParamCount(cell_t nparams);
+  bool verifyDimensionCount(cell_t ndims);
   bool verifyStackAmount(cell_t amount);
   bool verifyHeapAmount(cell_t amount);
   bool verifyMemAmount(cell_t amount);


### PR DESCRIPTION
Copy & paste error in validation of `sysreq.n` parameter count.
`nparams` is the number of parameters passed, not some address.

The `genarray` validation used the same validation logic, but the
`ndims` are the number of dimensions to be generated instead of an
address.