### PR TITLE
Fix typo when caching plugin file names

### DIFF
--- a/vm/plugin-runtime.cpp
+++ b/vm/plugin-runtime.cpp
@@ -174,7 +174,7 @@ void
 PluginRuntime::SetNames(const char *fullname, const char *name)
 {
   name_ = name;
-  full_name_ = name;
+  full_name_ = fullname;
 }
 
 RefPtr<MethodInfo>


### PR DESCRIPTION
The full path is passed but not saved.