### PR TITLE
Copy function debug name onto stack for crash dumps

### DIFF
--- a/vm/scripted-invoker.cpp
+++ b/vm/scripted-invoker.cpp
@@ -294,9 +294,9 @@ ScriptedInvoker::Invoke(cell_t *result)
   /* Make the call if we can */
   if (ok) {
     const char *debugName = this->DebugName();
-    size_t debugNameLength = strlen(debugName) + 1;
-    volatile char *debugNameForCrashDumps = (char *)alloca(debugNameLength);
-    SafeStrcpy((char *)debugNameForCrashDumps, debugNameLength, debugName);
+    size_t debugNameLength = strlen(debugName) + 2;
+    volatile char * volatile debugNameForCrashDumps = (char *)alloca(debugNameLength);
+    SafeStrcpy((char *)debugNameForCrashDumps + 1, debugNameLength, debugName);
 
     ok = context_->Invoke(m_FnId, temp_params, numparams, result);
   }

--- a/vm/scripted-invoker.cpp
+++ b/vm/scripted-invoker.cpp
@@ -296,7 +296,7 @@ ScriptedInvoker::Invoke(cell_t *result)
     const char *debugName = this->DebugName();
     size_t debugNameLength = strlen(debugName) + 2;
     volatile char * volatile debugNameForCrashDumps = (char *)alloca(debugNameLength);
-    SafeStrcpy((char *)debugNameForCrashDumps + 1, debugNameLength, debugName);
+    SafeStrcpy((char *)debugNameForCrashDumps + 1, debugNameLength - 1, debugName);
 
     ok = context_->Invoke(m_FnId, temp_params, numparams, result);
   }

--- a/vm/scripted-invoker.cpp
+++ b/vm/scripted-invoker.cpp
@@ -296,7 +296,7 @@ ScriptedInvoker::Invoke(cell_t *result)
     const char *debugName = this->DebugName();
     size_t debugNameLength = strlen(debugName) + 1;
     volatile char *debugNameForCrashDumps = (char *)alloca(debugNameLength);
-    SafeStrcpy(debugNameForCrashDumps, debugNameLength, debugName);
+    SafeStrcpy((char *)debugNameForCrashDumps, debugNameLength, debugName);
 
     ok = context_->Invoke(m_FnId, temp_params, numparams, result);
   }

--- a/vm/scripted-invoker.cpp
+++ b/vm/scripted-invoker.cpp
@@ -292,8 +292,14 @@ ScriptedInvoker::Invoke(cell_t *result)
   }
 
   /* Make the call if we can */
-  if (ok)
+  if (ok) {
+    const char *debugName = this->DebugName();
+    size_t debugNameLength = strlen(debugName) + 1;
+    volatile char *debugNameForCrashDumps = (char *)alloca(debugNameLength);
+    SafeStrcpy(debugNameForCrashDumps, debugNameLength, debugName);
+
     ok = context_->Invoke(m_FnId, temp_params, numparams, result);
+  }
 
   /* i should be equal to the last valid parameter + 1 */
   bool docopies = ok;


### PR DESCRIPTION
This is a useful hack I've had sitting in my queue for a while.

Copy the to-be-invoked function's debug name into the `ScriptedInvoker::Invoke` stack frame so it is always available in minidumps even without heap information.

This will hopefully make it easier to track down reproduction steps for plugin-related crashes.