### PR TITLE
More sc3.cpp cleanup.

### DIFF
--- a/compiler/AMBuilder
+++ b/compiler/AMBuilder
@@ -67,6 +67,7 @@ binary.sources += [
   'smx-builder.cpp',
   'sp_symhash.cpp',
   'types.cpp',
+  'expression-parsing.cpp',
 ]
 
 if builder.target.platform != 'windows' and not compiler.like('emscripten'):

--- a/compiler/expression-parsing.cpp
+++ b/compiler/expression-parsing.cpp
@@ -1,0 +1,112 @@
+/* vim: set ts=8 sts=2 sw=2 tw=99 et: */
+/*  Pawn compiler - Recursive descend expresion parser
+ *
+ *  Copyright (c) ITB CompuPhase, 1997-2005
+ *
+ *  This software is provided "as-is", without any express or implied warranty.
+ *  In no event will the authors be held liable for any damages arising from
+ *  the use of this software.
+ *
+ *  Permission is granted to anyone to use this software for any purpose,
+ *  including commercial applications, and to alter it and redistribute it
+ *  freely, subject to the following restrictions:
+ *
+ *  1.  The origin of this software must not be misrepresented; you must not
+ *      claim that you wrote the original software. If you use this software in
+ *      a product, an acknowledgment in the product documentation would be
+ *      appreciated but is not reeq;quired.
+ *  2.  Altered source versions must be plainly marked as such, and must not be
+ *      misrepresented as being the original software.
+ *  3.  This notice may not be removed or altered from any source distribution.
+ *
+ *  Version: $Id$
+ */
+#include "expression-parsing.h"
+#include "sc.h"
+#include <assert.h>
+#include <string.h>
+
+// The "op1" array in sc3.cpp must have the same ordering as if these lists
+// were flattened.
+int ExpressionParser::list3[]  = {'*','/','%',0};
+int ExpressionParser::list4[]  = {'+','-',0};
+int ExpressionParser::list5[]  = {tSHL,tSHR,tSHRU,0};
+int ExpressionParser::list6[]  = {'&',0};
+int ExpressionParser::list7[]  = {'^',0};
+int ExpressionParser::list8[]  = {'|',0};
+int ExpressionParser::list9[]  = {tlLE,tlGE,'<','>',0};
+int ExpressionParser::list10[] = {tlEQ,tlNE,0};
+int ExpressionParser::list11[] = {tlAND,0};
+int ExpressionParser::list12[] = {tlOR,0};
+
+ExpressionParser::ExpressionParser()
+ : bitwise_opercount_(0)
+{
+}
+
+/*
+ *  Searches for a binary operator a list of operators. The list is stored in
+ *  the array "list". The last entry in the list should be set to 0.
+ *
+ *  The index of an operator in "list" (if found) is returned in "opidx". If
+ *  no operator is found, nextop() returns 0.
+ *
+ *  If an operator is found in the expression, it cannot be used in a function
+ *  call with omitted parantheses. Mark this...
+ */
+int
+ExpressionParser::nextop(int *opidx,int *list)
+{
+  *opidx=0;
+  while (*list){
+    if (matchtoken(*list)){
+      return TRUE;      /* found! */
+    } else {
+      list+=1;
+      *opidx+=1;
+    } /* if */
+  } /* while */
+  return FALSE;         /* entire list scanned, nothing found */
+}
+
+int
+ExpressionParser::findnamedarg(arginfo *arg,char *name)
+{
+  int i;
+
+  for (i=0; arg[i].ident!=0 && arg[i].ident!=iVARARGS; i++)
+    if (strcmp(arg[i].name,name)==0)
+      return i;
+  return -1;
+}
+
+cell
+ExpressionParser::array_totalsize(symbol *sym)
+{
+  cell length;
+
+  assert(sym!=NULL);
+  assert(sym->ident==iARRAY || sym->ident==iREFARRAY);
+  length=sym->dim.array.length;
+  if (sym->dim.array.level > 0) {
+    cell sublength=array_totalsize(finddepend(sym));
+    if (sublength>0)
+      length=length+length*sublength;
+    else
+      length=0;
+  } /* if */
+  return length;
+}
+
+cell
+ExpressionParser::array_levelsize(symbol *sym,int level)
+{
+  assert(sym!=NULL);
+  assert(sym->ident==iARRAY || sym->ident==iREFARRAY);
+  assert(level <= sym->dim.array.level);
+  while (level-- > 0) {
+    sym=finddepend(sym);
+    assert(sym!=NULL);
+  } /* if */
+  return (sym->dim.array.slength ? sym->dim.array.slength : sym->dim.array.length);
+}

