### PR TITLE
Switch to AMBuild 2.1 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,16 +26,16 @@ before_script:
 script:
  - mkdir obj-release && cd obj-release
  - PATH="~/.local/bin:$PATH"
- - CC=clang-3.8 CXX=clang-3.8 python ../configure.py --enable-optimize --arch=x86
+ - CC=clang-3.8 CXX=clang-3.8 python ../configure.py --enable-optimize --target-arch=x86
  - ambuild
  - ./testing/test-all.sh
  - cd ..
  - mkdir x64-release && cd x64-release
- - CC=clang-3.8 CXX=clang-3.8 python ../configure.py --enable-optimize --arch=x64
+ - CC=clang-3.8 CXX=clang-3.8 python ../configure.py --enable-optimize --target-arch=x64
  - ambuild
  - ./testing/test-all.sh
  - cd ..
  - mkdir x86-debug && cd x86-debug
- - CC=clang-3.8 CXX=clang-3.8 python ../configure.py --enable-debug --arch=x86
+ - CC=clang-3.8 CXX=clang-3.8 python ../configure.py --enable-debug --target-arch=x86
  - ambuild
  - ./testing/test-all.sh

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -37,7 +37,7 @@ class Config(object):
         '-Werror',
         '-Wno-switch',
       ]
-      if builder.options.arch == 'x86':
+      if builder.target.arch == 'x86':
         cxx.cflags += ['-msse']
       else:
         cxx.cflags += ['-fPIC']
@@ -154,7 +154,7 @@ class Config(object):
       elif builder.target.platform == 'windows':
         cxx.defines += ['WIN32', '_WINDOWS']
 
