### PR TITLE
Remove the internal distinction between tags and types.

### DIFF
--- a/compiler/AMBuilder
+++ b/compiler/AMBuilder
@@ -66,6 +66,7 @@ binary.sources += [
   'scvars.cpp',
   'smx-builder.cpp',
   'sp_symhash.cpp',
+  'types.cpp',
 ]
 
 if builder.target.platform != 'windows' and not compiler.like('emscripten'):

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -592,7 +592,6 @@ typedef enum s_optmark {
 int pc_compile(int argc, char **argv);
 int pc_addconstant(const char *name,cell value,int tag);
 int pc_addtag(const char *name);
-int pc_addtag_flags(const char *name, int flags);
 int pc_findtag(const char *name);
 int pc_enablewarning(int number,int enable);
 const char *pc_tagname(int tag);

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -583,15 +583,6 @@ typedef enum s_optmark {
 
 #define suSLEEP_INSTR 0x01      /* the "sleep" instruction was used */
 
-#define FIXEDTAG     0x40000000
-#define FUNCTAG      0x20000000
-#define OBJECTTAG    0x10000000
-#define ENUMTAG      0x08000000
-#define METHODMAPTAG 0x04000000
-#define STRUCTTAG    0x02000000
-#define TAGTYPEMASK   (FUNCTAG | OBJECTTAG | ENUMTAG | METHODMAPTAG | STRUCTTAG)
-#define TAGFLAGMASK   (FIXEDTAG | TAGTYPEMASK)
-#define TAGID(tag)    ((tag) & ~(TAGFLAGMASK))
 #define CELL_MAX      (((ucell)1 << (sizeof(cell)*8-1)) - 1)
 
 
@@ -603,7 +594,6 @@ int pc_addconstant(const char *name,cell value,int tag);
 int pc_addtag(const char *name);
 int pc_addtag_flags(const char *name, int flags);
 int pc_findtag(const char *name);
-constvalue *pc_tagptr(const char *name);
 int pc_enablewarning(int number,int enable);
 const char *pc_tagname(int tag);
 int parse_decl(declinfo_t *decl, int flags);
@@ -650,7 +640,6 @@ constvalue *append_constval(constvalue *table,const char *name,cell val,int inde
 constvalue *find_constval(constvalue *table,char *name,int index);
 void delete_consttable(constvalue *table);
 symbol *add_constant(const char *name,cell val,int vclass,int tag);
-constvalue *find_tag_byval(int tag);
 int get_actual_compound(symbol *sym);
 
 /* function prototypes in SC2.C */
@@ -880,7 +869,6 @@ extern symbol glbtab;       /* global symbol table */
 extern cell *litq;          /* the literal queue */
 extern unsigned char pline[]; /* the line read from the input file */
 extern const unsigned char *lptr;/* points to the current position in "pline" */
-extern constvalue tagname_tab;/* tagname table */
 extern constvalue libname_tab;/* library table (#pragma library "..." syntax) */
 extern constvalue *curlibrary;/* current library */
 extern int pc_addlibtable;  /* is the library table added to the AMX file? */

--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -492,7 +492,7 @@ cleanup:
   delete_sourcefiletable();
   delete_inputfiletable();
   delete_dbgstringtable();
-  gTypes.reset();
+  gTypes.clear();
   funcenums_free();
   methodmaps_free();
   pstructs_free();
@@ -2739,7 +2739,7 @@ static int parse_new_typename(const token_t *tok)
       } else if (tag != pc_anytag) {
         // Perform some basic filters so we can start narrowing down what can
         // be used as a type.
-        if (!gTypes.find(tag)->isDefinedType())
+        if (!gTypes.find(tag)->isLikelyDefinedType())
           error(139, tok->str);
       }
       return tag;
@@ -3868,8 +3868,12 @@ static void dotypedef()
     return;
 
   Type* prev_type = gTypes.find(ident.name);
-  if (prev_type && !prev_type->isFunction())
+  if (prev_type &&
+      prev_type->isDefinedType() &&
+      !prev_type->isFunction())
+  {
     error(94);
+  }
 
   needtoken('=');
 
@@ -3888,8 +3892,12 @@ static void dotypeset()
     return;
 
   Type* prev_type = gTypes.find(ident.name);
-  if (prev_type && !prev_type->isFunction())
+  if (prev_type &&
+      prev_type->isDefinedType() &&
+      !prev_type->isFunction())
+  {
     error(94);
+  }
 
   funcenum_t *def = funcenums_add(ident.name);
   needtoken('{');

--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -1150,16 +1150,6 @@ static void setconstants(void)
 
   gTypes.init();
 
-  pc_anytag = gTypes.defineAny()->value();
-  pc_functag = gTypes.defineFunction("Function")->value();
-  pc_tag_string = gTypes.defineString()->value();
-  sc_rationaltag = gTypes.defineFloat()->value();
-  pc_tag_void = gTypes.defineVoid()->value();
-  pc_tag_object = gTypes.defineObject("object")->value();
-  pc_tag_bool = gTypes.defineBool()->value();
-  pc_tag_null_t = gTypes.defineObject("null_t")->value();
-  pc_tag_nullfunc_t = gTypes.defineObject("nullfunc_t")->value();
-
   add_constant("true",1,sGLOBAL,1);     /* boolean flags */
   add_constant("false",0,sGLOBAL,1);
   add_constant("EOS",0,sGLOBAL,0);      /* End Of String, or '\0' */
@@ -2749,7 +2739,7 @@ static int parse_new_typename(const token_t *tok)
       } else if (tag != pc_anytag) {
         // Perform some basic filters so we can start narrowing down what can
         // be used as a type.
-        if (!(tag & TAGTYPEMASK))
+        if (!gTypes.find(tag)->isDefinedType())
           error(139, tok->str);
       }
       return tag;
@@ -3883,8 +3873,8 @@ static void dotypedef()
   if (!needsymbol(&ident))
     return;
 
-  int prev_tag = pc_findtag(ident.name);
-  if (prev_tag != -1 && !(prev_tag & FUNCTAG))
+  Type* prev_type = gTypes.find(ident.name);
+  if (prev_type && !prev_type->isFunction())
     error(94);
 
   needtoken('=');
@@ -3903,8 +3893,8 @@ static void dotypeset()
   if (!needsymbol(&ident))
     return;
 
-  int prev_tag = pc_findtag(ident.name);
-  if (prev_tag != -1 && !(prev_tag & FUNCTAG))
+  Type* prev_type = gTypes.find(ident.name);
+  if (prev_type && !prev_type->isFunction())
     error(94);
 
   funcenum_t *def = funcenums_add(ident.name);

--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -3536,8 +3536,7 @@ static void declare_handle_intrinsics()
     return;
   }
 
