### PR TITLE
Test Emscripten build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,20 @@
+language: cpp
+sudo: false
+dist: trusty
 addons:
   apt:
     packages:
+      - g++-4.8
+      - g++-4.8-multilib
+      - clang-3.8
+      - libstdc++6
       - lib32stdc++6
-      - lib32z1-dev
+      - libc6-dev
       - libc6-dev-i386
       - linux-libc-dev
-      - g++-multilib
-      - g++-4.8
-    sources:
-      - ubuntu-toolchain-r-test
-language: cpp
-sudo: false
-compiler:
-  - clang
+      - linux-libc-dev:i386
 env:
   global:
-    - LLVM_ARCHIVE_URI=https://www.sourcemod.net/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
     - EMSCRIPTEN_SDK_URI=https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portable.tar.gz
   matrix:
     - AM_CC=clang-3.8 AM_CXX=clang++-3.8 AM_ARCH=x86 AM_TYPE=optimize

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ addons:
       - linux-libc-dev:i386
 env:
   global:
-    - EMSCRIPTEN_SDK_URI=https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portable.tar.gz
+    - EMSCRIPTEN_SDK_BRANCH=incoming
+    - EMSCRIPTEN_SDK_URI=https://github.com/urho3d/emscripten-sdk.git
   matrix:
     - AM_CC=clang-3.8 AM_CXX=clang++-3.8 AM_ARCH=x86 AM_TYPE=optimize
     - AM_CC=clang-3.8 AM_CXX=clang++-3.8 AM_ARCH=x86 AM_TYPE=debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,41 +1,41 @@
 addons:
- apt:
-   packages:
-    - lib32stdc++6
-    - lib32z1-dev
-    - libc6-dev-i386
-    - linux-libc-dev
-    - g++-multilib
-    - g++-4.8
-   sources:
-    - ubuntu-toolchain-r-test
+  apt:
+    packages:
+      - lib32stdc++6
+      - lib32z1-dev
+      - libc6-dev-i386
+      - linux-libc-dev
+      - g++-multilib
+      - g++-4.8
+    sources:
+      - ubuntu-toolchain-r-test
 language: cpp
 sudo: false
 compiler:
- - clang
+  - clang
 env:
   global:
-  - LLVM_ARCHIVE_URI=http://sourcemod.net/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+    - LLVM_ARCHIVE_URI=http://sourcemod.net/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
 before_install:
   - wget -nc $LLVM_ARCHIVE_URI -O $HOME/clang+llvm.tar.xz
   - mkdir -p $HOME/clang+llvm
   - tar -xf $HOME/clang+llvm.tar.xz -C $HOME/clang+llvm --strip-components 1
   - export PATH=$HOME/clang+llvm/bin:$PATH
 before_script:
- - CHECKOUT_DIR=$PWD && cd .. && $CHECKOUT_DIR/tools/checkout-deps.sh && cd $CHECKOUT_DIR
+  - CHECKOUT_DIR=$PWD && cd .. && $CHECKOUT_DIR/tools/checkout-deps.sh && cd $CHECKOUT_DIR
 script:
