### PR TITLE
Fixed inclusion of default include folder on macOS.

### DIFF
--- a/compiler/AMBuilder
+++ b/compiler/AMBuilder
@@ -72,7 +72,7 @@ for arch in Root.archs:
     'expression-parsing.cpp',
   ]
 
-  if builder.target.platform != 'windows' and not compiler.like('emscripten'):
+  if builder.target.platform == 'linux' and not compiler.like('emscripten'):
     compiler.defines += ['ENABLE_BINRELOC']
     binary.sources.append('binreloc.c')
 


### PR DESCRIPTION
The default include folder isn't being used by the compiler on macOS because it tries to use binreloc instead. The binreloc code only works on Linux since it reads from /proc which doesn't exist on macOS.