### PR TITLE
Fix adding function table entries for functions with no definition. (bug 124, r=fyren)

### DIFF
--- a/compiler/sc6.cpp
+++ b/compiler/sc6.cpp
@@ -846,6 +846,13 @@ static void assemble_to_buffer(MemoryBuffer *buffer, void *fin)
         nativeList.append(sym);
         continue;
       }
+
+      // If a function is marked as missing it should not be a public function
+      // with a declaration.
+      if (sym->usage & uMISSING) {
+        assert((sym->usage & (uPUBLIC|uDEFINE)) != (uPUBLIC|uDEFINE));
+        continue;
+      }
       
       if ((sym->usage & (uPUBLIC|uDEFINE)) == (uPUBLIC|uDEFINE) ||
           (sym->usage & uREAD))
@@ -881,8 +888,8 @@ static void assemble_to_buffer(MemoryBuffer *buffer, void *fin)
     symbol *sym = f.sym;
 
     assert(sym->addr() > 0);
-    assert(sym->codeaddr > sym->addr());
     assert(sym->usage & uDEFINE);
+    assert(sym->codeaddr > sym->addr());
 
     sp_file_publics_t &pubfunc = publics->add();
     pubfunc.address = sym->addr();

--- a/compiler/tests/fail-unused-call-with-undefined-call.sp
+++ b/compiler/tests/fail-unused-call-with-undefined-call.sp
@@ -1,0 +1,6 @@
+void foo()
+{
+        bar(baz(1));
+}
+
+public main() { foo(); }

--- a/compiler/tests/fail-unused-call-with-undefined-call.txt
+++ b/compiler/tests/fail-unused-call-with-undefined-call.txt
@@ -1,0 +1,1 @@
+(3) : error 017: undefined symbol "bar"


### PR DESCRIPTION
This is probably a regression from when we made all functions implicitly public. The code that builds the name/address table in the header, assumes that functions marked as `uREAD` can be exported. But in fact a function can be `uREAD | uMISSING` which means it was declared and used, but not defined. This is not a compiler error if the usage happened in a function that was omitted in the second pass.