### PR TITLE
Report the right error code for invalid param count

### DIFF
--- a/vm/method-verifier.cpp
+++ b/vm/method-verifier.cpp
@@ -555,7 +555,7 @@ bool
 MethodVerifier::verifyParamCount(cell_t nparams)
 {
   if (nparams < 0 || nparams > SP_MAX_EXEC_PARAMS) {
-    reportError(SP_ERROR_INSTRUCTION_PARAM);
+    reportError(SP_ERROR_PARAMS_MAX);
     return false;
   }
   return true;


### PR DESCRIPTION
There's a specific error number for exceeding the maximum parameter
count. Use it!