--- a/compiler/expression-parsing.h
+++ b/compiler/expression-parsing.h
@@ -1,0 +1,27 @@
+/* vim: set ts=8 sts=2 sw=2 tw=99 et: */
+/*  Pawn compiler - Recursive descend expresion parser
+ *
+ *  Copyright (c) ITB CompuPhase, 1997-2005
+ *
+ *  This software is provided "as-is", without any express or implied warranty.
+ *  In no event will the authors be held liable for any damages arising from
+ *  the use of this software.
+ *
+ *  Permission is granted to anyone to use this software for any purpose,
+ *  including commercial applications, and to alter it and redistribute it
+ *  freely, subject to the following restrictions:
+ *
+ *  1.  The origin of this software must not be misrepresented; you must not
+ *      claim that you wrote the original software. If you use this software in
+ *      a product, an acknowledgment in the product documentation would be
+ *      appreciated but is not reeq;quired.
+ *  2.  Altered source versions must be plainly marked as such, and must not be
+ *      misrepresented as being the original software.
+ *  3.  This notice may not be removed or altered from any source distribution.
+ *
+ *  Version: $Id$
+ */
+#ifndef am_sourcepawn_compiler_expression_parser_h
+#define am_sourcepawn_compiler_expression_parser_h
+
+#endif // am_sourcepawn_compiler_expression_parser_h

--- a/compiler/expression-parsing.h
+++ b/compiler/expression-parsing.h
@@ -24,4 +24,39 @@
 #ifndef am_sourcepawn_compiler_expression_parser_h
 #define am_sourcepawn_compiler_expression_parser_h
 
+#include "amx.h"
+
+struct arginfo;
+struct symbol;
+
+class ExpressionParser
+{
+public:
+  ExpressionParser();
+
+protected:
+  static int nextop(int *opidx,int *list);
+  static int findnamedarg(arginfo *arg,char *name);
+
+  cell array_levelsize(symbol *sym,int level);
+  cell array_totalsize(symbol *sym);
+
+  // Each of these lists is an operator precedence level, and each list is a
+  // zero-terminated list of operators in that level (in precedence order).
+  static int list3[];
+  static int list4[];
+  static int list5[];
+  static int list6[];
+  static int list7[];
+  static int list8[];
+  static int list9[];
+  static int list10[];
+  static int list11[];
+  static int list12[];
+
+protected:
+  // Count of bitwise operators in an expression.
+  int bitwise_opercount_;
+};
+
 #endif // am_sourcepawn_compiler_expression_parser_h

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -66,7 +66,7 @@ typedef union {
   int i;
 } stkitem;                  /* type of items stored on the compiler stack */
 
