### PR TITLE
Fix infinite loop scanning in the experimental parser.

### DIFF
--- a/exp/compiler/lexer.cpp
+++ b/exp/compiler/lexer.cpp
@@ -103,7 +103,7 @@ const char *
 Lexer::skipSpaces()
 {
   while (IsSkipSpace(peekChar()))
-    readChar();
+    skipChar();
   return ptr();
 }
 
@@ -122,7 +122,7 @@ Lexer::readUntilEnd(const char **beginp, const char **endp)
   const char *begin = skipSpaces();
 
   while (!IsLineTerminator(peekChar()))
-    readChar();
+    skipChar();
 
   const char *end = ptr();
   while (end > begin) {
@@ -550,7 +550,7 @@ TokenKind
 Lexer::singleLineComment()
 {
   while (!IsLineTerminator(peekChar()))
-    readChar();
+    skipChar();
   return TOK_COMMENT;
 }
 

--- a/exp/compiler/lexer.h
+++ b/exp/compiler/lexer.h
@@ -71,6 +71,10 @@ class Lexer : public ke::Refcounted<Lexer>
       return '\0';
     return *pos_;
   }
+  void skipChar() {
+    if (canRead())
+      pos_++;
+  }
   char readChar() {
     if (!canRead())
       return '\0';

--- a/exp/compiler/lexer.h
+++ b/exp/compiler/lexer.h
@@ -76,18 +76,41 @@ class Lexer : public ke::Refcounted<Lexer>
       pos_++;
   }
   char readChar() {
-    if (!canRead())
+    if (!canRead()) {
+      scanned_eof_ = true;
       return '\0';
+    }
     return *pos_++;
   }
   bool peekChar(char c) {
     return peekChar() == c;
   }
   bool matchChar(char c) {
-    if (!peekChar(c))
+    char got = readChar();
+    if (got != c) {
+      putBack(got);
       return false;
-    pos_++;
+    }
     return true;
+  }
+  void putBack(char c) {
+    // If the last character we consumed was an EOF, don't backtrack in the
+    // stream. If we did scan eof_, all of the following should be true:
+    //    pos_ == end_
+    //    scanned_eof_
+    //    c == '\0'
+    // If we did not scan EOF, then pos_ can be == end_, but scanned_eof_
+    // must be false.
+    if (pos_ == end_ && scanned_eof_) {
+      assert(c == '\0');
+      return;
+    }
+
+    pos_--;
+
+    assert(*pos_ == c);
+    assert(!scanned_eof_);
+    assert(canRead());
   }
 
   SourceLocation pos() const {
@@ -220,6 +243,9 @@ class Lexer : public ke::Refcounted<Lexer>
 
   // If true, we have already lexed at least one token on this line.
   bool lexed_tokens_on_line_;
+
+  // If true, the last character we scanned was EOF.
+  bool scanned_eof_;
 };
 
 int StringToInt32(const char *ptr);


### PR DESCRIPTION
If we didn't have to deal with macros, this would be a convincing case to use an auto-generated lexer.

> 4:30 PM <Peace-Maker> https://github.com/peace-maker/botmimic/blob/master/scripting/include/botmimic.inc that one never finishes unless i add a newline to the end
> 4:51 PM <dvander> Peace-Maker: bug is, say you consume the last char. then you try to read another and it's not what you expect, so you backtrack
> 4:51 PM <dvander> but backtracking loses the fact that you hit EOF soy ou keep reading the same token forever