### PR TITLE
Disallow |halt| instruction

### DIFF
--- a/vm/method-verifier.cpp
+++ b/vm/method-verifier.cpp
@@ -281,10 +281,18 @@ MethodVerifier::verifyOp(OPCODE op)
   case OP_SMUL_C:
   case OP_EQ_C_PRI:
   case OP_EQ_C_ALT:
-  case OP_HALT:
   {
     cell_t val;
     return readCell(&val);
+  }
+
+  case OP_HALT:
+  {
+    cell_t val;
+    if (!readCell(&val))
+      return false;
+    reportError(SP_ERROR_INVALID_INSTRUCTION);
+    return false;
   }
 
   case OP_MOVS:


### PR DESCRIPTION
The compiler never emits this instruction, so don't allow it in a binary.
@asherkin did a test against all uploaded .smx files in the forum to confirm.