- - mkdir obj-release && cd obj-release
- - PATH="~/.local/bin:$PATH"
- - CC=clang-3.8 CXX=clang-3.8 python ../configure.py --enable-optimize --target-arch=x86
- - ambuild
- - ./testing/test-all.x86.sh
- - cd ..
- - mkdir x64-release && cd x64-release
- - CC=clang-3.8 CXX=clang-3.8 python ../configure.py --enable-optimize --target-arch=x64
- - ambuild
- - ./testing/test-all.x64.sh
- - cd ..
- - mkdir x86-debug && cd x86-debug
- - CC=clang-3.8 CXX=clang-3.8 python ../configure.py --enable-debug --target-arch=x86
- - ambuild
- - ./testing/test-all.x86.sh
+  - mkdir obj-release && cd obj-release
+  - PATH="~/.local/bin:$PATH"
+  - CC=clang-3.8 CXX=clang-3.8 python ../configure.py --enable-optimize --target-arch=x86
+  - ambuild
+  - ./testing/test-all.x86.sh
+  - cd ..
+  - mkdir x64-release && cd x64-release
+  - CC=clang-3.8 CXX=clang-3.8 python ../configure.py --enable-optimize --target-arch=x64
+  - ambuild
+  - ./testing/test-all.x64.sh
+  - cd ..
+  - mkdir x86-debug && cd x86-debug
+  - CC=clang-3.8 CXX=clang-3.8 python ../configure.py --enable-debug --target-arch=x86
+  - ambuild
+  - ./testing/test-all.x86.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,19 +16,20 @@ compiler:
 env:
   global:
     - LLVM_ARCHIVE_URI=https://www.sourcemod.net/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+    - EMSCRIPTEN_SDK_URI=https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portable.tar.gz
   matrix:
     - AM_CC=clang-3.8 AM_CXX=clang++-3.8 AM_ARCH=x86 AM_TYPE=optimize
     - AM_CC=clang-3.8 AM_CXX=clang++-3.8 AM_ARCH=x86 AM_TYPE=debug
     - AM_CC=clang-3.8 AM_CXX=clang++-3.8 AM_ARCH=x64 AM_TYPE=optimize
     - AM_CC=clang-3.8 AM_CXX=clang++-3.8 AM_ARCH=x64 AM_TYPE=debug
-before_install:
-  - wget -nc $LLVM_ARCHIVE_URI -O $HOME/clang+llvm.tar.xz
-  - mkdir -p $HOME/clang+llvm
-  - tar -xf $HOME/clang+llvm.tar.xz -C $HOME/clang+llvm --strip-components 1
-  - export PATH=$HOME/clang+llvm/bin:$PATH
-before_script:
+    - AM_CC=emcc AM_CXX=em++ AM_ARCH=x86 AM_TYPE=optimize
+    - AM_CC=emcc AM_CXX=em++ AM_ARCH=x86 AM_TYPE=debug
+install:
+  - source ./tools/travis-download-compiler.sh
   - CHECKOUT_DIR=$PWD && cd .. && $CHECKOUT_DIR/tools/checkout-deps.sh && cd $CHECKOUT_DIR
   - export PATH="~/.local/bin:$PATH"
+  - echo $PATH
+  - $AM_CC --version
 script:
   - mkdir $AM_CC-$AM_ARCH-$AM_TYPE && cd $AM_CC-$AM_ARCH-$AM_TYPE
   - CC=$AM_CC CXX=$AM_CXX python ../configure.py --enable-$AM_TYPE --target-arch=$AM_ARCH

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,17 +19,16 @@ env:
     - EMSCRIPTEN_SDK_URI=https://github.com/urho3d/emscripten-sdk.git
   matrix:
     - AM_CC=clang-3.8 AM_CXX=clang++-3.8 AM_ARCH=x86 AM_TYPE=optimize
-    - AM_CC=clang-3.8 AM_CXX=clang++-3.8 AM_ARCH=x86 AM_TYPE=debug
     - AM_CC=clang-3.8 AM_CXX=clang++-3.8 AM_ARCH=x64 AM_TYPE=optimize
-    - AM_CC=clang-3.8 AM_CXX=clang++-3.8 AM_ARCH=x64 AM_TYPE=debug
     - AM_CC=emcc AM_CXX=em++ AM_ARCH=x86 AM_TYPE=optimize
     - AM_CC=emcc AM_CXX=em++ AM_ARCH=x86 AM_TYPE=debug
