### PR TITLE
Clean up sc5.cpp.

### DIFF
--- a/compiler/libpawnc.cpp
+++ b/compiler/libpawnc.cpp
@@ -69,7 +69,7 @@ unsigned sc_total_errors = 0;
  *    If the function returns 0, the parser attempts to continue compilation.
  *    On a non-zero return value, the parser aborts.
  */
-int pc_error(int number,const char *message,const char *filename,int firstline,int lastline,va_list argptr)
+int pc_error(int number,const char *message,const char *filename,int line,va_list argptr)
 {
 static const char *prefix[3]={ "error", "fatal error", "warning" };
 
@@ -87,10 +87,7 @@ static const char *prefix[3]={ "error", "fatal error", "warning" };
       sc_total_errors++;
 
     const char *pre=prefix[idx];
-    if (firstline>=0)
-      fprintf(stdout,"%s(%d -- %d) : %s %03d: ",filename,firstline,lastline,pre,number);
-    else
-      fprintf(stdout,"%s(%d) : %s %03d: ",filename,lastline,pre,number);
+    fprintf(stdout,"%s(%d) : %s %03d: ",filename,line,pre,number);
   } /* if */
   vfprintf(stdout,message,argptr);
   fflush(stdout);

--- a/compiler/libpawnc.cpp
+++ b/compiler/libpawnc.cpp
@@ -55,45 +55,6 @@ int pc_printf(const char *message,...)
 
 unsigned sc_total_errors = 0;
 