-    if builder.options.arch == 'x64':
+    if builder.target.arch == 'x64':
       gccarch = '-m64'
       msvcarch = '/MACHINE:X64'
     else:

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -221,17 +221,17 @@ class SourcePawn(object):
     self.included_zlib = False
     self.arch = builder.target.arch
     self.spcomp_scripts = [
-      os.path.join(builder.currentSourceFolder, 'compiler/AMBuilder'),
+      os.path.join('compiler', 'AMBuilder'),
     ]
     self.vm_scripts = [
-      os.path.join(builder.currentSourceFolder, 'vm/AMBuilder'),
+      os.path.join('vm', 'AMBuilder'),
     ]
     self.test_scripts = [
-      os.path.join(builder.currentSourceFolder, 'tools/testing/Testing.ambuild'),
+      os.path.join('tools', 'testing', 'Testing.ambuild'),
     ]
     self.exp_scripts = [
-      os.path.join(builder.currentSourceFolder, 'exp/compiler/AMBuilder'),
-      os.path.join(builder.currentSourceFolder, 'exp/tools/docparse/AMBuilder'),
+      os.path.join('exp', 'compiler', 'AMBuilder'),
+      os.path.join('exp', 'tools', 'docparse', 'AMBuilder'),
     ]
     self.vars = {
       'Root': self.root,
@@ -261,7 +261,7 @@ class SourcePawn(object):
   def EnsureZlib(self):
     if self.included_zlib:
       return
-    zlib_dir = os.path.join(builder.currentSourceFolder, 'third_party/zlib/AMBuilder')
+    zlib_dir = os.path.join('third_party', 'zlib', 'AMBuilder')
     builder.Build([zlib_dir], self.vars)
     self.included_zlib = True
 
@@ -270,18 +270,23 @@ if builder.parent is None:
   root.configure()
   sp = SourcePawn(root, root.amtl)
   build = getattr(builder.options, 'build', 'all').split(',')
-  if 'all' in build:
-    sp.BuildSuite()
-  else:
-    if 'core' in build:
-      build += ['spcomp', 'vm']
-    if 'spcomp' in build:
-      sp.BuildSpcomp()
-    if 'vm' in build:
-      sp.BuildVM()
-    if 'exp' in build:
-      sp.BuildExperimental()
-    if 'test' in build:
-      sp.BuildTests()
 else:
-  rvalue = SourcePawn
+  sp = SourcePawn(external_root, external_amtl)
+  build = external_build
+
+if 'all' in build:
+  sp.BuildSuite()
+else:
+  if 'core' in build:
+    build += ['spcomp', 'vm']
+  if 'spcomp' in build:
+    sp.BuildSpcomp()
+  if 'vm' in build:
+    sp.BuildVM()
+  if 'exp' in build:
+    sp.BuildExperimental()
+  if 'test' in build:
+    sp.BuildTests()
+
+if builder.parent is not None:
+  rvalue = sp

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -71,7 +71,7 @@ class Config(object):
         emflags = ['-s', 'PRECISE_F32=1']
         cxx.cflags += emflags
         cxx.linkflags += emflags
-    elif cxx.name is 'msvc':
+    elif cxx.like('msvc'):
       if builder.options.debug == '1':
         cxx.cflags += ['/MTd']
         cxx.linkflags += ['/NODEFAULTLIB:libcmt']
@@ -139,9 +139,9 @@ class Config(object):
     # Platform-specifics
     if not cxx.like('emscripten'):
       if builder.target.platform == 'linux':
-        if cxx.name == 'gcc':
+        if cxx.family == 'gcc':
           cxx.postlink += ['-static-libgcc']
-        elif cxx.name == 'clang':
+        elif cxx.family == 'clang':
           cxx.postlink += ['-lgcc_eh']
         cxx.postlink += ['-lpthread', '-lrt']
       elif builder.target.platform == 'mac':

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -25,37 +25,36 @@ def Normalize(path):
 class Config(object):
   def __init__(self):
     super(Config, self).__init__()
-    self.arch = getattr(builder.options, 'arch', 'x86')
+    self.arch = builder.target.arch
 
   def configure(self):
-    cfg = builder.DetectCompilers()
-    cxx = cfg.cxx
+    cxx = builder.DetectCxx()
 
     if cxx.like('gcc'):
-      cfg.cflags += [
+      cxx.cflags += [
         '-pipe',
         '-Wall',
         '-Werror',
         '-Wno-switch',
       ]
       if builder.options.arch == 'x86':
-        cfg.cflags += ['-msse']
+        cxx.cflags += ['-msse']
       else:
-        cfg.cflags += ['-fPIC']
+        cxx.cflags += ['-fPIC']
 
-      cfg.cxxflags += ['-std=c++11']
+      cxx.cxxflags += ['-std=c++11']
 
-      have_gcc = cxx.name is 'gcc'
-      have_clang = cxx.name is 'clang' or cxx.name is 'emscripten'
+      have_gcc = cxx.family is 'gcc'
+      have_clang = cxx.family is 'clang' or cxx.family is 'emscripten'
       if have_clang or (have_gcc and cxx.majorVersion >= 4):
-        cfg.cflags += ['-fvisibility=hidden']
-        cfg.cxxflags += ['-fvisibility-inlines-hidden']
+        cxx.cflags += ['-fvisibility=hidden']
+        cxx.cxxflags += ['-fvisibility-inlines-hidden']
         if have_clang or (have_gcc and (cxx.majorVersion >= 5 or cxx.minorVersion >= 7)):
-          cfg.cxxflags += ['-Wno-delete-non-virtual-dtor']
+          cxx.cxxflags += ['-Wno-delete-non-virtual-dtor']
 
       # Disable some stuff we don't use, that gives us better binary
       # compatibility on Linux.
-      cfg.cxxflags += [
+      cxx.cxxflags += [
         '-fno-exceptions',
         '-fno-rtti',
         '-fno-threadsafe-statics',
@@ -64,36 +63,36 @@ class Config(object):
       ]
 
       if have_gcc:
-        cfg.cflags += ['-mfpmath=sse']
+        cxx.cflags += ['-mfpmath=sse']
 
-      cfg.postlink += ['-lm']
+      cxx.postlink += ['-lm']
 
       if cxx.like('emscripten'):
         emflags = ['-s', 'PRECISE_F32=1']
-        cfg.cflags += emflags
-        cfg.linkflags += emflags
+        cxx.cflags += emflags
+        cxx.linkflags += emflags
     elif cxx.name is 'msvc':
       if builder.options.debug == '1':
-        cfg.cflags += ['/MTd']
-        cfg.linkflags += ['/NODEFAULTLIB:libcmt']
+        cxx.cflags += ['/MTd']
+        cxx.linkflags += ['/NODEFAULTLIB:libcmt']
       else:
-        cfg.cflags += ['/MT']
-      cfg.defines += [
+        cxx.cflags += ['/MT']
+      cxx.defines += [
         '_CRT_SECURE_NO_DEPRECATE',
         '_CRT_SECURE_NO_WARNINGS',
         '_CRT_NONSTDC_NO_DEPRECATE',
         '_ITERATOR_DEBUG_LEVEL=0',
       ]
-      cfg.cflags += [
+      cxx.cflags += [
         '/W3',
         '/wd4351',
       ]
-      cfg.cxxflags += [
+      cxx.cxxflags += [
         '/EHsc',
         '/GR-',
         '/TP',
       ]
-      cfg.linkflags += [
+      cxx.linkflags += [
         '/MACHINE:X86',
         'kernel32.lib',
         'user32.lib',
@@ -111,49 +110,49 @@ class Config(object):
 
     # Optimization
     if builder.options.opt == '1':
-      cfg.defines += ['NDEBUG']
+      cxx.defines += ['NDEBUG']
       if cxx.like('gcc'):
-        cfg.cflags += ['-O3']
+        cxx.cflags += ['-O3']
         if cxx.like('emscripten'):
           emflags = ['--closure', '0', '--memory-init-file', '0', '-s', 'AGGRESSIVE_VARIABLE_ELIMINATION=1', '--llvm-lto', '1']
-          cfg.cflags += emflags
-          cfg.linkflags += ['-O3'] + emflags
+          cxx.cflags += emflags
+          cxx.linkflags += ['-O3'] + emflags
       elif cxx.like('msvc'):
-        cfg.cflags += ['/Ox']
-        cfg.linkflags += ['/OPT:ICF', '/OPT:REF']
+        cxx.cflags += ['/Ox']
+        cxx.linkflags += ['/OPT:ICF', '/OPT:REF']
 
     # Debugging
     if builder.options.debug == '1':
-      cfg.defines += ['DEBUG', '_DEBUG']
+      cxx.defines += ['DEBUG', '_DEBUG']
       if cxx.like('msvc'):
-        cfg.cflags += ['/Od', '/RTC1']
+        cxx.cflags += ['/Od', '/RTC1']
       elif cxx.like('emscripten'):
         emflags = ['-s', 'ASSERTIONS=1', '-s', 'SAFE_HEAP=1', '-s', 'STACK_OVERFLOW_CHECK=1', '-s', 'WARN_UNALIGNED=0', '-s', 'DEMANGLE_SUPPORT=1']
-        cfg.cflags += emflags
-        cfg.linkflags += emflags
+        cxx.cflags += emflags
+        cxx.linkflags += emflags
 
     # This needs to be after our optimization flags which could otherwise disable it.
-    if cxx.name == 'msvc':
+    if cxx.like('msvc'):
       # Don't omit the frame pointer.
-      cfg.cflags += ['/Oy-']
+      cxx.cflags += ['/Oy-']
 
     # Platform-specifics
     if not cxx.like('emscripten'):
-      if builder.target_platform == 'linux':
+      if builder.target.platform == 'linux':
         if cxx.name == 'gcc':
-          cfg.postlink += ['-static-libgcc']
+          cxx.postlink += ['-static-libgcc']
         elif cxx.name == 'clang':
-          cfg.postlink += ['-lgcc_eh']
-        cfg.postlink += ['-lpthread', '-lrt']
-      elif builder.target_platform == 'mac':
-        cfg.cflags += [
+          cxx.postlink += ['-lgcc_eh']
+        cxx.postlink += ['-lpthread', '-lrt']
+      elif builder.target.platform == 'mac':
+        cxx.cflags += [
           '-mmacosx-version-min=10.5',
         ]
-        cfg.linkflags += [
+        cxx.linkflags += [
           '-mmacosx-version-min=10.5',
         ]
-      elif builder.target_platform == 'windows':
-        cfg.defines += ['WIN32', '_WINDOWS']
+      elif builder.target.platform == 'windows':
+        cxx.defines += ['WIN32', '_WINDOWS']
 
     if builder.options.arch == 'x64':
       gccarch = '-m64'
@@ -162,17 +161,17 @@ class Config(object):
       gccarch = '-m32'
       msvcarch = '/MACHINE:X86'
 
-    if cxx.name == 'msvc':
-      if msvcarch not in cfg.linkflags:    
-        cfg.linkflags += [msvcarch]
+    if cxx.like('msvc'):
+      if msvcarch not in cxx.linkflags:    
+        cxx.linkflags += [msvcarch]
     else:
-      if gccarch not in cfg.cflags:
-        cfg.cflags += [gccarch]
-      if gccarch not in cfg.linkflags:
-        cfg.linkflags += [gccarch]
+      if gccarch not in cxx.cflags:
+        cxx.cflags += [gccarch]
+      if gccarch not in cxx.linkflags:
+        cxx.linkflags += [gccarch]
 
-    cfg.defines += ['KE_THREADSAFE']
-    cfg.defines += ['SOURCEPAWN_VERSION="1.9"']
+    cxx.defines += ['KE_THREADSAFE']
+    cxx.defines += ['SOURCEPAWN_VERSION="1.9"']
 
     if builder.options.amtl:
       amtl_path = builder.options.amtl
@@ -184,23 +183,31 @@ class Config(object):
       raise Exception('Could not find AMTL at: {0}'.format(amtl_path))
     self.amtl = amtl_path
 
-    cfg.cxxincludes += [
+    cxx.cxxincludes += [
       os.path.join(self.amtl, 'amtl'),
       os.path.join(self.amtl),
       os.path.join(builder.sourcePath, 'include'),
     ]
 
-  def Program(self, context, name):
-    binary = context.compiler.Program(name)
+  def ProgramBuilder(self, compiler, name):
+    binary = compiler.Program(name)
     if binary.compiler.like('msvc'):
       binary.compiler.linkflags.append('/SUBSYSTEM:CONSOLE')
     return binary
 
-  def Library(self, context, name):
-    binary = context.compiler.Library(name)
+  def LibraryBuilder(self, compiler, name):
+    binary = compiler.Library(name)
     if binary.compiler.like('msvc'):
       binary.compiler.linkflags.append('/SUBSYSTEM:WINDOWS')
     return binary
+
+  def Program(self, context, name):
+    compiler = context.cxx.clone()
+    return self.ProgramBuilder(compiler, name)
+
+  def Library(self, context, name):
+    compiler = context.cxx.clone()
+    return self.LibraryBuilder(compiler, name)
 
 ProjectScripts = [
   #'exp/tools/docparse/AMBuilder'
@@ -212,7 +219,7 @@ class SourcePawn(object):
     self.root = root
     self.amtl = amtl
     self.included_zlib = False
-    self.arch = getattr(root, 'arch', 'x86')
+    self.arch = builder.target.arch
     self.spcomp_scripts = [
       os.path.join(builder.currentSourceFolder, 'compiler/AMBuilder'),
     ]
@@ -233,17 +240,17 @@ class SourcePawn(object):
 
   def BuildSpcomp(self):
     self.EnsureZlib()
-    builder.RunBuildScripts(self.spcomp_scripts, self.vars)
+    builder.Build(self.spcomp_scripts, self.vars)
 
   def BuildVM(self):
     self.EnsureZlib()
-    builder.RunBuildScripts(self.vm_scripts, self.vars)
+    builder.Build(self.vm_scripts, self.vars)
 
   def BuildExperimental(self):
-    builder.RunBuildScripts(self.exp_scripts, self.vars)
+    builder.Build(self.exp_scripts, self.vars)
 
   def BuildTests(self):
-    builder.RunBuildScripts(self.test_scripts, self.vars)
+    builder.Build(self.test_scripts, self.vars)
 
   def BuildSuite(self):
     self.BuildSpcomp()
@@ -255,7 +262,7 @@ class SourcePawn(object):
     if self.included_zlib:
       return
     zlib_dir = os.path.join(builder.currentSourceFolder, 'third_party/zlib/AMBuilder')
-    builder.RunBuildScripts([zlib_dir], self.vars)
+    builder.Build([zlib_dir], self.vars)
     self.included_zlib = True
 
 if builder.parent is None:

--- a/compiler/AMBuilder
+++ b/compiler/AMBuilder
@@ -17,25 +17,25 @@ if compiler.like('gcc'):
     '-Wno-format',
   ]
   compiler.c_only_flags += ['-std=c99']
-  if builder.target_platform == 'linux':
+  if builder.target.platform == 'linux':
     compiler.postlink += ['-lm']
   compiler.postlink += ['-lstdc++']
   compiler.cxxflags += [
     '-Wno-implicit-exception-spec-mismatch',
   ]
-if compiler.cxx.name == 'gcc':
+if compiler.family == 'gcc':
   compiler.cflags += [
     '-Wno-maybe-uninitialized',
   ]
 
 compiler.defines += ['HAVE_STDINT_H']
-if builder.target_platform == 'linux':
+if builder.target.platform == 'linux':
   compiler.defines += [
     'LINUX',
     'AMX_ANSIONLY',
     '_GNU_SOURCE'
   ]
-elif builder.target_platform == 'mac':
+elif builder.target.platform == 'mac':
   compiler.defines += [
     'DARWIN',
     'AMX_ANSIONLY',
@@ -68,7 +68,7 @@ binary.sources += [
   'sp_symhash.cpp',
 ]
 
-if builder.target_platform != 'windows' and not compiler.like('emscripten'):
+if builder.target.platform != 'windows' and not compiler.like('emscripten'):
   compiler.defines += ['ENABLE_BINRELOC']
   binary.sources.append('binreloc.c')
 

--- a/configure.py
+++ b/configure.py
@@ -39,7 +39,6 @@ parser.options.add_option('--enable-debug', action='store_const', const='1', des
                        help='Enable debugging symbols')
 parser.options.add_option('--enable-optimize', action='store_const', const='1', dest='opt',
                        help='Enable optimization')
-parser.options.add_option('--arch', dest='arch', default='x86', help='Architecture (x86, x64)')
 parser.options.add_option('--amtl', type='string', dest='amtl', default=None, help='Custom AMTL path')
 parser.options.add_option('--build', type='string', dest='build', default='all', 
                        help='Build which components (all, spcomp, vm, exp, test, core)')

--- a/configure.py
+++ b/configure.py
@@ -18,7 +18,7 @@
 #
 import sys
 try:
-	from ambuild2 import run
+	from ambuild2 import run, util
 except:
 	try:
 		import ambuild
@@ -29,13 +29,18 @@ except:
 		sys.stderr.write('http://www.alliedmods.net/ambuild\n')
 	sys.exit(1)
 
-run = run.PrepareBuild(sourcePath=sys.path[0])
-run.options.add_option('--enable-debug', action='store_const', const='1', dest='debug',
+def make_objdir_name(p):
+  return 'obj-' + util.Platform() + '-' + p.target_arch
+
+parser = run.BuildParser(sourcePath=sys.path[0], api='2.1')
+parser.default_arch = 'x86'
+parser.default_build_folder = make_objdir_name
+parser.options.add_option('--enable-debug', action='store_const', const='1', dest='debug',
                        help='Enable debugging symbols')
-run.options.add_option('--enable-optimize', action='store_const', const='1', dest='opt',
+parser.options.add_option('--enable-optimize', action='store_const', const='1', dest='opt',
                        help='Enable optimization')
-run.options.add_option('--arch', dest='arch', default='x86', help='Architecture (x86, x64)')
-run.options.add_option('--amtl', type='string', dest='amtl', default=None, help='Custom AMTL path')
-run.options.add_option('--build', type='string', dest='build', default='all', 
+parser.options.add_option('--arch', dest='arch', default='x86', help='Architecture (x86, x64)')
+parser.options.add_option('--amtl', type='string', dest='amtl', default=None, help='Custom AMTL path')
+parser.options.add_option('--build', type='string', dest='build', default='all', 
                        help='Build which components (all, spcomp, vm, exp, test, core)')
-run.Configure()
+parser.Configure()

--- a/exp/compiler/AMBuilder
+++ b/exp/compiler/AMBuilder
@@ -19,7 +19,7 @@
 import os
 
 ### CLI
-binary = builder.compiler.StaticLibrary('spcomp')
+binary = builder.cxx.StaticLibrary('spcomp')
 binary.compiler.cxxincludes += [
   os.path.join(builder.sourcePath, 'include'),
 ]
@@ -66,7 +66,7 @@ binary.sources += [
 ]
 SP.libspcomp = builder.Add(binary)
 
-binary = builder.compiler.Program('spcomp')
+binary = builder.cxx.Program('spcomp')
 binary.compiler.cxxincludes += [
   os.path.join(builder.sourcePath),
   os.path.join(builder.sourcePath, 'include'),

--- a/exp/tools/docparse/AMBuilder
+++ b/exp/tools/docparse/AMBuilder
@@ -17,7 +17,7 @@
 # SourcePawn. If not, see http://www.gnu.org/licenses/.
 import os
 
-binary = builder.compiler.Program('docparse')
+binary = builder.cxx.Program('docparse')
 binary.compiler.cxxincludes += [
   os.path.join(builder.sourcePath, 'exp'),
 ]

--- a/third_party/zlib/AMBuilder
+++ b/third_party/zlib/AMBuilder
@@ -1,7 +1,7 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os
 
-library = builder.compiler.StaticLibrary('z')
+library = builder.cxx.StaticLibrary('z')
 library.compiler.includes += [
   os.path.join(builder.currentSourcePath, '..', 'third_party'),
 ]

--- a/tools/testing/Testing.ambuild
+++ b/tools/testing/Testing.ambuild
@@ -28,7 +28,7 @@ Scripts = [
 ]
 
 def fixup_path(mode, path):
-  if builder.target_platform == 'windows':
+  if builder.target.platform == 'windows':
     if mode == '.sh':
       return path.replace('\\', '\\\\')
   return path

--- a/vm/AMBuilder
+++ b/vm/AMBuilder
@@ -11,23 +11,23 @@ Includes = [
   os.path.join(builder.sourcePath, 'sourcepawn', 'include'),
 ]
 
-if builder.compiler.like('gcc'):
-  builder.compiler.cflags += [
+if builder.cxx.like('gcc'):
+  builder.cxx.cflags += [
     '-Wno-invalid-offsetof',
   ]
-  builder.compiler.cxxflags += ['-fno-rtti']
-if builder.compiler.like('clang'):
-  builder.compiler.cxxflags += [
+  builder.cxx.cxxflags += ['-fno-rtti']
+if builder.cxx.like('clang'):
+  builder.cxx.cxxflags += [
     '-Wno-implicit-exception-spec-mismatch',
   ]
-if builder.compiler.cxx.name == 'gcc':
+if builder.cxx.family == 'gcc':
   # ABI restrictions...
   builder.compiler.cxxflags += [
     '-Wno-delete-non-virtual-dtor',
   ]
 
 # Build the static library.
-library = builder.compiler.StaticLibrary('sourcepawn')
+library = builder.cxx.StaticLibrary('sourcepawn')
 library.compiler.includes += Includes
 
 library.sources += [
@@ -52,7 +52,7 @@ library.sources += [
   'runtime-helpers.cpp',
 ]
 
-has_jit = SP.arch in ['x86'] and builder.compiler.cxx.name != 'emscripten'
+has_jit = SP.arch in ['x86'] and builder.cxx.family != 'emscripten'
 
 if has_jit:
   library.sources += [
@@ -82,7 +82,7 @@ dll.sources += [
   'dll_exports.cpp'
 ]
 
-if builder.target_platform == 'linux':
+if builder.target.platform == 'linux':
   dll.compiler.postlink += ['-lpthread', '-lrt']
 
 SP.libsourcepawn = builder.Add(dll)
@@ -96,7 +96,7 @@ def configure_like_shell(name):
   ]
   if prog.compiler.like('gcc'):
     prog.compiler.linkflags += ['-lstdc++']
-  if builder.target_platform == 'linux':
+  if builder.target.platform == 'linux':
     prog.compiler.postlink += ['-lpthread', '-lrt']
   return prog
 


### PR DESCRIPTION
While attempting to port the SourceMod build scripts to the 2.1 API for the 64-bit port, I realized this needed to be switched first.