+    - AM_CC=clang-3.8 AM_CXX=clang++-3.8 AM_ARCH=x86 AM_TYPE=debug
+    - AM_CC=clang-3.8 AM_CXX=clang++-3.8 AM_ARCH=x64 AM_TYPE=debug
 install:
   - source ./tools/travis-download-compiler.sh
   - CHECKOUT_DIR=$PWD && cd .. && $CHECKOUT_DIR/tools/checkout-deps.sh && cd $CHECKOUT_DIR
   - export PATH="~/.local/bin:$PATH"
-  - echo $PATH
-  - $AM_CC --version
+  - $AM_CXX --version
 script:
   - mkdir $AM_CC-$AM_ARCH-$AM_TYPE && cd $AM_CC-$AM_ARCH-$AM_TYPE
   - CC=$AM_CC CXX=$AM_CXX python ../configure.py --enable-$AM_TYPE --target-arch=$AM_ARCH

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,12 @@ compiler:
   - clang
 env:
   global:
-    - LLVM_ARCHIVE_URI=http://sourcemod.net/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+    - LLVM_ARCHIVE_URI=https://www.sourcemod.net/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+  matrix:
+    - AM_CC=clang-3.8 AM_CXX=clang++-3.8 AM_ARCH=x86 AM_TYPE=optimize
+    - AM_CC=clang-3.8 AM_CXX=clang++-3.8 AM_ARCH=x86 AM_TYPE=debug
+    - AM_CC=clang-3.8 AM_CXX=clang++-3.8 AM_ARCH=x64 AM_TYPE=optimize
+    - AM_CC=clang-3.8 AM_CXX=clang++-3.8 AM_ARCH=x64 AM_TYPE=debug
 before_install:
   - wget -nc $LLVM_ARCHIVE_URI -O $HOME/clang+llvm.tar.xz
   - mkdir -p $HOME/clang+llvm
@@ -23,19 +28,9 @@ before_install:
   - export PATH=$HOME/clang+llvm/bin:$PATH
 before_script:
   - CHECKOUT_DIR=$PWD && cd .. && $CHECKOUT_DIR/tools/checkout-deps.sh && cd $CHECKOUT_DIR
+  - export PATH="~/.local/bin:$PATH"
 script:
-  - mkdir obj-release && cd obj-release
-  - PATH="~/.local/bin:$PATH"
-  - CC=clang-3.8 CXX=clang-3.8 python ../configure.py --enable-optimize --target-arch=x86
+  - mkdir $AM_CC-$AM_ARCH-$AM_TYPE && cd $AM_CC-$AM_ARCH-$AM_TYPE
+  - CC=$AM_CC CXX=$AM_CXX python ../configure.py --enable-$AM_TYPE --target-arch=$AM_ARCH
   - ambuild
-  - ./testing/test-all.x86.sh
-  - cd ..
-  - mkdir x64-release && cd x64-release
-  - CC=clang-3.8 CXX=clang-3.8 python ../configure.py --enable-optimize --target-arch=x64
-  - ambuild
-  - ./testing/test-all.x64.sh
-  - cd ..
-  - mkdir x86-debug && cd x86-debug
-  - CC=clang-3.8 CXX=clang-3.8 python ../configure.py --enable-debug --target-arch=x86
-  - ambuild
-  - ./testing/test-all.x86.sh
+  - ./testing/test-all.$AM_ARCH.sh

--- a/exp/compiler/preprocessor.cpp
+++ b/exp/compiler/preprocessor.cpp
@@ -68,13 +68,13 @@ Preprocessor::setup_builtin_macros()
     char datestring[64];
     char timestring[64];
 
-#if defined(EMSCRIPTEN)
+#if defined(KE_EMSCRIPTEN)
     snprintf(datestring, sizeof(datestring),
              "%02d/%02d/%04d",
-             curtime->tm_mon + 1, curtime->tm_mday, curtime->tm_year + 1900);
+             curtime.tm_mon + 1, curtime.tm_mday, curtime.tm_year + 1900);
     snprintf(timestring, sizeof(timestring),
              "%02d:%02d:%02d",
-             curtime->tm_hour, curtime->tm_min, curtime->tm_sec);
+             curtime.tm_hour, curtime.tm_min, curtime.tm_sec);
 #else
     strftime(datestring, sizeof(datestring), "%m/%d/%Y", &curtime);
     strftime(timestring, sizeof(timestring), "%H:%M:%S", &curtime);

