### PR TITLE
Fix macro expansion when evaluating preprocessor expressions. (bug 6582)

### DIFF
--- a/exp/compiler/tk-evaluator.cpp
+++ b/exp/compiler/tk-evaluator.cpp
@@ -171,6 +171,7 @@ Preprocessor::eval_next()
     // Macro expansion is disabled, so we manually expand the macro. If we
     // can't, it's not a valid identifier.
     const Token *tok = current();
+    SaveAndSet<bool> enableMacroExpansion(&allow_macro_expansion_, true);
     if (!enterMacro(tok->start.loc, tok->atom())) {
       cc_.report(tok->start.loc, rmsg::macro_not_found)
         << tok->atom();
@@ -291,7 +292,7 @@ Preprocessor::eval_unary(int *val)
     {
       const Token *tok = current();
       cc_.report(tok->start.loc, rmsg::unexpected_directive_token)
-        << tok->atom();
+        << TokenNames[tok->kind];
       return false;
     }
   }


### PR DESCRIPTION
This looks like a bug, we actually do intend to expand the macro but we have to spot-enable it, since it is always disabled normally (so we don't expand the input to the defined operator).