-  int tag = gTypes.defineMethodmap("Handle")->value();
-  methodmap_t *map = methodmap_add(nullptr, Layout_MethodMap, "Handle", tag);
+  methodmap_t *map = methodmap_add(nullptr, Layout_MethodMap, "Handle");
   map->nullable = true;
 
   declare_methodmap_symbol(map, true);
@@ -3618,12 +3617,7 @@ static void domethodmap(LayoutSpec spec)
     }
   }
 
-  int tag = 0;
-  if (spec == Layout_MethodMap)
-    tag = gTypes.defineMethodmap(mapname)->value();
-  else
-    tag = gTypes.defineObject(mapname)->value();
-  methodmap_t *map = methodmap_add(parent, spec, mapname, tag);
+  methodmap_t *map = methodmap_add(parent, spec, mapname);
 
   if (old_nullable)
     map->keyword_nullable = old_nullable;
@@ -3724,7 +3718,7 @@ static void dodelete()
     return;
   }
 
-  methodmap_t *map = methodmap_find_by_tag(sval.val.tag);
+  methodmap_t *map = gTypes.find(sval.val.tag)->asMethodmap();
   if (!map) {
     error(115, "type", pc_tagname(sval.val.tag));
     return;
@@ -4263,7 +4257,7 @@ static void decl_enum(int vclass)
 // seen later than another instance of a tag.
 static int compare_tag(int tag1, int tag2)
 {
-  return (tag1 & (~METHODMAPTAG)) == (tag2 & (~METHODMAPTAG));
+  return gTypes.find(tag1) == gTypes.find(tag2);
 }
 
 /*

--- a/compiler/sc2.cpp
+++ b/compiler/sc2.cpp
@@ -36,6 +36,7 @@
   #include "sclinux.h"
 #endif
 #include "sp_symhash.h"
+#include "types.h"
 
 #if defined FORTIFY
   #include <alloc/fortify.h>
@@ -2177,7 +2178,7 @@ int lex(cell *lexvalue,char **lexsym)
       if (sc_allowtags) {
         tok->id = tLABEL; /* it wasn't a normal symbol, it was a label/tagname */
         lptr+=1;        /* skip colon */
-      } else if (find_constval(&tagname_tab,tok->str,0)!=NULL) {
+      } else if (gTypes.find(tok->str)) {
         /* this looks like a tag override (because a tag with this name
          * exists), but tags are not allowed right now, so it is probably an
          * error

--- a/compiler/sc3.cpp
+++ b/compiler/sc3.cpp
@@ -391,7 +391,7 @@ static int matchobjecttags(Type* formal, Type* actual, int flags)
 
     // Some methodmaps are nullable. The nullable property is inherited
     // automatically.
-    methodmap_t *map = methodmap_find_by_tag(formaltag);
+    methodmap_t *map = formal->asMethodmap();
     if (map && map->nullable)
       return TRUE;
 
@@ -409,7 +409,7 @@ static int matchobjecttags(Type* formal, Type* actual, int flags)
   if (flags & MATCHTAG_COERCE)
     return obj_typeerror(134, formaltag, actualtag);
 
-  methodmap_t *map = methodmap_find_by_tag(actualtag);
+  methodmap_t *map = actual->asMethodmap();
   for (; map; map = map->parent) {
     if (map->tag == formaltag)
       return TRUE;
@@ -568,10 +568,9 @@ int matchtag(int formaltag, int actualtag, int flags)
   if (flags & (MATCHTAG_COERCE|MATCHTAG_DEDUCE)) {
     // See if the tag has a methodmap associated with it. If so, see if the given
     // tag is anywhere on the inheritance chain.
-    methodmap_t *map = methodmap_find_by_tag(actualtag);
-    if (map) {
+    if (methodmap_t *map = actual->asMethodmap()) {
       for (; map; map = map->parent) {
-        if (map->tag == formaltag)
+        if (gTypes.find(map->tag) == formal)
           return TRUE;
       }
     }
@@ -1995,8 +1994,8 @@ field_expression(svalue &thisval, value *lval, symbol **target, methodmap_method
     return FER_CallFunction;
   }
 
-  methodmap_t *map;
-  if ((map = methodmap_find_by_tag(thisval.val.tag)) == NULL) {
+  methodmap_t *map = gTypes.find(thisval.val.tag)->asMethodmap();
+  if (!map) {
     error(104, pc_tagname(thisval.val.tag));
     return FER_Fail;
   }

--- a/compiler/sc3.cpp
+++ b/compiler/sc3.cpp
@@ -30,6 +30,7 @@
 #endif
 #include "sc.h"
 #include "sctracker.h"
+#include "types.h"
 
 static int skim(int *opstr,void (*testfunc)(int),int dropval,int endval,
                 int (*hier)(value*),value *lval);
@@ -1773,8 +1774,8 @@ static int hier2(value *lval)
     if (tok!=tSYMBOL && tok!=tLABEL)
       return error(20,st);      /* illegal symbol name */
     if (tok==tLABEL) {
-      constvalue *tagsym=find_constval(&tagname_tab,st,0);
-      tag=(int)((tagsym!=NULL) ? tagsym->value : 0);
+      Type* type = gTypes.find(st);
+      tag = type ? type->value() : 0;
     } else {
       sym=findloc(st);
       if (sym==NULL)

--- a/compiler/sc3.cpp
+++ b/compiler/sc3.cpp
@@ -521,8 +521,10 @@ int matchtag(int formaltag, int actualtag, int flags)
   if (formaltag == actualtag)
     return TRUE;
 
+  Type* actual = gTypes.find(actualtag);
+
   if (formaltag == pc_tag_string && actualtag == 0)
-	return TRUE;
+    return TRUE;
 
   if ((formaltag & OBJECTTAG) || (actualtag & OBJECTTAG))
     return matchobjecttags(formaltag, actualtag, flags);
@@ -536,8 +538,12 @@ int matchtag(int formaltag, int actualtag, int flags)
   /* if the formal tag is zero and the actual tag is not "fixed", the actual
    * tag is "coerced" to zero
    */
-  if ((flags & MATCHTAG_COERCE) && !formaltag && !(actualtag & FIXEDTAG))
+  if ((flags & MATCHTAG_COERCE) &&
+      !formaltag &&
+      actual && !actual->isFixed())
+  {
     return TRUE;
+  }
 
   if (formaltag == pc_anytag || actualtag == pc_anytag)
     return TRUE;

--- a/compiler/sc3.cpp
+++ b/compiler/sc3.cpp
@@ -359,8 +359,8 @@ static int obj_typeerror(int id, int tag1, int tag2)
 
 static int matchobjecttags(Type* formal, Type* actual, int flags)
 {
-  int formaltag = formal->value();
-  int actualtag = actual->value();
+  int formaltag = formal->tagid();
+  int actualtag = actual->tagid();
 
   if ((flags & MATCHTAG_COMMUTATIVE) &&
       (formaltag == pc_tag_null_t || formaltag == pc_tag_nullfunc_t))
@@ -495,8 +495,8 @@ static int functag_compare(const functag_t *formal, const functag_t *actual)
 
 static int matchfunctags(Type* formal, Type* actual)
 {
-  int formaltag = formal->value();
-  int actualtag = actual->value();
+  int formaltag = formal->tagid();
+  int actualtag = actual->tagid();
 
   if (formaltag == pc_functag && actual->isFunction())
     return TRUE;
@@ -570,7 +570,7 @@ int matchtag(int formaltag, int actualtag, int flags)
     // tag is anywhere on the inheritance chain.
     if (methodmap_t *map = actual->asMethodmap()) {
       for (; map; map = map->parent) {
-        if (gTypes.find(map->tag) == formal)
+        if (map->tag == formaltag)
           return TRUE;
       }
     }
@@ -1793,7 +1793,7 @@ static int hier2(value *lval)
       return error(20,st);      /* illegal symbol name */
     if (tok==tLABEL) {
       Type* type = gTypes.find(st);
-      tag = type ? type->value() : 0;
+      tag = type ? type->tagid() : 0;
     } else {
       sym=findloc(st);
       if (sym==NULL)

--- a/compiler/sc6.cpp
+++ b/compiler/sc6.cpp
@@ -747,7 +747,7 @@ static void append_debug_tables(SmxBuilder *builder, StringPool &pool, RefPtr<Sm
     assert(strlen(type->name())>0);
 
     sp_file_tag_t &tag = tags->add();
-    tag.tag_id = type->value();
+    tag.tag_id = type->smx_export_value();
     tag.name = names->add(pool, type->name());
   });
 

--- a/compiler/sc6.cpp
+++ b/compiler/sc6.cpp
@@ -42,6 +42,7 @@
 #include <zlib/zlib.h>
 #include "smx-builder.h"
 #include "memory-buffer.h"
+#include "types.h"
 
 using namespace sp;
 using namespace ke;
@@ -742,13 +743,13 @@ static void append_debug_tables(SmxBuilder *builder, StringPool &pool, RefPtr<Sm
   }
 
   // Build the tags table.
-  for (constvalue *constptr = tagname_tab.next; constptr; constptr = constptr->next) {
-    assert(strlen(constptr->name)>0);
+  gTypes.forEachType([&](Type* type) -> void {
+    assert(strlen(type->name())>0);
 
     sp_file_tag_t &tag = tags->add();
-    tag.tag_id = constptr->value;
-    tag.name = names->add(pool, constptr->name);
-  }
+    tag.tag_id = type->value();
+    tag.name = names->add(pool, type->name());
+  });
 
   // Finish up debug header statistics.
   info->header().num_files = files->count();

--- a/compiler/sctracker.cpp
+++ b/compiler/sctracker.cpp
@@ -157,7 +157,7 @@ funcenum_t *funcenums_add(const char *name)
   }
 
   strcpy(e->name, name);
-  e->tag = pc_addtag_flags((char *)name, FIXEDTAG|FUNCTAG);
+  e->tag = gTypes.defineFunction(name)->value();
 
   return e;
 }

--- a/compiler/sctracker.cpp
+++ b/compiler/sctracker.cpp
@@ -452,14 +452,12 @@ void resetheaplist()
 methodmap_t*
 methodmap_add(methodmap_t* parent,
               LayoutSpec spec,
-              const char* name,
-              int tag)
+              const char* name)
 {
   methodmap_t *map = (methodmap_t *)calloc(1, sizeof(methodmap_t));
   map->parent = parent;
   map->spec = spec;
   strcpy(map->name, name);
-  map->tag = tag;
 
   if (spec == Layout_MethodMap && parent) {
     if (parent->nullable)
@@ -475,17 +473,17 @@ methodmap_add(methodmap_t* parent,
     methodmap_last->next = map;
     methodmap_last = map;
   }
+
+  if (spec == Layout_MethodMap)
+    map->tag = gTypes.defineMethodmap(name, map)->value();
+  else
+    map->tag = gTypes.defineObject(name)->value();
   return map;
 }
 
 methodmap_t *methodmap_find_by_tag(int tag)
 {
-  methodmap_t *ptr = methodmap_first;
-  for (; ptr; ptr = ptr->next) {
-    if (ptr->tag == tag)
-      return ptr;
-  }
-  return NULL;
+  return gTypes.find(tag)->asMethodmap();
 }
 
 methodmap_t *methodmap_find_by_name(const char *name)

--- a/compiler/sctracker.cpp
+++ b/compiler/sctracker.cpp
@@ -144,7 +144,7 @@ funcenum_t *funcenums_add(const char *name)
   }
 
   strcpy(e->name, name);
-  e->tag = gTypes.defineFunction(name, e)->value();
+  e->tag = gTypes.defineFunction(name, e)->tagid();
 
   return e;
 }
