### PR TITLE
Fix compilation for GCC6

### DIFF
--- a/compiler/sc3.cpp
+++ b/compiler/sc3.cpp
@@ -1152,8 +1152,8 @@ static int hier14(value *lval1)
       assert(lval2.arrayidx==arrayidx2);
       for (i=0; i<sDIMEN_MAX; i++)
         same=same && (lval3.arrayidx[i]==lval2.arrayidx[i]);
-        if (same)
-          error(226,lval3.sym->name);   /* self-assignment */
+      if (same)
+        error(226,lval3.sym->name);   /* self-assignment */
     } /* if */
   } else if (lval1->ident == iACCESSOR) {
     pushreg(sPRI);


### PR DESCRIPTION
Similar to https://github.com/alliedmodders/amxmodx/pull/372

Option ```-Wmisleading-indentation``` has been introduced in GCC 6 and it's enabled by ```-Wall```. Due ```-Werror``` option we're unable to successfully build SourcePawn using GCC.