### PR TITLE
Fixed segmentation fault in DocGen

### DIFF
--- a/exp/compiler/name-resolver.cpp
+++ b/exp/compiler/name-resolver.cpp
@@ -528,8 +528,10 @@ NameResolver::LeavePropertyDecl(PropertyDecl *decl)
 
   FunctionNode* getter = decl->getter();
   FunctionNode* setter = decl->setter();
-  if (!decl->te().resolved() ||
-      (!getter->signature()->isResolved() || !setter->signature()->isResolved()))
+  if (!decl->te().resolved() || (
+      (getter && !getter->signature()->isResolved()) ||
+      (setter && !setter->signature()->isResolved())
+     ))
   {
     tr_.addPending(decl);
   }


### PR DESCRIPTION
Fixes #164 

Example on `admin.inc`:
![default](https://user-images.githubusercontent.com/12576822/37242396-1ce25aac-2482-11e8-854f-eadce81202af.png)
For readability, i marked my input commands in bash with red arrows.

Result JSON:
![default](https://user-images.githubusercontent.com/12576822/37242408-5bc2cafe-2482-11e8-8de7-bb10b4062d4c.png)

All ok, if we look this properties in official web API:
![default](https://user-images.githubusercontent.com/12576822/37242412-86819356-2482-11e8-87d8-b642d100521a.png)
![default](https://user-images.githubusercontent.com/12576822/37242413-8f5e9794-2482-11e8-822d-9cb943f84aec.png)