@@ -475,9 +475,9 @@ methodmap_add(methodmap_t* parent,
   }
 
   if (spec == Layout_MethodMap)
-    map->tag = gTypes.defineMethodmap(name, map)->value();
+    map->tag = gTypes.defineMethodmap(name, map)->tagid();
   else
-    map->tag = gTypes.defineObject(name)->value();
+    map->tag = gTypes.defineObject(name)->tagid();
   return map;
 }
 

--- a/compiler/sctracker.cpp
+++ b/compiler/sctracker.cpp
@@ -5,6 +5,7 @@
 #include <stdarg.h>
 #include "sc.h"
 #include "sctracker.h"
+#include "types.h"
 
 memuse_list_t *heapusage = NULL;
 memuse_list_t *stackusage = NULL;

--- a/compiler/sctracker.h
+++ b/compiler/sctracker.h
@@ -182,9 +182,7 @@ void resetheaplist();
  */
 methodmap_t* methodmap_add(methodmap_t* parent,
                            LayoutSpec spec,
-                           const char* name,
-                           int tag);
-methodmap_t *methodmap_find_by_tag(int tag);
+                           const char* name);
 methodmap_t *methodmap_find_by_name(const char *name);
 methodmap_method_t *methodmap_find_method(methodmap_t *map, const char *name);
 void methodmap_add_method(methodmap_t* map, methodmap_method_t* method);

