### PR TITLE
Optimize compilation for large global arrays

### DIFF
--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -1363,7 +1363,7 @@ static void dumpzero(int count)
     return;
   assert(curseg==2);
   
-  stgwrite("dumpdup ");
+  stgwrite("dumpfill ");
   outval(0, FALSE);
   stgwrite(" ");
   outval(count, TRUE);

--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -1359,20 +1359,14 @@ static void dumplits(void)
  */
 static void dumpzero(int count)
 {
-  int i;
-
   if (sc_status==statSKIP || count<=0)
     return;
   assert(curseg==2);
-  defstorage();
-  i=0;
-  while (count-- > 0) {
-    outval(0, FALSE);
-    i=(i+1) % 16;
-    stgwrite((i==0 || count==0) ? "\n" : " ");
-    if (i==0 && count>0)
-      defstorage();
-  } /* while */
+  
+  stgwrite("dumpdup ");
+  outval(0, FALSE);
+  stgwrite(" ");
+  outval(count, TRUE);
 }
 
 /* declstruct - declare global struct symbols

--- a/compiler/sc6.cpp
+++ b/compiler/sc6.cpp
@@ -233,6 +233,15 @@ static void do_dump(CellWriter* writer, char *params, cell opcode)
   }
 }
 
+static void do_dumpdup(CellWriter* writer, char *params, cell opcode)
+{
+  ucell value = getparam(params, &params);
+  ucell times = getparam(params, nullptr);
+  while(times-- > 0) {
+    writer->append(value);
+  }
+}
+
 static symbol*
 extract_call_target(char *params)
 {
@@ -331,6 +340,7 @@ static OPCODEC opcodelist[] = {
   {112, "dec.pri",    sIN_CSEG, parm0 },
   {115, "dec.s",      sIN_CSEG, parm1 },
   {  0, "dump",       sIN_DSEG, do_dump },
+  {  0, "dumpdup",    sIN_DSEG, do_dumpdup },
   {166, "endproc",    sIN_CSEG, parm0 },
   { 95, "eq",         sIN_CSEG, parm0 },
   {106, "eq.c.alt",   sIN_CSEG, parm1 },

--- a/compiler/sc6.cpp
+++ b/compiler/sc6.cpp
@@ -233,7 +233,7 @@ static void do_dump(CellWriter* writer, char *params, cell opcode)
   }
 }
 
-static void do_dumpdup(CellWriter* writer, char *params, cell opcode)
+static void do_dumpfill(CellWriter* writer, char *params, cell opcode)
 {
   ucell value = getparam(params, &params);
   ucell times = getparam(params, nullptr);
@@ -340,7 +340,7 @@ static OPCODEC opcodelist[] = {
   {112, "dec.pri",    sIN_CSEG, parm0 },
   {115, "dec.s",      sIN_CSEG, parm1 },
   {  0, "dump",       sIN_DSEG, do_dump },
-  {  0, "dumpdup",    sIN_DSEG, do_dumpdup },
+  {  0, "dumpfill",    sIN_DSEG, do_dumpfill },
   {166, "endproc",    sIN_CSEG, parm0 },
   { 95, "eq",         sIN_CSEG, parm0 },
   {106, "eq.c.alt",   sIN_CSEG, parm1 },


### PR DESCRIPTION
Introduces `dumpdup` opcode (compiler only). It helps with huge arrays with default values by creating only 1 `dumpdup` opcode instead of many `dump` opcodes together with a lot of vaues. Array indirection tables still use `dump` though, but they are small in size compared to the array data itself.

The following array:
```SourcePawn
bool x[32][1024][1024];
```
compiles in ~1.7s with this patch instead of ~9.5s on my machine.