### PR TITLE
Fix test suite overwriting compiler test result on windows

### DIFF
--- a/tools/testing/test-all.bat.in
+++ b/tools/testing/test-all.bat.in
@@ -1,4 +1,5 @@
 @echo off
+setlocal
 set status=0
 
 call {objdir}/testing/test-compiler.bat

--- a/tools/testing/test-runtime.bat.in
+++ b/tools/testing/test-runtime.bat.in
@@ -1,4 +1,5 @@
 @echo off
+setlocal
 set status=0
 
 echo "Running shell tests..."


### PR DESCRIPTION
Even if there is a failing test case in the compiler tests the test-all.bat script would have an exit code of 0 if the runtime tests all passed afterwards.

Batch variables are global by default, so the test-runtime.bat script overwrote the `status` variable in the test-all.bat script.