--- a/compiler/sctracker.h
+++ b/compiler/sctracker.h
@@ -38,14 +38,14 @@ typedef struct functag_s
   struct functag_s *next;
 } functag_t;
 
-typedef struct funcenum_s
+struct funcenum_t
 {
   int tag;
   char name[METHOD_NAMEMAX+1];
   functag_t *first;
   functag_t *last;
-  struct funcenum_s *next;
-} funcenum_t;
+  funcenum_t *next;
+};
 
 typedef struct structarg_s
 {
@@ -137,7 +137,6 @@ structarg_t *pstructs_getarg(pstruct_t *pstruct, const char *member);
  */
 void funcenums_free();
 funcenum_t *funcenums_add(const char *name);
-funcenum_t *funcenums_find_by_tag(int tag);
 functag_t *functags_add(funcenum_t *en, functag_t *src);
 funcenum_t *funcenum_for_symbol(symbol *sym);
 functag_t *functag_find_intrinsic(int tag);

--- a/compiler/sctracker.h
+++ b/compiler/sctracker.h
@@ -59,13 +59,13 @@ typedef struct structarg_s
   int index;
 } structarg_t;
 
-typedef struct pstruct_s
+struct pstruct_t
 {
   int argcount;
   char name[sNAMEMAX+1];
   structarg_t **args;
-  struct pstruct_s *next;
-} pstruct_t;
+  pstruct_t *next;
+};
 
 // The ordering of these definitions should be preserved for
 // can_redef_layout_spec().

--- a/compiler/types.cpp
+++ b/compiler/types.cpp
@@ -25,6 +25,7 @@
  */
 #include "types.h"
 #include "sc.h"
+#include <ctype.h>
 
 using namespace ke;
 
@@ -107,4 +108,78 @@ TypeDictionary::init()
 
   type = findOrAdd("bool", 0);
   assert(type->value() == 1);
+}
+
+Type*
+TypeDictionary::defineAny()
+{
+  return findOrAdd("any", 0);
+}
+
+Type*
+TypeDictionary::defineFunction(const char* name)
+{
+  return findOrAdd(name, FIXEDTAG|FUNCTAG);
+}
+
+Type*
+TypeDictionary::defineString()
+{
+  return findOrAdd("String", FIXEDTAG);
+}
+
+Type*
+TypeDictionary::defineFloat()
+{
+  return findOrAdd("Float", FIXEDTAG);
+}
+
+Type*
+TypeDictionary::defineVoid()
+{
+  return findOrAdd("void", FIXEDTAG);
+}
+
+Type*
+TypeDictionary::defineObject(const char* name)
+{
+  return findOrAdd(name, FIXEDTAG|OBJECTTAG);
+}
+
+Type*
+TypeDictionary::defineBool()
+{
+  return findOrAdd("bool", 0);
+}
+
+Type*
+TypeDictionary::defineMethodmap(const char* name)
+{
+  return findOrAdd(name, FIXEDTAG|METHODMAPTAG);
+}
+
+Type*
+TypeDictionary::defineEnumTag(const char* name)
+{
+  int flags = ENUMTAG;
+  if (isupper(*name))
+    flags |= FIXEDTAG;
+  return findOrAdd(name, flags);
+}
+
+Type*
+TypeDictionary::defineTag(const char* name)
+{
+  int flags = 0;
+  if (isupper(*name))
+    flags |= FIXEDTAG;
+  return findOrAdd(name, flags);
+}
+
+Type*
+TypeDictionary::definePStruct(const char* name, pstruct_t* ps)
+{
+  Type* type = findOrAdd(name, FIXEDTAG);
+  type->setStruct(ps);
+  return type;
 }

