### PR TITLE
Disallow negative indices in all array access patterns

### DIFF
--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -752,6 +752,7 @@ void ffcall(symbol *sym,const char *label,int numargs);
 void ffret();
 void ffabort(int reason);
 void ffbounds(cell size);
+void ffbounds();
 void jumplabel(int number);
 void defstorage(void);
 void modstk(int delta);

--- a/compiler/sc3.cpp
+++ b/compiler/sc3.cpp
@@ -2188,10 +2188,14 @@ restart:
         if (close==']' && !magic_string) {
           if (sym->dim.array.length!=0)
             ffbounds(sym->dim.array.length-1);  /* run time check for array bounds */
+          else
+            ffbounds();
           cell2addr();  /* normal array index */
         } else {
           if (sym->dim.array.length!=0)
             ffbounds(sym->dim.array.length*(32/sCHARBITS)-1);
+          else
+            ffbounds();
           char2addr();  /* character array index */
         } /* if */
         popreg(sALT);

--- a/compiler/sc4.cpp
+++ b/compiler/sc4.cpp
@@ -749,11 +749,18 @@ void ffabort(int reason)
 
 void ffbounds(cell size)
 {
-  if ((sc_debug & sCHKBOUNDS)!=0) {
-    stgwrite("\tbounds ");
-    outval(size,TRUE);
-    code_idx+=opcodes(1)+opargs(1);
-  } /* if */
+  stgwrite("\tbounds ");
+  outval(size,TRUE);
+  code_idx+=opcodes(1)+opargs(1);
+}
+
+void ffbounds()
+{
+  // Since the VM uses an unsigned compare here, this effectively protects us
+  // from negative array indices.
+  stgwrite("\tbounds ");
+  outval(INT_MAX, TRUE);
+  code_idx += opcodes(1) + opargs(1);
 }
 
 /*

--- a/compiler/tests/fail-index-array-with-const-negative.sp
+++ b/compiler/tests/fail-index-array-with-const-negative.sp
@@ -1,0 +1,7 @@
+native void printnum(int n);
+
+public main()
+{
+  char x[] = "hello!";
+  printnum(x[-1]);
+}

--- a/compiler/tests/fail-index-array-with-const-negative.txt
+++ b/compiler/tests/fail-index-array-with-const-negative.txt
@@ -1,0 +1,1 @@
+(6) : error 032: array index out of bounds (variable "x")

--- a/tests/exceptions/negative-array-index-1.err
+++ b/tests/exceptions/negative-array-index-1.err
@@ -1,0 +1,1 @@
+Error executing main: Array index out-of-bounds (index -1, limit 4)

--- a/tests/exceptions/negative-array-index-1.out
+++ b/tests/exceptions/negative-array-index-1.out
@@ -1,0 +1,2 @@
+Exception thrown: Array index out-of-bounds (index -1, limit 4)
+  [0] negative-array-index-1.sp::main, line 8

--- a/tests/exceptions/negative-array-index-1.sp
+++ b/tests/exceptions/negative-array-index-1.sp
@@ -1,0 +1,9 @@
+// returnCode: 1
+#include <shell>
+
+public main()
+{
+  int x[] = {1, 2, 3, 4};
+  int n = -1;
+  printnum(x[n]);
+}

--- a/tests/exceptions/negative-array-index-2.err
+++ b/tests/exceptions/negative-array-index-2.err
@@ -1,0 +1,1 @@
+Error executing main: Array index out-of-bounds (index -1)

--- a/tests/exceptions/negative-array-index-2.out
+++ b/tests/exceptions/negative-array-index-2.out
@@ -1,0 +1,3 @@
+Exception thrown: Array index out-of-bounds (index -1)
+  [0] negative-array-index-2.sp::bad, line 13
+  [1] negative-array-index-2.sp::main, line 8

--- a/tests/exceptions/negative-array-index-2.sp
+++ b/tests/exceptions/negative-array-index-2.sp
@@ -1,0 +1,14 @@
+// returnCode: 1
+#include <shell>
+
+public main()
+{
+  int x[] = {1, 2, 3, 4};
+  int n = -1;
+  bad(x, n);
+}
+
+void bad(int[] x, int n)
+{
+  printnum(x[n]);
+}

--- a/tests/exceptions/negative-array-index-3.err
+++ b/tests/exceptions/negative-array-index-3.err
@@ -1,0 +1,1 @@
+Error executing main: Array index out-of-bounds (index -1)

--- a/tests/exceptions/negative-array-index-3.out
+++ b/tests/exceptions/negative-array-index-3.out
@@ -1,0 +1,3 @@
+Exception thrown: Array index out-of-bounds (index -1)
+  [0] negative-array-index-3.sp::bad, line 13
+  [1] negative-array-index-3.sp::main, line 8

--- a/tests/exceptions/negative-array-index-3.sp
+++ b/tests/exceptions/negative-array-index-3.sp
@@ -1,0 +1,19 @@
+// returnCode: 1
+#include <shell>
+
+public main()
+{
+  int x[] = {1, 2, 3, 4};
+  int n = -1;
+  bad(x, n);
+}
+
+void bad(int[] x, int n)
+{
+  bad2(x[n], n);
+}
+
+void bad2(int[] x, int n)
+{
+  printnum(x[n]);
+}

--- a/vm/runtime-helpers.cpp
+++ b/vm/runtime-helpers.cpp
@@ -24,11 +24,20 @@ using namespace SourcePawn;
 void
 ReportOutOfBoundsError(cell_t index, cell_t bounds)
 {
-  Environment::get()->ReportErrorFmt(
-    SP_ERROR_ARRAY_BOUNDS,
-    "Array index out-of-bounds (index %d, limit %d)",
-    index,
-    size_t(bounds) + 1);
+  if (bounds == INT_MAX) {
+    // This is an internal protection against negative indices on arrays with
+    // unknown size.
+    Environment::get()->ReportErrorFmt(
+      SP_ERROR_ARRAY_BOUNDS,
+      "Array index out-of-bounds (index %d)",
+      index);
+  } else {
+    Environment::get()->ReportErrorFmt(
+      SP_ERROR_ARRAY_BOUNDS,
+      "Array index out-of-bounds (index %d, limit %d)",
+      index,
+      size_t(bounds) + 1);
+  }
 }
 
 } // namespace sp


### PR DESCRIPTION
When the compiler knows the size of an array, an index into the array will be protected by a `BOUNDS n` opcode. This forces the index to be within `[0, n)`. If the compiler doesn't know the size of an array, it gives up and there is no protection. As a result, when passing arrays as parameters, it is possible to unintentionally read garbage data with negative indices. This can mask real bugs and needs to be fixed.

We (ideally) should do this without a new opcode, since that requires a breaking ABI change. The easiest solution, I think, is to just always emit a `BOUNDS` opcode. If we don't know the actual bounds we can emit `INT_MAX`, effectively guaranteeing that only negative numbers will fail the check. This is pretty straightforward and the only gotcha was having to update an error message.