--- a/tools/travis-download-compiler.sh
+++ b/tools/travis-download-compiler.sh
@@ -3,15 +3,14 @@
 set -e
 
 if [ "$AM_CC" == "emcc" ]; then
-  wget -nc $EMSCRIPTEN_SDK_URI -O $HOME/emsdk-portable.tar.gz
-  tar -xf $HOME/emsdk-portable.tar.gz -C $HOME
-  pushd $HOME/emsdk-portable
-  ./emsdk update
-  ./emsdk install latest
-  ./emsdk activate latest
-  popd
+  git clone --depth 1 --branch $EMSCRIPTEN_SDK_BRANCH $EMSCRIPTEN_SDK_URI $HOME/emscripten-sdk
+  $HOME/emscripten-sdk/emsdk activate --build=Release sdk-$EMSCRIPTEN_SDK_BRANCH-64bit
 
-  source $HOME/emsdk-portable/emsdk_env.sh
+  source $HOME/emscripten-sdk/emsdk_env.sh
+
+  for compiler in $EMSCRIPTEN/{emcc,em++}; do
+    touch -d "2017-01-01 00:00:00 +0800" $compiler
+  done
 fi
 
 set "$state"

--- a/tools/travis-download-compiler.sh
+++ b/tools/travis-download-compiler.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+[[ $- == *e* ]] && state=-e || state=+e
+set -e
+
+if [ "$AM_CC" != "emcc" ]; then
+  wget -nc $LLVM_ARCHIVE_URI -O $HOME/clang+llvm.tar.xz
+  mkdir -p $HOME/clang+llvm
+  tar -xf $HOME/clang+llvm.tar.xz -C $HOME/clang+llvm --strip-components 1
+
+  export PATH=$HOME/clang+llvm/bin:$PATH
+else
+  wget -nc $EMSCRIPTEN_SDK_URI -O $HOME/emsdk-portable.tar.gz
+  tar -xf $HOME/emsdk-portable.tar.gz -C $HOME
+  pushd $HOME/emsdk-portable
+  ./emsdk update
+  ./emsdk install latest
+  ./emsdk activate latest
+  popd
+
+  source $HOME/emsdk-portable/emsdk_env.sh
+fi
+
+set "$state"

--- a/tools/travis-download-compiler.sh
+++ b/tools/travis-download-compiler.sh
@@ -2,13 +2,7 @@
 [[ $- == *e* ]] && state=-e || state=+e
 set -e
 
-if [ "$AM_CC" != "emcc" ]; then
-  wget -nc $LLVM_ARCHIVE_URI -O $HOME/clang+llvm.tar.xz
-  mkdir -p $HOME/clang+llvm
-  tar -xf $HOME/clang+llvm.tar.xz -C $HOME/clang+llvm --strip-components 1
-
-  export PATH=$HOME/clang+llvm/bin:$PATH
-else
+if [ "$AM_CC" == "emcc" ]; then
   wget -nc $EMSCRIPTEN_SDK_URI -O $HOME/emsdk-portable.tar.gz
   tar -xf $HOME/emsdk-portable.tar.gz -C $HOME
   pushd $HOME/emsdk-portable


### PR DESCRIPTION
This PR adds Emscripten build/test to Travis CI.

Due to incompatibilities with the Travis environment and the prebuilt Emscripten SDK, this is using a built-for-Travis `emsdk` from the Urho3D project - which I trust.

The Emscripten builds are fairly slow (especially for debug), but with the other improvements it is only about an extra minute to total build time. Builds are ordered for optimal running time when Travis is running normally, but still getting important results quickly if overloaded.