--- a/compiler/types.cpp
+++ b/compiler/types.cpp
@@ -36,6 +36,7 @@ Type::Type(const char* name, cell value)
    value_(value),
    fixed_(0),
    intrinsic_(false),
+   was_defined_(false),
    kind_(TypeKind::None)
 {
   private_ptr_ = nullptr;
@@ -51,22 +52,8 @@ Type::resetPtr()
   if (intrinsic_)
     return;
 
-  // We preserve funcenums across compilations, but not the private ptr,
-  // since dotypedef() and dotypeset() want to check that the type
-  // wasn't previously defined as something else.
-  //
-  // Enums are also a special case, since they can be implicitly defined
-  // before they are used. This is ancient cruft that results from the
-  // 2-pass model, where initially errors are ignored. Similarly,
-  // methodmaps are protected since they are actually enums.
-  switch (kind_) {
-  case TypeKind::Function:
-  case TypeKind::Enum:
-  case TypeKind::Methodmap:
-    break;
-  default:
-    kind_ = TypeKind::None;
-  }
+  was_defined_ |= isLikelyDefinedType();
+  kind_ = TypeKind::None;
   private_ptr_ = nullptr;
 }
 
@@ -107,7 +94,7 @@ TypeDictionary::findOrAdd(const char* name)
 }
 
 void
-TypeDictionary::reset()
+TypeDictionary::clear()
 {
   types_.clear();
 }

--- a/compiler/types.cpp
+++ b/compiler/types.cpp
@@ -1,0 +1,102 @@
+/* vim: set sts=2 ts=8 sw=2 tw=99 et: */
+/*  Pawn compiler
+ *
+ *  Function and variable definition and declaration, statement parser.
+ *
+ *  Copyright (c) ITB CompuPhase, 1997-2006
+ *
+ *  This software is provided "as-is", without any express or implied warranty.
+ *  In no event will the authors be held liable for any damages arising from
+ *  the use of this software.
+ *
+ *  Permission is granted to anyone to use this software for any purpose,
+ *  including commercial applications, and to alter it and redistribute it
+ *  freely, subject to the following restrictions:
+ *
+ *  1.  The origin of this software must not be misrepresented; you must not
+ *      claim that you wrote the original software. If you use this software in
+ *      a product, an acknowledgment in the product documentation would be
+ *      appreciated but is not required.
+ *  2.  Altered source versions must be plainly marked as such, and must not be
+ *      misrepresented as being the original software.
+ *  3.  This notice may not be removed or altered from any source distribution.
+ *
+ *  Version: $Id$
+ */
+#include "types.h"
+#include "sc.h"
+
+using namespace ke;
+
+TypeDictionary gTypes;
+
+Type::Type(const char* name, cell value)
+ : name_(name),
+   value_(value)
+{
+}
+
+Type*
+TypeDictionary::find(const char* name)
+{
+  for (const auto& type : types_) {
+    if (strcmp(type->name(), name) == 0)
+      return type.get();
+  }
+  return nullptr;
+}
+
+Type*
+TypeDictionary::find(int tag)
+{
+  for (const auto& type : types_) {
+    if (type->tagid() == TAGID(tag))
+      return type.get();
+  }
+  return nullptr;
+}
+
+Type*
+TypeDictionary::findByValue(int tag)
+{
+  for (const auto& type : types_) {
+    if (type->value() == tag)
+      return type.get();
+  }
+  return nullptr;
+}
+
+Type*
+TypeDictionary::findOrAdd(const char* name, int flags)
+{
+  int last = 0;
+  for (const auto& type : types_) {
+    if (strcmp(type->name(), name) == 0) {
+      type->value() |= flags;
+      return type.get();
+    }
+    if (type->tagid() > last)
+      last = type->tagid();
+  }
+
+  int tag = (last + 1) | flags;
+  UniquePtr<Type> type = MakeUnique<Type>(name, tag);
+  types_.append(Move(type));
+  return types_.back().get();
+}
+
+void
+TypeDictionary::reset()
+{
+  types_.clear();
+}
+
+void
+TypeDictionary::init()
+{
+  UniquePtr<Type> intType = MakeUnique<Type>("_", 0);
+  types_.append(Move(intType));
+
+  Type* type = findOrAdd("bool", 0);
+  assert(type->value() == 1);
+}

--- a/compiler/types.cpp
+++ b/compiler/types.cpp
@@ -87,20 +87,9 @@ TypeDictionary::find(const char* name)
 Type*
 TypeDictionary::find(int tag)
 {
-  int index = TAGID(tag);
-  assert(size_t(index) < types_.length());
+  assert(size_t(tag) < types_.length());
 
-  return types_[index].get();
-}
-
-Type*
-TypeDictionary::findByValue(int tag)
-{
-  int tagid = TAGID(tag);
-  Type* type = find(tagid);
-  if (type && type->value() == tag)
-    return type;
-  return nullptr;
+  return types_[tag].get();
 }
 
 Type*
