### PR TITLE
Fix Emscripten support

### DIFF
--- a/compiler/AMBuilder
+++ b/compiler/AMBuilder
@@ -22,6 +22,7 @@ for arch in Root.archs:
     if builder.target.platform == 'linux':
       compiler.postlink += ['-lm']
     compiler.postlink += ['-lstdc++']
+  if compiler.family == 'clang':
     compiler.cxxflags += [
       '-Wno-implicit-exception-spec-mismatch',
     ]
@@ -29,6 +30,8 @@ for arch in Root.archs:
     compiler.cflags += [
       '-Wno-maybe-uninitialized',
     ]
+    if compiler.version >= '4.6':
+      compiler.cxxflags += ['-Wno-unused-but-set-variable']
 
   compiler.defines += ['HAVE_STDINT_H']
   if builder.target.platform == 'linux':

--- a/vm/AMBuilder
+++ b/vm/AMBuilder
@@ -52,44 +52,47 @@ for arch in Root.archs:
     'api.cpp',
     'base-context.cpp',
     'code-allocator.cpp',
+    'code-stubs.cpp',
     'compiled-function.cpp',
     'environment.cpp',
     'file-utils.cpp',
+    'interpreter.cpp',
     'md5/md5.cpp',
+    'method-info.cpp',
+    'method-verifier.cpp',
     'opcodes.cpp',
     'plugin-context.cpp',
     'plugin-runtime.cpp',
-    'scripted-invoker.cpp',
-    'stack-frames.cpp',
-    'smx-v1-image.cpp',
-    'watchdog_timer.cpp',
     'pool-allocator.cpp',
-    'method-verifier.cpp',
-    'method-info.cpp',
-    'interpreter.cpp',
     'runtime-helpers.cpp',
+    'scripted-invoker.cpp',
+    'smx-v1-image.cpp',
+    'stack-frames.cpp',
+    'watchdog_timer.cpp',
   ]
 
-  has_jit = arch in ['x86'] and builder.cxx.family != 'emscripten'
+  is_emscripten = builder.cxx.family == 'emscripten'
+  has_jit = arch in ['x86'] and not is_emscripten
 
   if has_jit:
     library.sources += [
-      'code-stubs.cpp',
       'jit.cpp',
-      'linking.cpp',
     ]
     library.compiler.defines += ['SP_HAS_JIT']
 
-  if has_jit and arch == 'x86':
+  if is_emscripten:
     library.sources += [
+      'code-stubs-null.cpp',
+    ]
+  elif arch == 'x86':
+    library.sources += [
+      'linking.cpp',
       'x86/assembler-x86.cpp',
       'x86/code-stubs-x86.cpp',
       'x86/jit_x86.cpp',
     ]
-
-  if arch == 'x64':
+  elif arch == 'x64':
     library.sources += [
-      'code-stubs.cpp',
       'linking.cpp',
       'x64/assembler-x64.cpp',
       'x64/code-stubs-x64.cpp',

--- a/vm/code-stubs-null.cpp
+++ b/vm/code-stubs-null.cpp
@@ -1,0 +1,37 @@
+// vim: set sts=2 ts=8 sw=2 tw=99 et:
+// 
+// Copyright (C) 2006-2015 AlliedModders LLC
+// 
+// This file is part of SourcePawn. SourcePawn is free software: you can
+// redistribute it and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License along with
+// SourcePawn. If not, see http://www.gnu.org/licenses/.
+//
+#include <sp_vm_api.h>
+#include "code-stubs.h"
+#include "environment.h"
+
+using namespace sp;
+using namespace SourcePawn;
+
+bool
+CodeStubs::InitializeFeatureDetection()
+{
+  return true;
+}
+
+bool
+CodeStubs::CompileInvokeStub()
+{
+  return true;
+}
+
+SPVM_NATIVE_FUNC
+CodeStubs::CreateFakeNativeStub(SPVM_FAKENATIVE_FUNC callback, void *pData)
+{
+  assert(false);
+  return (SPVM_NATIVE_FUNC)nullptr;
+}

--- a/vm/environment.cpp
+++ b/vm/environment.cpp
@@ -19,7 +19,9 @@
 #include "method-info.h"
 #include "compiled-function.h"
 #include "code-stubs.h"
+#ifndef KE_EMSCRIPTEN
 #include "jit.h"
+#endif
 #include "interpreter.h"
 #include <stdarg.h>
 


### PR DESCRIPTION
Requires alliedmodders/ambuild#56 to be useful.

After the changes in #157, CodeStubs were required everywhere, breaking Emscripten support.
I don't think there is any reasonable way for Emscripten to support this properly, so this just creates an asserting, empty CodeStubs impl for it to use.

It seems to me like the interpreter path should never require runtime code generation however (else we'll never be able to work properly on iOS for instance), so it would be nice to have a fallback that works on all platforms if possible - but I do not think I understand the requirements here enough to implement one yet.