-/* pc_error()
- * Called for producing error output.
- *    number      the error number (as documented in the manual)
- *    message     a string describing the error with embedded %d and %s tokens
- *    filename    the name of the file currently being parsed
- *    firstline   the line number at which the expression started on which
- *                the error was found, or -1 if there is no "starting line"
- *    lastline    the line number at which the error was detected
- *    argptr      a pointer to the first of a series of arguments (for macro
- *                "va_arg")
- * Return:
- *    If the function returns 0, the parser attempts to continue compilation.
- *    On a non-zero return value, the parser aborts.
- */
-int pc_error(int number,const char *message,const char *filename,int line,va_list argptr)
-{
-static const char *prefix[3]={ "error", "fatal error", "warning" };
-
-  if (number!=0) {
-    int idx;
-
-    if (number < FIRST_FATAL_ERROR || (number >= 200 && sc_warnings_are_errors))
-      idx = 0;
-    else if (number < 200)
-      idx = 1;
-    else
-      idx = 2;
-
-    if (idx == 0 || idx == 1)
-      sc_total_errors++;
-
-    const char *pre=prefix[idx];
-    fprintf(stdout,"%s(%d) : %s %03d: ",filename,line,pre,number);
-  } /* if */
-  vfprintf(stdout,message,argptr);
-  fflush(stdout);
-  return 0;
-}
-
 typedef struct src_file_s {
   FILE *fp;         // Set if writing.
   char *buffer;     // IO buffer.

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -606,7 +606,7 @@ bool parse_new_typename(const token_t *tok, int *tagp);
 int pc_printf(const char *message,...);
 
 /* error report function */
-int pc_error(int number,const char *message,const char *filename,int firstline,int lastline,va_list argptr);
+int pc_error(int number,const char *message,const char *filename,int line,va_list argptr);
 
 /* input from source file */
 void *pc_opensrc(char *filename); /* reading only */

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -558,8 +558,6 @@ enum TokenKind {
 #define sFORCESET       1       /* force error flag on */
 #define sEXPRMARK       2       /* mark start of expression */
 #define sEXPRRELEASE    3       /* mark end of expression */
-#define sSETLINE        4       /* set line number for the error */
-#define sSETFILE        5       /* set file number for the error */
 
 enum {
   sOPTIMIZE_NONE,               /* no optimization */
@@ -604,9 +602,6 @@ bool parse_new_typename(const token_t *tok, int *tagp);
 
 /* general console output */
 int pc_printf(const char *message,...);
-
-/* error report function */
-int pc_error(int number,const char *message,const char *filename,int line,va_list argptr);
 
 /* input from source file */
 void *pc_opensrc(char *filename); /* reading only */
@@ -800,6 +795,7 @@ void outval(cell val,int newline);
 
 /* function prototypes in SC5.C */
 int error(int number,...);
+int error(symbol* sym, int number, ...);
 void errorset(int code,int line);
 
 /* function prototypes in SC6.C */

--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -5071,9 +5071,7 @@ static int testsymbols(symbol *root,int level,int testlabs,int testconst)
         if ((sym->usage & uDEFINE)==0) {
           error(19,sym->name);      /* not a label: ... */
         } else if ((sym->usage & uREAD)==0) {
-          errorset(sSETFILE,sym->fnumber);
-          errorset(sSETLINE,sym->lnumber);
-          error(203,sym->name);     /* symbol isn't used: ... */
+          error(sym,203,sym->name);     /* symbol isn't used: ... */
         } /* if */
       } /* if */
       break;
@@ -5081,9 +5079,7 @@ static int testsymbols(symbol *root,int level,int testlabs,int testconst)
       if ((sym->usage & (uDEFINE | uREAD | uNATIVE | uSTOCK | uPUBLIC))==uDEFINE) {
         funcdisplayname(symname,sym->name);
         if (strlen(symname)>0) {
-          errorset(sSETFILE,sym->fnumber);
-          errorset(sSETLINE,sym->lnumber);
-          error(203,symname);       /* symbol isn't used ... (and not public/native/stock) */
+          error(sym,203,symname);       /* symbol isn't used ... (and not public/native/stock) */
         }
       } /* if */
       if ((sym->usage & uPUBLIC)!=0 || strcmp(sym->name,uMAINFUNC)==0)
@@ -5094,9 +5090,7 @@ static int testsymbols(symbol *root,int level,int testlabs,int testconst)
       break;
     case iCONSTEXPR:
       if (testconst && (sym->usage & uREAD)==0) {
-        errorset(sSETFILE,sym->fnumber);
-        errorset(sSETLINE,sym->lnumber);
-        error(203,sym->name);       /* symbol isn't used: ... */
+        error(sym,203,sym->name);       /* symbol isn't used: ... */
       } /* if */
       break;
     case iMETHODMAP:
@@ -5107,13 +5101,9 @@ static int testsymbols(symbol *root,int level,int testlabs,int testconst)
       if (sym->parent!=NULL)
         break;                      /* hierarchical data type */
       if ((sym->usage & (uWRITTEN | uREAD | uSTOCK))==0) {
-        errorset(sSETFILE,sym->fnumber);
-        errorset(sSETLINE,sym->lnumber);
-        error(203,sym->name);  /* symbol isn't used (and not stock) */
+        error(sym,203,sym->name);  /* symbol isn't used (and not stock) */
       } else if ((sym->usage & (uREAD | uSTOCK | uPUBLIC))==0) {
-        errorset(sSETFILE,sym->fnumber);
-        errorset(sSETLINE,sym->lnumber);
-        error(204,sym->name);       /* value assigned to symbol is never used */
+        error(sym,204,sym->name);       /* value assigned to symbol is never used */
 #if 0 // ??? not sure whether it is a good idea to force people use "const"
       } else if ((sym->usage & (uWRITTEN | uPUBLIC | uCONST))==0 && sym->ident==iREFARRAY) {
         errorset(sSETFILE,sym->fnumber);

--- a/compiler/sc5.h
+++ b/compiler/sc5.h
@@ -1,0 +1,55 @@
+// vim: set ts=8 sts=2 sw=2 tw=99 et:
+/*  Pawn compiler - Error message system
+ *  In fact a very simple system, using only 'panic mode'.
+ *
+ *  Copyright (c) ITB CompuPhase, 1997-2006
+ *
+ *  This software is provided "as-is", without any express or implied warranty.
+ *  In no event will the authors be held liable for any damages arising from
+ *  the use of this software.
+ *
+ *  Permission is granted to anyone to use this software for any purpose,
+ *  including commercial applications, and to alter it and redistribute it
+ *  freely, subject to the following restrictions:
+ *
+ *  1.  The origin of this software must not be misrepresented; you must not
+ *      claim that you wrote the original software. If you use this software in
+ *      a product, an acknowledgment in the product documentation would be
+ *      appreciated but is not required.
+ *  2.  Altered source versions must be plainly marked as such, and must not be
+ *      misrepresented as being the original software.
+ *  3.  This notice may not be removed or altered from any source distribution.
+ *
+ *  Version: $Id$
+ */
+#ifndef am_sourcepawn_compiler_sc5_h
+#define am_sourcepawn_compiler_sc5_h
+
+#include <amtl/am-string.h>
+
+enum class ErrorType {
+  Suppressed,
+  Warning,
+  Error,
+  Fatal
+};
+
+struct ErrorReport
+{
+  static ErrorReport infer_va(int number, va_list ap);
+  static ErrorReport create_va(int number,
+                               int fileno,
+                               int lineno,
+                               va_list ap);
+
+  int number;
+  int fileno;
+  int lineno;
+  const char* filename;
+  ke::AString message;
+  ErrorType type;
+};
+
+void report_error(ErrorReport* report);
+
+#endif // am_sourcepawn_compiler_sc5_h


### PR DESCRIPTION
As is a theme with spcomp, error handling concerns in sc5.cpp are very poorly separated. It has multiple fields of global state that are mutated/consumed at seemingly random times. The way messages are formatted is not centralized (and is indeed duplicated), and everything is interleaved with the lexer/parser's behavior.

These patches separates everything, such that the concept of an "error report" is independent of "displaying an error." The error() function now creates an `ErrorReport` object which is passed to `report_error`. State that used to be global has been removed or moved to ErrorReport.

As a consequence I've removed what I've always considered a terribly confusing feature: line number ranges. The upstream compiler will mark the beginning and ends of expressions so as to not report too many errors on a malformed statement. The start of such an expression would record the line number, and then an error message on a different line within the same expression would look like:

`blah.sp(1 -- 5) : error 023: whatever`

This was never very accurate or helpful, and usually made it *harder* to tell where the error was. So that's now gone.