### PR TITLE
Treat OP_PROC as metadata instead of an opcode.

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -44,6 +44,9 @@ class Config(object):
 
       cxx.cxxflags += ['-std=c++11']
 
+      if builder.options.debug == '1':
+          cxx.cflags += ['-g3']
+
       have_gcc = cxx.family is 'gcc'
       have_clang = cxx.family is 'clang' or cxx.family is 'emscripten'
       if have_clang or have_gcc:
@@ -172,6 +175,9 @@ class Config(object):
 
     cxx.defines += ['KE_THREADSAFE']
     cxx.defines += ['SOURCEPAWN_VERSION="1.9"']
+
+    if getattr(builder.options, 'enable_spew', False):
+      cxx.defines += ['JIT_SPEW']
 
     if builder.options.amtl:
       amtl_path = builder.options.amtl

--- a/configure.py
+++ b/configure.py
@@ -42,4 +42,6 @@ parser.options.add_option('--enable-optimize', action='store_const', const='1', 
 parser.options.add_option('--amtl', type='string', dest='amtl', default=None, help='Custom AMTL path')
 parser.options.add_option('--build', type='string', dest='build', default='all', 
                        help='Build which components (all, spcomp, vm, exp, test, core)')
+parser.options.add_option('--enable-spew', action='store_true', default=False, dest='enable_spew',
+		                   help='Enable debug spew')
 parser.Configure()

--- a/vm/interpreter.cpp
+++ b/vm/interpreter.cpp
@@ -60,7 +60,9 @@ Interpreter::run()
   InterpInvokeFrame ivk(cx_, method_, reader_.cip());
   ke::SaveAndSet<InterpInvokeFrame*> enterIvk(&ivk_, &ivk);
 
-  if (!reader_.visitNext())
+  reader_.begin();
+
+  if (!cx_->pushAmxFrame())
     return false;
 
   while (!has_returned_ && reader_.more()) {
@@ -92,12 +94,6 @@ Interpreter::invokeNative(uint32_t native_index)
   ivk_->leaveNativeCall();
 
   return !env_->hasPendingException();
-}
-
-bool
-Interpreter::visitPROC()
-{
-  return cx_->pushAmxFrame();
 }
 
 bool

--- a/vm/interpreter.h
+++ b/vm/interpreter.h
@@ -62,7 +62,6 @@ class Interpreter final : public PcodeVisitor
   static bool Run(PluginContext* cx, RefPtr<MethodInfo> method, cell_t* rval);
 
  public:
-  bool visitPROC() override;
   bool visitPUSH_C(const cell_t* vals, size_t nvals) override;
   bool visitPUSH_ADR(const cell_t* offsets, size_t nvals) override;
   bool visitCALL(cell_t offset) override;

--- a/vm/jit.cpp
+++ b/vm/jit.cpp
@@ -246,8 +246,8 @@ CompilerBase::CompileFromThunk(PluginContext* cx, cell_t pcode_offs, void **addr
 #if defined JIT_SPEW
   Environment::get()->debugger()->OnDebugSpew(
       "Patching thunk to %s::%s\n",
-      runtime->Name(),
-      runtime->image()->LookupFunction(pcode_offs));
+      cx->runtime()->Name(),
+      cx->runtime()->image()->LookupFunction(pcode_offs));
 #endif
 
   *addrp = fn->GetEntryAddress();

--- a/vm/jit.cpp
+++ b/vm/jit.cpp
@@ -87,9 +87,9 @@ CompilerBase::emit()
 
   const cell_t *codeseg = reinterpret_cast<const cell_t *>(rt_->code().bytes);
 
-  if (!reader.visitNext())
-    return nullptr;
+  emitPrologue();
 
+  reader.begin();
   while (reader.more()) {
     // If we reach the end of this function, or the beginning of a new
     // procedure, then stop.

--- a/vm/jit.h
+++ b/vm/jit.h
@@ -68,6 +68,7 @@ class CompilerBase : public PcodeVisitor
  protected:
   CompiledFunction* emit();
 
+  virtual void emitPrologue() = 0;
   virtual void emitThrowPath(int err) = 0;
   virtual void emitErrorHandlers() = 0;
   virtual void emitOutOfBoundsErrorPath(OutOfBoundsErrorPath* path) = 0;

--- a/vm/opcodes.cpp
+++ b/vm/opcodes.cpp
@@ -46,7 +46,7 @@ SourcePawn::SpewOpcode(PluginRuntime *runtime, const cell_t *start, const cell_t
 {
   fprintf(stdout, "  [%05d:%04d]", cip - (cell_t *)runtime->code().bytes, cip - start);
 
-  if (*cip >= OPCODES_TOTAL) {
+  if (*cip >= OPCODES_LAST) {
     fprintf(stdout, " unknown-opcode\n");
     return;
   }
@@ -59,8 +59,6 @@ SourcePawn::SpewOpcode(PluginRuntime *runtime, const cell_t *start, const cell_t
     case OP_PUSH_ADR:
     case OP_SHL_C_PRI:
     case OP_SHL_C_ALT:
-    case OP_SHR_C_PRI:
-    case OP_SHR_C_ALT:
     case OP_ADD_C:
     case OP_SMUL_C:
     case OP_EQ_C_PRI:
@@ -95,7 +93,7 @@ SourcePawn::SpewOpcode(PluginRuntime *runtime, const cell_t *start, const cell_t
     {
       uint32_t index = cip[1];
       if (index < runtime->image()->NumNatives())
-        fprintf(stdout, "%s", runtime->NativeAt(index)->name); 
+        fprintf(stdout, "%s", runtime->GetNative(index)->name);
       if (op == OP_SYSREQ_N)
         fprintf(stdout, " ; (%d args, index %d)", cip[2], index);
       else

--- a/vm/pcode-reader.h
+++ b/vm/pcode-reader.h
@@ -43,6 +43,11 @@ class PcodeReader
     stop_at_ = reinterpret_cast<const cell_t*>(code.bytes + code.length);
   }
 
+  void begin() {
+    assert(peekOpcode() == OP_PROC);
+    readCell();
+  }
+
   // Read the next opcode, return true on success, false otherwise.
   bool visitNext() {
     OPCODE op = (OPCODE)readCell();
@@ -252,9 +257,6 @@ class PcodeReader
       cell_t amount = readCell();
       return visitor_->visitHEAP(amount);
     }
-
-    case OP_PROC:
-      return visitor_->visitPROC();
 
     case OP_RETN:
       return visitor_->visitRETN();

--- a/vm/pcode-visitor.h
+++ b/vm/pcode-visitor.h
@@ -69,7 +69,6 @@ class PcodeVisitor
   virtual bool visitPOP(PawnReg dest) = 0;
   virtual bool visitSTACK(cell_t amount) = 0;
   virtual bool visitHEAP(cell_t amount) = 0;
-  virtual bool visitPROC() = 0;
   virtual bool visitRETN() = 0;
   virtual bool visitCALL(cell_t offset) = 0;
   virtual bool visitJUMP(cell_t offset) = 0;
@@ -228,10 +227,6 @@ class IncompletePcodeVisitor : public PcodeVisitor
     return false;
   }
   virtual bool visitHEAP(cell_t amount) override {
-    assert(false);
-    return false;
-  }
-  virtual bool visitPROC() override {
     assert(false);
     return false;
   }

--- a/vm/x86/jit_x86.cpp
+++ b/vm/x86/jit_x86.cpp
@@ -217,8 +217,8 @@ Compiler::visitSUB_ALT()
   return true;
 }
 
-bool
-Compiler::visitPROC()
+void
+Compiler::emitPrologue()
 {
   __ enterFrame(JitFrameType::Scripted, pcode_start_);
 
@@ -232,7 +232,6 @@ Compiler::visitPROC()
   __ movl(frm, stk);
   __ subl(tmp, dat);
   __ movl(Operand(frmAddr()), tmp);
-  return true;
 }
 
 bool

--- a/vm/x86/jit_x86.h
+++ b/vm/x86/jit_x86.h
@@ -67,7 +67,6 @@ class Compiler : public CompilerBase
   bool visitPOP(PawnReg dest) override;
   bool visitSTACK(cell_t amount) override;
   bool visitHEAP(cell_t amount) override;
-  bool visitPROC() override;
   bool visitRETN() override;
   bool visitCALL(cell_t offset) override;
   bool visitJUMP(cell_t offset) override;
@@ -140,6 +139,7 @@ class Compiler : public CompilerBase
   bool setup(cell_t pcode_offs);
 
  private:
+  void emitPrologue() override;
   void emitThrowPath(int err) override;
   void emitErrorHandlers() override;
   void emitOutOfBoundsErrorPath(OutOfBoundsErrorPath* path) override;


### PR DESCRIPTION
Functions are required to start with OP_PROC since it pushes a frame. But it's not a real opcode - it's special-cased everywhere. This formally drops it from PcodeVisitor.