@@ -134,20 +123,20 @@ void
 TypeDictionary::init()
 {
   Type* type = findOrAdd("_");
-  assert(type->value() == 0);
+  assert(type->tagid() == 0);
 
   type = findOrAdd("bool");
-  assert(type->value() == 1);
+  assert(type->tagid() == 1);
 
-  pc_anytag = defineAny()->value();
-  pc_functag = defineFunction("Function", nullptr)->value();
-  pc_tag_string = defineString()->value();
-  sc_rationaltag = defineFloat()->value();
-  pc_tag_void = defineVoid()->value();
-  pc_tag_object = defineObject("object")->value();
-  pc_tag_bool = defineBool()->value();
-  pc_tag_null_t = defineObject("null_t")->value();
-  pc_tag_nullfunc_t = defineObject("nullfunc_t")->value();
+  pc_anytag = defineAny()->tagid();
+  pc_functag = defineFunction("Function", nullptr)->tagid();
+  pc_tag_string = defineString()->tagid();
+  sc_rationaltag = defineFloat()->tagid();
+  pc_tag_void = defineVoid()->tagid();
+  pc_tag_object = defineObject("object")->tagid();
+  pc_tag_bool = defineBool()->tagid();
+  pc_tag_null_t = defineObject("null_t")->tagid();
+  pc_tag_nullfunc_t = defineObject("nullfunc_t")->tagid();
 
   for (const auto& type : types_)
     type->setIntrinsic();

--- a/compiler/types.cpp
+++ b/compiler/types.cpp
@@ -32,7 +32,8 @@ TypeDictionary gTypes;
 
 Type::Type(const char* name, cell value)
  : name_(name),
-   value_(value)
+   value_(value),
+   kind_(TypeKind::None)
 {
 }
 
@@ -89,6 +90,13 @@ void
 TypeDictionary::reset()
 {
   types_.clear();
+}
+
+void
+TypeDictionary::clearExtendedTypes()
+{
+  for (const auto& type : types_)
+    type->resetPtr();
 }
 
 void

--- a/compiler/types.cpp
+++ b/compiler/types.cpp
@@ -34,6 +34,7 @@ TypeDictionary gTypes;
 Type::Type(const char* name, cell value)
  : name_(name),
    value_(value),
+   fixed_(0),
    kind_(TypeKind::None)
 {
 }
@@ -72,16 +73,14 @@ TypeDictionary::findByValue(int tag)
 }
 
 Type*
-TypeDictionary::findOrAdd(const char* name, int flags)
+TypeDictionary::findOrAdd(const char* name)
 {
   for (const auto& type : types_) {
-    if (strcmp(type->name(), name) == 0) {
-      type->value() |= flags;
+    if (strcmp(type->name(), name) == 0)
       return type.get();
-    }
   }
 
-  int tag = int(types_.length()) | flags;
+  int tag = int(types_.length());
   UniquePtr<Type> type = MakeUnique<Type>(name, tag);
   types_.append(Move(type));
   return types_.back().get();
@@ -103,83 +102,96 @@ TypeDictionary::clearExtendedTypes()
 void
 TypeDictionary::init()
 {
-  Type* type = findOrAdd("_", 0);
+  Type* type = findOrAdd("_");
   assert(type->value() == 0);
 
-  type = findOrAdd("bool", 0);
+  type = findOrAdd("bool");
   assert(type->value() == 1);
 }
 
 Type*
 TypeDictionary::defineAny()
 {
-  return findOrAdd("any", 0);
+  return findOrAdd("any");
 }
 
 Type*
 TypeDictionary::defineFunction(const char* name)
 {
-  return findOrAdd(name, FIXEDTAG|FUNCTAG);
+  Type* type = findOrAdd(name);
+  type->setFunction();
+  return type;
 }
 
 Type*
 TypeDictionary::defineString()
 {
-  return findOrAdd("String", FIXEDTAG);
+  Type* type = findOrAdd("String");
+  type->setFixed();
+  return type;
 }
 
 Type*
 TypeDictionary::defineFloat()
 {
-  return findOrAdd("Float", FIXEDTAG);
+  Type* type = findOrAdd("Float");
+  type->setFixed();
+  return type;
 }
 
 Type*
 TypeDictionary::defineVoid()
 {
-  return findOrAdd("void", FIXEDTAG);
+  Type* type = findOrAdd("void");
+  type->setFixed();
+  return type;
 }
 
 Type*
 TypeDictionary::defineObject(const char* name)
 {
-  return findOrAdd(name, FIXEDTAG|OBJECTTAG);
+  Type* type = findOrAdd(name);
+  type->setObject();
+  return type;
 }
 
 Type*
 TypeDictionary::defineBool()
 {
-  return findOrAdd("bool", 0);
+  return findOrAdd("bool");
 }
 
 Type*
 TypeDictionary::defineMethodmap(const char* name)
 {
-  return findOrAdd(name, FIXEDTAG|METHODMAPTAG);
+  Type* type = findOrAdd(name);
+  type->setMethodmap();
+  return type;
 }
 
 Type*
 TypeDictionary::defineEnumTag(const char* name)
 {
-  int flags = ENUMTAG;
+  Type* type = findOrAdd(name);
+  type->setEnumTag();
   if (isupper(*name))
-    flags |= FIXEDTAG;
-  return findOrAdd(name, flags);
+    type->setFixed();
+  return type;
 }
 
 Type*
 TypeDictionary::defineTag(const char* name)
 {
-  int flags = 0;
+  Type* type = findOrAdd(name);
   if (isupper(*name))
-    flags |= FIXEDTAG;
-  return findOrAdd(name, flags);
+    type->setFixed();
+  return type;
 }
 
 Type*
 TypeDictionary::definePStruct(const char* name, pstruct_t* ps)
 {
-  Type* type = findOrAdd(name, FIXEDTAG);
+  Type* type = findOrAdd(name);
   type->setStruct(ps);
   return type;
 }

--- a/compiler/types.cpp
+++ b/compiler/types.cpp
@@ -54,7 +54,11 @@ Type::resetPtr()
   // We preserve funcenums across compilations, but not the private ptr,
   // since dotypedef() and dotypeset() want to check that the type
   // wasn't previously defined as something else.
-  if (kind_ != TypeKind::Function)
+  //
+  // Enums are also a special case, since they can be implicitly defined
+  // before they are used. This is ancient cruft that results from the
+  // 2-pass model, where initially errors are ignored.
+  if (kind_ != TypeKind::Function && kind_ != TypeKind::Enum)
     kind_ = TypeKind::None;
   private_ptr_ = nullptr;
 }

--- a/compiler/types.cpp
+++ b/compiler/types.cpp
@@ -57,9 +57,16 @@ Type::resetPtr()
   //
   // Enums are also a special case, since they can be implicitly defined
   // before they are used. This is ancient cruft that results from the
