### PR TITLE
Report file (and line) of the declaration of unused variables/functions

### DIFF
--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -559,7 +559,8 @@ enum TokenKind {
 #define sFORCESET       1       /* force error flag on */
 #define sEXPRMARK       2       /* mark start of expression */
 #define sEXPRRELEASE    3       /* mark end of expression */
-#define sSETPOS         4       /* set line number for the error */
+#define sSETLINE        4       /* set line number for the error */
+#define sSETFILE        5       /* set file number for the error */
 
 enum {
   sOPTIMIZE_NONE,               /* no optimization */
@@ -844,6 +845,9 @@ void delete_substtable(void);
 stringlist *insert_sourcefile(char *string);
 char *get_sourcefile(int index);
 void delete_sourcefiletable(void);
+stringlist *insert_inputfile(char *string);
+char *get_inputfile(int index);
+void delete_inputfiletable(void);
 stringlist *insert_docstring(char *string);
 char *get_docstring(int index);
 void delete_docstring(int index);
@@ -909,8 +913,8 @@ extern int curseg;          /* 1 if currently parsing CODE, 2 if parsing DATA */
 extern cell pc_stksize;     /* stack size */
 extern int freading;        /* is there an input file ready for reading? */
 extern int fline;           /* the line number in the current file */
-extern short fnumber;       /* number of files in the file table (debugging) */
-extern short fcurrent;      /* current file being processed (debugging) */
+extern short fnumber;       /* number of files in the input file table */
+extern short fcurrent;      /* current file being processed */
 extern short sc_intest;     /* true if inside a test */
 extern int sideeffect;      /* true if an expression causes a side-effect */
 extern int stmtindent;      /* current indent of the statement */

--- a/compiler/sc2.cpp
+++ b/compiler/sc2.cpp
@@ -187,14 +187,16 @@ int plungequalifiedfile(char *name)
   inpfname=duplicatestring(name);/* set name of include file */
   if (inpfname==NULL)
     error(FATAL_ERROR_OOM);
-  inpf=fp;                  /* set input file pointer to include file */
+  inpf=fp;                      /* set input file pointer to include file */
   fnumber++;
-  fline=0;                  /* set current line number to 0 */
+  fline=0;                      /* set current line number to 0 */
   fcurrent=fnumber;
-  icomment=0;               /* not in a comment */
-  insert_dbgfile(inpfname);
-  setfiledirect(inpfname);
-  listline=-1;              /* force a #line directive when changing the file */
+  icomment=0;                   /* not in a comment */
+  insert_dbgfile(inpfname);     /* attach to debug information */
+  insert_inputfile(inpfname);   /* save for the error system */
+  assert(sc_status==statFIRST || strcmp(get_inputfile(fcurrent), inpfname)==0);
+  setfiledirect(inpfname);      /* (optionally) set in the list file */
+  listline=-1;                  /* force a #line directive when changing the file */
   sc_is_utf8=(short)scan_utf8(inpf,name);
   return TRUE;
 }
@@ -345,6 +347,7 @@ static void readline(unsigned char *line)
       inpf=POPSTK_P();
       insert_dbgfile(inpfname);
       setfiledirect(inpfname);
+      assert(sc_status==statFIRST || strcmp(get_inputfile(fcurrent),inpfname)==0);
       listline=-1;              /* force a #line directive when changing the file */
     } /* if */
 

--- a/compiler/sclist.cpp
+++ b/compiler/sclist.cpp
@@ -368,7 +368,7 @@ void delete_substtable(void)
 #endif /* !defined NO_SUBST */
 
 
-/* ----- input file list ----------------------------------------- */
+/* ----- input file list (explicit files) ------------------------ */
 static stringlist sourcefiles;
 
 stringlist *insert_sourcefile(char *string)
@@ -385,6 +385,28 @@ void delete_sourcefiletable(void)
 {
   delete_stringtable(&sourcefiles);
   assert(sourcefiles.next==NULL);
+}
+
+
+/* ----- parsed file list (explicit + included files) ------------ */
+static stringlist inputfiles;
+
+stringlist *insert_inputfile(char *string)
+{
+  if (sc_status!=statFIRST)
+    return insert_string(&inputfiles,string);
+  return NULL;
+}
+
+char *get_inputfile(int index)
+{
+  return get_string(&inputfiles,index);
+}
+
+void delete_inputfiletable(void)
+{
+  delete_stringtable(&inputfiles);
+  assert(inputfiles.next==NULL);
 }
 
 

--- a/compiler/tests/fail-delete-no-dtor.sp
+++ b/compiler/tests/fail-delete-no-dtor.sp
@@ -1,7 +1,7 @@
 native Handle:CreateHandle();
 
 methodmap Handle {
-	public Handle() = CreateHandle;
+	public Handle() { return CreateHandle(); }
 };
 
 public main() {


### PR DESCRIPTION
Currently an unused function is reported on the last line of a file instead of the line in the file of the declaration.

Line numbers could get confused too if there is an unused function and an unused variable in one file.

plugin.sp(22) : warning 203: symbol is never used: "func"

This is a ported fix from upstream Pawn https://github.com/compuphase/pawn/commit/584901e179e07f7efb8d4f77d372a3236f515b6a