-typedef struct s_arginfo {  /* function argument info */
+struct arginfo {  /* function argument info */
   char name[sNAMEMAX+1];
   char ident;           /* iVARIABLE, iREFERENCE, iREFARRAY or iVARARGS */
   char usage;           /* uCONST */
@@ -85,7 +85,7 @@ typedef struct s_arginfo {  /* function argument info */
     } array;
   } defvalue;           /* default value, or pointer to default array */
   int defvalue_tag;     /* tag of the default value */
-} arginfo;
+};
 
 /*  Equate table, tagname table, library table */
 typedef struct s_constvalue {
@@ -108,9 +108,9 @@ struct methodmap_t;
  *      label           generated hexadecimal number
  *      function        offset into code segment
  */
-typedef struct s_symbol {
-  struct s_symbol *next;
-  struct s_symbol *parent;  /* hierarchical types */
+struct symbol {
+  symbol *next;
+  symbol *parent;  /* hierarchical types */
   char name[sNAMEMAX+1];
   uint32_t hash;        /* value derived from name, for quicker searching */
   cell addr_;            /* address or offset (or value for constant, index for native function) */
@@ -141,7 +141,7 @@ typedef struct s_symbol {
   } dim;                /* for 'dimension', both functions and arrays */
   int fnumber;          /* static global variables: file number in which the declaration is visible */
   int lnumber;          /* line number (in the current source file) for the declaration */
-  struct s_symbol **refer;  /* referrer list, functions that "use" this symbol */
+  symbol **refer;       /* referrer list, functions that "use" this symbol */
   int numrefers;        /* number of entries in the referrer list */
   char *documentation;  /* optional documentation string */
   methodmap_t *methodmap; /* if ident == iMETHODMAP */
@@ -153,7 +153,7 @@ typedef struct s_symbol {
   void setAddr(int addr) {
     addr_ = addr;
   }
-} symbol;
+};
 
 /*  Possible entries for "ident". These are used in the "symbol", "value"
  *  and arginfo structures. Not every constant is valid for every use.

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -238,7 +238,7 @@ typedef struct s_symbol {
 
 struct methodmap_method_s;
 
-typedef struct value_s {
+struct value {
   symbol *sym;          /* symbol in symbol table, NULL for (constant) expression */
   cell constval;        /* value of the constant expression (if ident==iCONSTEXPR)
                          * also used for the size of a literal array */
@@ -265,17 +265,17 @@ typedef struct value_s {
 
   /* when ident == iACCESSOR */
   struct methodmap_method_s *accessor;
-} value;
+};
 
 /* Wrapper around value + l/rvalue bit. */
-typedef struct svalue_s {
+struct svalue {
   value val;
   int lvalue;
 
   bool canRematerialize() const {
     return val.canRematerialize();
   }
-} svalue;
+};
 
 #define DECLFLAG_ARGUMENT        0x02 // The declaration is for an argument.
 #define DECLFLAG_VARIABLE        0x04 // The declaration is for a variable.

--- a/compiler/sc3.cpp
+++ b/compiler/sc3.cpp
@@ -604,7 +604,7 @@ int matchtag(int formaltag, int actualtag, int flags)
  *            right hand are FALSE, so endval must be 0 for "or" expressions.
  */
 int
-ExpressionParser::skim(int *opstr,void (*testfunc)(int),int dropval,int endval,
+SC3ExpressionParser::skim(int *opstr,void (*testfunc)(int),int dropval,int endval,
                        HierFn hier, value *lval)
 {
   int lvalue,hits,droplab,endlab,opidx;
@@ -715,7 +715,7 @@ static void checkfunction(value *lval)
  *  Plunge to a lower level
  */
 int
-ExpressionParser::plnge(int *opstr,int opoff,
+SC3ExpressionParser::plnge(int *opstr,int opoff,
                         HierFn hier, value *lval,
                         const char *forcetag,int chkbitwise)
 {
@@ -748,7 +748,7 @@ ExpressionParser::plnge(int *opstr,int opoff,
  *  it has special code generation sequences for chained operations.
  */
 int
-ExpressionParser::plnge_rel(int *opstr,int opoff,HierFn hier,value *lval)
+SC3ExpressionParser::plnge_rel(int *opstr,int opoff,HierFn hier,value *lval)
 {
   int lvalue,opidx;
   value lval2={0};
@@ -790,7 +790,7 @@ ExpressionParser::plnge_rel(int *opstr,int opoff,HierFn hier,value *lval)
  *  Called by: skim(), plnge(), plnge2(), plnge_rel(), hier14() and hier13()
  */
 int
-ExpressionParser::plnge1(HierFn hier, value *lval)
+SC3ExpressionParser::plnge1(HierFn hier, value *lval)
 {
   int lvalue,index;
   cell cidx;
@@ -808,7 +808,7 @@ ExpressionParser::plnge1(HierFn hier, value *lval)
  *  Called by: plnge(), plnge_rel(), hier14() and hier1()
  */
 void
-ExpressionParser::plnge2(void (*oper)(void),
+SC3ExpressionParser::plnge2(void (*oper)(void),
                          HierFn hier,
                          value *lval1,value *lval2)
 {
@@ -962,7 +962,7 @@ int lvalexpr(svalue *sval)
   errorset(sEXPRMARK, 0);
   pushheaplist();
   {
-    ExpressionParser parser;
+    SC3ExpressionParser parser;
     sval->lvalue = parser.evaluate(&sval->val);
   }
   popheaplist();
@@ -976,7 +976,7 @@ int expression(cell *val,int *tag,symbol **symptr,int chkfuncresult,value *_lval
   value lval={0};
   pushheaplist();
 
-  ExpressionParser parser;
+  SC3ExpressionParser parser;
   if (parser.evaluate(&lval))
     rvalue(&lval);
   /* scrap any arrays left on the heap */
@@ -1031,7 +1031,7 @@ static cell array_levelsize(symbol *sym,int level)
  *  Global references: sc_intest        (reffered to only)
  */
 int
-ExpressionParser::hier14(value *lval1)
+SC3ExpressionParser::hier14(value *lval1)
 {
   int lvalue;
   value lval2={0},lval3={0};
@@ -1055,7 +1055,7 @@ ExpressionParser::hier14(value *lval1)
   org_arrayidx=lval1->arrayidx; /* save current pointer, to reset later */
   if (lval1->arrayidx==NULL)
     lval1->arrayidx=arrayidx1;
-  lvalue=plnge1(&ExpressionParser::hier13,lval1);
+  lvalue=plnge1(&SC3ExpressionParser::hier13,lval1);
   if (lval1->ident!=iARRAYCELL && lval1->ident!=iARRAYCHAR)
     lval1->arrayidx=NULL;
   if (lval1->ident==iCONSTEXPR) /* load constant here */
@@ -1141,7 +1141,7 @@ ExpressionParser::hier14(value *lval1)
       rvalue(lval1);
     } /* if */
     lval2.arrayidx=arrayidx2;
-    plnge2(oper,&ExpressionParser::hier14,lval1,&lval2);
+    plnge2(oper,&SC3ExpressionParser::hier14,lval1,&lval2);
     if (lval2.ident!=iARRAYCELL && lval2.ident!=iARRAYCHAR)
       lval2.arrayidx=NULL;
     if (oper)
@@ -1160,7 +1160,7 @@ ExpressionParser::hier14(value *lval1)
     pushreg(sPRI);
     if (oper) {
       rvalue(lval1);
-      plnge2(oper,&ExpressionParser::hier14,lval1,&lval2);
+      plnge2(oper,&SC3ExpressionParser::hier14,lval1,&lval2);
     } else {
       if (hier14(&lval2))
         rvalue(&lval2);         /* instead of plnge2(). */
@@ -1172,7 +1172,7 @@ ExpressionParser::hier14(value *lval1)
   } else {
     if (oper){
       rvalue(lval1);
-      plnge2(oper,&ExpressionParser::hier14,lval1,&lval2);
+      plnge2(oper,&SC3ExpressionParser::hier14,lval1,&lval2);
     } else {
       /* if direct fetch and simple assignment: no "push"
        * and "pop" needed -> call hier14() directly, */
@@ -1334,9 +1334,9 @@ long dynarray_from_heaplist(memuse_list_t *heap)
 }
 
 int
-ExpressionParser::hier13(value *lval)
+SC3ExpressionParser::hier13(value *lval)
 {
-  int lvalue=plnge1(&ExpressionParser::hier12,lval);
+  int lvalue=plnge1(&SC3ExpressionParser::hier12,lval);
   if (matchtoken('?')) {
     int flab1=getlabel();
     int flab2=getlabel();
@@ -1425,67 +1425,67 @@ static int list11[] = {tlAND,0};
 static int list12[] = {tlOR,0};
 
 int
-ExpressionParser::hier12(value *lval)
+SC3ExpressionParser::hier12(value *lval)
 {
-  return skim(list12,jmp_ne0,1,0,&ExpressionParser::hier11,lval);
+  return skim(list12,jmp_ne0,1,0,&SC3ExpressionParser::hier11,lval);
 }
 
 int
-ExpressionParser::hier11(value *lval)
+SC3ExpressionParser::hier11(value *lval)
 {
-  return skim(list11,jmp_eq0,0,1,&ExpressionParser::hier10,lval);
+  return skim(list11,jmp_eq0,0,1,&SC3ExpressionParser::hier10,lval);
 }
 
 int
-ExpressionParser::hier10(value *lval)
+SC3ExpressionParser::hier10(value *lval)
 { /* ==, != */
-  return plnge(list10,15,&ExpressionParser::hier9,lval,"bool",TRUE);
+  return plnge(list10,15,&SC3ExpressionParser::hier9,lval,"bool",TRUE);
 }                  /* ^ this variable is the starting index in the op1[]
                     *   array of the operators of this hierarchy level */
 int
-ExpressionParser::hier9(value *lval)
+SC3ExpressionParser::hier9(value *lval)
 { /* <=, >=, <, > */
-  return plnge_rel(list9,11,&ExpressionParser::hier8,lval);
+  return plnge_rel(list9,11,&SC3ExpressionParser::hier8,lval);
 }
 
 int
-ExpressionParser::hier8(value *lval)
+SC3ExpressionParser::hier8(value *lval)
 { /* | */
-  return plnge(list8,10,&ExpressionParser::hier7,lval,NULL,FALSE);
+  return plnge(list8,10,&SC3ExpressionParser::hier7,lval,NULL,FALSE);
 }
 
 int
-ExpressionParser::hier7(value *lval)
+SC3ExpressionParser::hier7(value *lval)
 { /* ^ */
-  return plnge(list7,9,&ExpressionParser::hier6,lval,NULL,FALSE);
+  return plnge(list7,9,&SC3ExpressionParser::hier6,lval,NULL,FALSE);
 }
 
 int
-ExpressionParser::hier6(value *lval)
+SC3ExpressionParser::hier6(value *lval)
 { /* & */
-  return plnge(list6,8,&ExpressionParser::hier5,lval,NULL,FALSE);
+  return plnge(list6,8,&SC3ExpressionParser::hier5,lval,NULL,FALSE);
 }
 
 int
-ExpressionParser::hier5(value *lval)
+SC3ExpressionParser::hier5(value *lval)
 { /* <<, >>, >>> */
-  return plnge(list5,5,&ExpressionParser::hier4,lval,NULL,FALSE);
+  return plnge(list5,5,&SC3ExpressionParser::hier4,lval,NULL,FALSE);
 }
 
 int
-ExpressionParser::hier4(value *lval)
+SC3ExpressionParser::hier4(value *lval)
 { /* +, - */
-  return plnge(list4,3,&ExpressionParser::hier3,lval,NULL,FALSE);
+  return plnge(list4,3,&SC3ExpressionParser::hier3,lval,NULL,FALSE);
 }
 
 int
-ExpressionParser::hier3(value *lval)
+SC3ExpressionParser::hier3(value *lval)
 { /* *, /, % */
-  return plnge(list3,0,&ExpressionParser::hier2,lval,NULL,FALSE);
+  return plnge(list3,0,&SC3ExpressionParser::hier2,lval,NULL,FALSE);
 }
 
 int
-ExpressionParser::hier2(value *lval)
+SC3ExpressionParser::hier2(value *lval)
 {
   int lvalue,tok;
   int tag;
@@ -1782,7 +1782,7 @@ ExpressionParser::hier2(value *lval)
 }
 
 cell
-ExpressionParser::parse_defined()
+SC3ExpressionParser::parse_defined()
 {
   cell val;
   char* st;
@@ -1808,7 +1808,7 @@ ExpressionParser::parse_defined()
 }
 
 cell
-ExpressionParser::parse_sizeof()
+SC3ExpressionParser::parse_sizeof()
 {
   int paranthese=0;
   while (matchtoken('('))
@@ -1875,7 +1875,7 @@ ExpressionParser::parse_sizeof()
 }
 
 cell
-ExpressionParser::parse_cellsof()
+SC3ExpressionParser::parse_cellsof()
 {
   int paranthese=0;
   while (matchtoken('('))
@@ -1942,7 +1942,7 @@ ExpressionParser::parse_cellsof()
 }
 
 cell
-ExpressionParser::parse_tagof()
+SC3ExpressionParser::parse_tagof()
 {
   int paranthese=0;
   while (matchtoken('('))
@@ -2096,7 +2096,7 @@ field_expression(svalue &thisval, value *lval, symbol **target, methodmap_method
 }
 
 int
-ExpressionParser::parse_view_as(value* lval)
+SC3ExpressionParser::parse_view_as(value* lval)
 {
   needtoken('<');
   int tag = 0;
@@ -2145,7 +2145,7 @@ ExpressionParser::parse_view_as(value* lval)
  *  callfunction() to call the function.
  */
 int
-ExpressionParser::hier1(value *lval1)
+SC3ExpressionParser::hier1(value *lval1)
 {
   int lvalue,index,tok;
   cell val,cidx;
@@ -2475,7 +2475,7 @@ restart:
  *  Global references: sc_intest  (may be altered, but restored upon termination)
  */
 int
-ExpressionParser::primary(value *lval)
+SC3ExpressionParser::primary(value *lval)
 {
   char *st;
   int lvalue,tok;
@@ -2822,7 +2822,7 @@ class CallArgPusher
  *  and positional as well as named parameters.
  */
 void
-ExpressionParser::callfunction(symbol *sym, const svalue *aImplicitThis, value *lval_result, int matchparanthesis)
+SC3ExpressionParser::callfunction(symbol *sym, const svalue *aImplicitThis, value *lval_result, int matchparanthesis)
 {
   int close,lvalue;
   int argpos;       /* index in the output stream (argpos==nargs if positional parameters) */

--- a/compiler/sc3.h
+++ b/compiler/sc3.h
@@ -25,11 +25,12 @@
 #define am_sourcepawn_compiler_sc3_h
 
 #include "amx.h"
+#include "expression-parsing.h"
 
 struct value;
 struct svalue;
 
-class SC3ExpressionParser
+class SC3ExpressionParser : public ExpressionParser
 {
 public:
   int evaluate(value* lval) {

--- a/compiler/sc3.h
+++ b/compiler/sc3.h
@@ -21,12 +21,15 @@
  *
  *  Version: $Id$
  */
-#ifndef am_sourcepawn_compiler_expression_parser_h
-#define am_sourcepawn_compiler_expression_parser_h
+#ifndef am_sourcepawn_compiler_sc3_h
+#define am_sourcepawn_compiler_sc3_h
 
-#include "sc.h"
+#include "amx.h"
 
-class ExpressionParser
+struct value;
+struct svalue;
+
+class SC3ExpressionParser
 {
 public:
   int evaluate(value* lval) {
@@ -34,7 +37,7 @@ public:
   }
 
 private:
-  typedef int (ExpressionParser::*HierFn)(value*);
+  typedef int (SC3ExpressionParser::*HierFn)(value*);
 
   int hier14(value* lval);
   int hier13(value *lval);
@@ -68,4 +71,4 @@ private:
   cell parse_tagof();
 };
 
-#endif // am_sourcepawn_compiler_expression_parser_h
+#endif // am_sourcepawn_compiler_sc3_h


### PR DESCRIPTION
This set of patches moves sc3.cpp helpers into a separate file, so sc3.cpp "only" contains the parser.