-  // 2-pass model, where initially errors are ignored.
-  if (kind_ != TypeKind::Function && kind_ != TypeKind::Enum)
+  // 2-pass model, where initially errors are ignored. Similarly,
+  // methodmaps are protected since they are actually enums.
+  switch (kind_) {
+  case TypeKind::Function:
+  case TypeKind::Enum:
+  case TypeKind::Methodmap:
+    break;
+  default:
     kind_ = TypeKind::None;
+  }
   private_ptr_ = nullptr;
 }
 
@@ -199,10 +206,10 @@ TypeDictionary::defineBool()
 }
 
 Type*
-TypeDictionary::defineMethodmap(const char* name)
+TypeDictionary::defineMethodmap(const char* name, methodmap_t* map)
 {
   Type* type = findOrAdd(name);
-  type->setMethodmap();
+  type->setMethodmap(map);
   return type;
 }
 

--- a/compiler/types.h
+++ b/compiler/types.h
@@ -27,8 +27,8 @@
 #define _INCLUDE_SOURCEPAWN_COMPILER_TYPES_H_
 
 #include <amtl/am-string.h>
-#include <amtl/am-linkedlist.h>
 #include <amtl/am-uniqueptr.h>
+#include <amtl/am-vector.h>
 #include "amx.h"
 
 #define FIXEDTAG     0x40000000
@@ -67,6 +67,8 @@ private:
 class TypeDictionary
 {
 public:
+  TypeDictionary();
+
   Type* find(int tag);
   Type* find(const char* name);
   Type* findOrAdd(const char* name, int flags);
@@ -82,7 +84,7 @@ public:
   }
 
 private:
-  ke::LinkedList<ke::UniquePtr<Type>> types_;
+  ke::Vector<ke::UniquePtr<Type>> types_;
 };
 
 extern TypeDictionary gTypes;

--- a/compiler/types.h
+++ b/compiler/types.h
@@ -31,9 +31,8 @@
 #include <amtl/am-vector.h>
 #include "amx.h"
 
-#define ENUMTAG      0x08000000
 #define METHODMAPTAG 0x04000000
-#define TAGTYPEMASK   (0x32000000 | ENUMTAG | METHODMAPTAG)
+#define TAGTYPEMASK   (0x3A000000 | METHODMAPTAG)
 #define TAGFLAGMASK   (TAGTYPEMASK | 0x40000000)
 #define TAGID(tag)    ((tag) & ~(TAGFLAGMASK))
 
@@ -41,6 +40,7 @@ enum class TypeKind : uint32_t
 {
   None,
   Struct   = 0x02000000,
+  Enum     = 0x08000000,
   Object   = 0x10000000,
   Function = 0x20000000
 };
@@ -121,7 +121,7 @@ private:
     kind_ = TypeKind::Object;
   }
   void setEnumTag() {
-    value_ |= ENUMTAG;
+    kind_ = TypeKind::Enum;
   }
   void setStruct(pstruct_t* ptr) {
     setFixed();

--- a/compiler/types.h
+++ b/compiler/types.h
@@ -104,7 +104,6 @@ public:
 
   Type* find(int tag);
   Type* find(const char* name);
-  Type* findOrAdd(const char* name, int flags);
   Type* findByValue(int tag);
 
   void clearExtendedTypes();
@@ -112,11 +111,26 @@ public:
   void reset();
   void init();
 
+  Type* defineAny();
+  Type* defineFunction(const char* name);
+  Type* defineString();
+  Type* defineFloat();
+  Type* defineVoid();
+  Type* defineObject(const char* name);
+  Type* defineBool();
+  Type* defineMethodmap(const char* name);
+  Type* defineEnumTag(const char* name);
+  Type* defineTag(const char* name);
+  Type* definePStruct(const char* name, pstruct_t* ps);
+
   template <typename T>
   void forEachType(const T& callback) {
     for (const auto& type : types_)
       callback(type.get());
   }
+
+private:
+  Type* findOrAdd(const char* name, int flags);
 
 private:
   ke::Vector<ke::UniquePtr<Type>> types_;

--- a/compiler/types.h
+++ b/compiler/types.h
@@ -31,10 +31,9 @@
 #include <amtl/am-vector.h>
 #include "amx.h"
 
-#define OBJECTTAG    0x10000000
 #define ENUMTAG      0x08000000
 #define METHODMAPTAG 0x04000000
-#define TAGTYPEMASK   (0x20000000 | OBJECTTAG | ENUMTAG | METHODMAPTAG | 0x02000000)
+#define TAGTYPEMASK   (0x32000000 | ENUMTAG | METHODMAPTAG)
 #define TAGFLAGMASK   (TAGTYPEMASK | 0x40000000)
 #define TAGID(tag)    ((tag) & ~(TAGFLAGMASK))
 
@@ -42,6 +41,7 @@ enum class TypeKind : uint32_t
 {
   None,
   Struct   = 0x02000000,
+  Object   = 0x10000000,
   Function = 0x20000000
 };
 KE_DEFINE_ENUM_OPERATORS(TypeKind)
@@ -92,6 +92,10 @@ public:
     value_ |= METHODMAPTAG;
   }
 
+  bool isObject() const {
+    return kind_ == TypeKind::Object;
+  }
+
   bool isFunction() const {
     return kind_ == TypeKind::Function;
   }
