### PR TITLE
Align JIT HALT implementation with Interpreter and Verifier

### DIFF
--- a/vm/x86/jit_x86.cpp
+++ b/vm/x86/jit_x86.cpp
@@ -1082,12 +1082,10 @@ Compiler::visitTRACKER_POP_SETHEAP()
 bool
 Compiler::visitHALT(cell_t value)
 {
-  // This should never be hit.
-  __ align(16);
-  __ movl(pri, value);
-  __ testl(eax, eax);
-  jumpOnError(not_zero);
-  return true;
+  // We don't support this. It's included in the bytestream by default, but it
+  // must be unreachable.
+  reportError(SP_ERROR_INVALID_INSTRUCTION);
+  return false;
 }
 
 bool


### PR DESCRIPTION
Next step is removing the code paths that can emit reachable `halt`'s from spcomp (exit, sleep, and assert), but this fixes the crash for now.

For shell use it might be nice to have these work (and just map `halt` through to `SetFailState` for SM), but that is a discussion for the future.

Fixes #174