### PR TITLE
Expose error code in IErrorReport

### DIFF
--- a/include/sp_vm_api.h
+++ b/include/sp_vm_api.h
@@ -23,8 +23,8 @@
 #include "sp_vm_types.h"
 
 /** SourcePawn Engine API Versions */
-#define SOURCEPAWN_ENGINE2_API_VERSION 0xB
-#define SOURCEPAWN_API_VERSION   0x020B
+#define SOURCEPAWN_ENGINE2_API_VERSION 0xC
+#define SOURCEPAWN_API_VERSION   0x020C
 
 namespace SourceMod {
   struct IdentityToken_t;
@@ -1002,6 +1002,13 @@ namespace SourcePawn
      * @return          Blamed function.
      */
     virtual IPluginFunction *Blame() const = 0;
+
+    /**
+    * @brief Return the error code of the error report.
+    *
+    * @return           SP_ERROR_* integer code.
+    */
+    virtual int Code() const = 0;
   };
 
   /**

--- a/vm/environment.h
+++ b/vm/environment.h
@@ -208,10 +208,10 @@ class ErrorReport : public SourcePawn::IErrorReport
 {
   public:
   ErrorReport(int code, const char *message, PluginContext *cx, SourcePawn::IPluginFunction *pf);
-  int Code() const;
 
   public: //IErrorReport
   const char *Message() const override;
+  int Code() const override;
   IPluginFunction *Blame() const override;
   bool IsFatal() const override;
   IPluginContext *Context() const override;


### PR DESCRIPTION
Give listeners more information about the cause of the error, so they
can choose which error to log.