@@ -114,7 +118,7 @@ private:
   }
   void setObject() {
     setFixed();
-    value_ |= OBJECTTAG;
+    kind_ = TypeKind::Object;
   }
   void setEnumTag() {
     value_ |= ENUMTAG;

--- a/compiler/types.h
+++ b/compiler/types.h
@@ -33,7 +33,6 @@
 
 #define TAGTYPEMASK   (0x3E000000)
 #define TAGFLAGMASK   (TAGTYPEMASK | 0x40000000)
-#define TAGID(tag)    ((tag) & ~(TAGFLAGMASK))
 
 enum class TypeKind : uint32_t
 {
@@ -63,16 +62,15 @@ public:
   TypeKind kind() const {
     return kind_;
   }
-  cell value() const {
+  cell smx_export_value() const {
     return value_ | int(kind_) | fixed_;
   }
   int tagid() const {
-    return TAGID(value_);
+    return value_;
   }
 
   bool isDefinedType() const {
-    return kind_ != TypeKind::None ||
-           (value() & TAGTYPEMASK) != 0;
+    return kind_ != TypeKind::None;
   }
 
   bool isFixed() const {
@@ -173,7 +171,6 @@ public:
 
   Type* find(int tag);
   Type* find(const char* name);
-  Type* findByValue(int tag);
 
   void clearExtendedTypes();
 

--- a/compiler/types.h
+++ b/compiler/types.h
@@ -1,0 +1,90 @@
+/* vim: set sts=2 ts=8 sw=2 tw=99 et: */
+/*  Pawn compiler
+ *
+ *  Function and variable definition and declaration, statement parser.
+ *
+ *  Copyright (c) ITB CompuPhase, 1997-2006
+ *
+ *  This software is provided "as-is", without any express or implied warranty.
+ *  In no event will the authors be held liable for any damages arising from
+ *  the use of this software.
+ *
+ *  Permission is granted to anyone to use this software for any purpose,
+ *  including commercial applications, and to alter it and redistribute it
+ *  freely, subject to the following restrictions:
+ *
+ *  1.  The origin of this software must not be misrepresented; you must not
+ *      claim that you wrote the original software. If you use this software in
+ *      a product, an acknowledgment in the product documentation would be
+ *      appreciated but is not required.
+ *  2.  Altered source versions must be plainly marked as such, and must not be
+ *      misrepresented as being the original software.
+ *  3.  This notice may not be removed or altered from any source distribution.
+ *
+ *  Version: $Id$
+ */
+#ifndef _INCLUDE_SOURCEPAWN_COMPILER_TYPES_H_
+#define _INCLUDE_SOURCEPAWN_COMPILER_TYPES_H_
+
+#include <amtl/am-string.h>
+#include <amtl/am-linkedlist.h>
+#include <amtl/am-uniqueptr.h>
+#include "amx.h"
+
+#define FIXEDTAG     0x40000000
+#define FUNCTAG      0x20000000
+#define OBJECTTAG    0x10000000
+#define ENUMTAG      0x08000000
+#define METHODMAPTAG 0x04000000
+#define STRUCTTAG    0x02000000
+#define TAGTYPEMASK   (FUNCTAG | OBJECTTAG | ENUMTAG | METHODMAPTAG | STRUCTTAG)
+#define TAGFLAGMASK   (FIXEDTAG | TAGTYPEMASK)
+#define TAGID(tag)    ((tag) & ~(TAGFLAGMASK))
+
+class Type
+{
+public:
+  Type(const char* name, cell value);
+
+  const char* name() const {
+    return name_.chars();
+  }
+  cell& value() {
+    return value_;
+  }
+  cell value() const {
+    return value_;
+  }
+  int tagid() const {
+    return TAGID(value_);
+  }
+
+private:
+  ke::AString name_;
+  cell value_;
+};
+
+class TypeDictionary
+{
+public:
+  Type* find(int tag);
+  Type* find(const char* name);
+  Type* findOrAdd(const char* name, int flags);
+  Type* findByValue(int tag);
+
+  void reset();
+  void init();
+
+  template <typename T>
+  void forEachType(const T& callback) {
+    for (const auto& type : types_)
+      callback(type.get());
+  }
+
+private:
+  ke::LinkedList<ke::UniquePtr<Type>> types_;
+};
+
+extern TypeDictionary gTypes;
+
+#endif // _INCLUDE_SOURCEPAWN_COMPILER_TYPES_H_

--- a/compiler/types.h
+++ b/compiler/types.h
@@ -69,6 +69,11 @@ public:
     return value_;
   }
 
+  // Returns true if this is, or ever was, defined as an actual type rather
+  // than an implicit tag.
+  bool isLikelyDefinedType() const {
+    return kind_ != TypeKind::None || was_defined_;
+  }
   bool isDefinedType() const {
     return kind_ != TypeKind::None;
   }
@@ -152,6 +157,7 @@ private:
   cell value_;
   int fixed_;
   bool intrinsic_;
+  bool was_defined_;
 
   // These are reset in between the first and second passes, since the
   // underlying structures are reparsed.
@@ -172,10 +178,9 @@ public:
   Type* find(int tag);
   Type* find(const char* name);
 
-  void clearExtendedTypes();
-
-  void reset();
   void init();
+  void clearExtendedTypes();
+  void clear();
 
   Type* defineAny();
   Type* defineFunction(const char* name, funcenum_t* fe);


### PR DESCRIPTION
Pawn's original tag system basically worked, but when we extended it for funcenums in SourceMod Alpha, we made a terrible mistake. We did not create a distinction between "tags" and "types". Instead, we annotated tags with a bits that denoted extended type information.

The problem with this was that internally, type information got stored on a "first-come, first-see" basis. If the name `Handle` was used before its definition, that was okay - functions just wouldn't have the definition available, because it wasn't part of the tag bits yet.

Things get weirder because of how spcomp has a two-pass system that preserves tags and global functions signatures. On the second pass, we would have seen definitions for internal types, but that information would still not be available to methods. Meanwhile methods would have a confusing view of what type the tag actually represented, since in the first pass it would have extended bits and the second pass it would not.

This also meant comparing tags was a real challenge. Code had to be very careful to strip bits. Extended type information was also scattered everywhere, resulting in secondary lookups to find critical information.

This refactoring replaces tags internally with types. The mask bits are gone, and ancillary type structures are stored directly on the Type object. Tag integers are now handles into a TypeDictionary and can be easily compared for equality.

The main complication with this approach is that some information has to be preserved across compiler passes, but some information cannot. For example, to preserve use-before-def behavior, methodmap and enum types preserve their classification, but not ancillary data. I expect bugs to be found since behavior may have changed.