### PR TITLE
Unify parameter count defines in VM and compiler (bug 6540)

### DIFF
--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -59,7 +59,6 @@
 #define sDEF_AMXSTACK 4096  /* default stack size for AMX files */
 #define PREPROC_TERM  '\x7f'/* termination character for preprocessor expressions (the "DEL" code) */
 #define sDEF_PREFIX   "sourcemod.inc" /* default prefix filename */
-#define sARGS_MAX		32	/* number of arguments a function can have, max */
 #define sTAGS_MAX		16  /* maximum number of tags on an argument */
 
 typedef union {
@@ -532,7 +531,6 @@ enum TokenKind {
 #define sSTARTREORDER 0x01
 #define sENDREORDER   0x02
 #define sEXPRSTART    0x80      /* top bit set, rest is free */
-#define sMAXARGS      127       /* relates to the bit pattern of sEXPRSTART */
 
 #define sDOCSEP       0x01      /* to separate documentation comments between functions */
 

--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -3851,7 +3851,7 @@ static void parse_function_type(functag_t *type)
     matchtoken(tSYMBOL);
 
     // Error once when we're past max args.
-    if (type->argcount == sARGS_MAX) {
+    if (type->argcount == SP_MAX_EXEC_PARAMS) {
       error(45);
       continue;
     }
@@ -4056,7 +4056,7 @@ static void dofuncenum(int listmode)
         arg->tags[arg->tagcount++] = pc_addtag(str);
         l=tLABEL;
       } else if (l == tSYMBOL) {
-        if (func.argcount >= sARGS_MAX)
+        if (func.argcount >= SP_MAX_EXEC_PARAMS)
           error(45);
         if (str[0] == PUBLIC_CHAR)
           error(56, str);
@@ -5047,7 +5047,7 @@ static int declargs(symbol *sym, int chkshadow, const int *thistag)
         continue;
       }
 
-      if (argcnt>=sMAXARGS)
+      if (argcnt>=SP_MAX_CALL_ARGUMENTS)
         error(45);
       if (decl.name[0] == PUBLIC_CHAR)
         error(56, decl.name); /* function arguments cannot be public */

--- a/compiler/sc3.cpp
+++ b/compiler/sc3.cpp
@@ -2735,7 +2735,7 @@ static void callfunction(symbol *sym, const svalue *aImplicitThis, value *lval_r
   int namedparams=FALSE;
   value lval = {0};
   arginfo *arg;
-  char arglist[sMAXARGS];
+  char arglist[SP_MAX_CALL_ARGUMENTS];
   constvalue arrayszlst = { NULL, "", 0, 0};/* array size list starts empty */
   constvalue taglst = { NULL, "", 0, 0};    /* tag list starts empty */
   symbol *symret;
@@ -2827,7 +2827,7 @@ static void callfunction(symbol *sym, const svalue *aImplicitThis, value *lval_r
        * of the function; check it again for functions with a variable
        * argument list
        */
-      if (argpos>=sMAXARGS)
+      if (argpos>=SP_MAX_CALL_ARGUMENTS)
         error(45);                /* too many function arguments */
       stgmark((char)(sEXPRSTART+argpos));/* mark beginning of new expression in stage */
       if (arglist[argpos]!=ARG_UNHANDLED)

--- a/compiler/sc7.cpp
+++ b/compiler/sc7.cpp
@@ -289,8 +289,8 @@ static int stgstring(char *start,char *end)
   while (start<end) {
     if (*start==sSTARTREORDER) {
       start+=1;         /* skip token */
-      /* allocate a argstack with sMAXARGS items */
-      stack=(argstack *)malloc(sMAXARGS*sizeof(argstack));
+      /* allocate a argstack with SP_MAX_CALL_ARGUMENTS items */
+      stack=(argstack *)malloc(SP_MAX_CALL_ARGUMENTS*sizeof(argstack));
       if (stack==NULL)
         error(103);     /* insufficient memory */
       reordered=1;      /* mark that the expression is reordered */

--- a/compiler/sctracker.h
+++ b/compiler/sctracker.h
@@ -34,7 +34,7 @@ typedef struct functag_s
   int usage;
   int argcount;
   int ommittable;
-  funcarg_t args[sARGS_MAX];
+  funcarg_t args[SP_MAX_EXEC_PARAMS];
   struct functag_s *next;
 } functag_t;
 

--- a/include/sp_vm_types.h
+++ b/include/sp_vm_types.h
@@ -45,7 +45,8 @@ typedef uint32_t	funcid_t;			/**< Function index code */
 
 #include "sp_typeutil.h"
 
-#define SP_MAX_EXEC_PARAMS				32	/**< Maximum number of parameters in a function */
+#define SP_MAX_EXEC_PARAMS				32	/**< Maximum number of parameters in a function signature */
+#define SP_MAX_CALL_ARGUMENTS			127	/**< Maximum number of arguments when calling a function (relates to the bit pattern of sEXPRSTART) */
 
 #define SP_JITCONF_DEBUG		"debug"		/**< Configuration option for debugging. */
 #define SP_JITCONF_PROFILE		"profile"	/**< Configuration option for profiling. */

--- a/vm/method-verifier.cpp
+++ b/vm/method-verifier.cpp
@@ -562,7 +562,7 @@ MethodVerifier::verifyDimensionCount(cell_t ndims)
 bool
 MethodVerifier::verifyParamCount(cell_t nparams)
 {
-  if (nparams < 0 || nparams > SP_MAX_EXEC_PARAMS) {
+  if (nparams < 0 || nparams > SP_MAX_CALL_ARGUMENTS) {
     reportError(SP_ERROR_INSTRUCTION_PARAM);
     return false;
   }


### PR DESCRIPTION
`sARGS_MAX` becomes `SP_MAX_EXEC_PARAMS` and `sMAXARGS` becomes `SP_MAX_CALL_ARGUMENTS` in the VM as well as the compiler.

The method verifier now checks for the maximum allowed arguments of a call,
which differs from the maximum number of parameters when declaring a function in the compiler.

The present name `SP_MAX_EXEC_PARAMS` doesn't really describe the value, but it would require changes to SourceMod too to make it more descriptive.