### PR TITLE
Fix initialization of dynamic char[]

### DIFF
--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -1841,6 +1841,8 @@ static void declloc(int tokid)
       // literal. In other cases (such as a fixed-array literal), we error.
       //
       // For now, we only implement the string literal initializer.
+
+      cur_lit = litidx; /* save current index in the literal table */
       if (type->is_new && needtoken('=')) {
         if (type->isCharArray() && !lexpeek(tNEW)) {
           // Error if we're assigning something other than a string literal.

--- a/tests/basic/genarray.out
+++ b/tests/basic/genarray.out
@@ -14,3 +14,4 @@ decl complex genarray
 new complex genarray
 0, 6
 hello
+this is initialized

--- a/tests/basic/genarray.sp
+++ b/tests/basic/genarray.sp
@@ -30,4 +30,7 @@ public main()
   str[4] = 'o';
   str[5] = '\n';
   print(str);
+  
+  char[] strinit = "this is initialized\n";
+  print(strinit);
 }


### PR DESCRIPTION
Initializing a string on the heap using
```
char[] str = "this is a value";
// NOT |char str[] = "this is a value";| which is on the stack
```
wasn't copying the correct string.

Add a test to catch this from now on.

Fixes https://github.com/alliedmodders/sourcemod/issues/760