### PR TITLE
Expand the semantics of the RETN instruction

### DIFF
--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -922,6 +922,7 @@ extern int glbstringread;	  /* last global string read */
 extern int sc_require_newdecls; /* only newdecls are allowed */
 extern bool sc_warnings_are_errors;
 extern unsigned sc_total_errors;
+extern int pc_code_version; /* override the code version */
 
 // Returns true if compilation is in its second phase (writing phase) and has
 // so far proceeded without error.

--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -92,6 +92,9 @@ int pc_tag_bool = 0;
 int pc_tag_null_t = 0;
 int pc_tag_nullfunc_t = 0;
 
+int pc_code_version = 0;
+bool pc_must_drop_stack = true;
+
 static void resetglobals(void);
 static void initglobals(void);
 static char *get_extension(char *filename);
@@ -871,6 +874,18 @@ static void parseoptions(int argc,char **argv,char *oname,char *ename,char *pnam
           pc_enablewarning(i,1);
         else if (*ptr=='\0')
           pc_enablewarning(i,2);
+        break;
+      case 'x':
+        i=(int)strtol(option_value(ptr,argv,argc,&arg),(char **)&ptr,10);
+        switch (i) {
+          case 12:
+            pc_code_version = i;
+            pc_must_drop_stack = false;
+            break;
+          default:
+            fprintf(stderr, "unknown code version: %d\n", i);
+            exit(1);
+        }
         break;
       case '\\':                /* use \ instead for escape characters */
         sc_ctrlchar='\\';
@@ -4651,7 +4666,8 @@ static int newfunc(declinfo_t *decl, const int *thistag, int fpublic, int fstati
      * has only a single statement in its body (no compound block) and that
      * statement declares a new variable
      */
-    popstacklist(1);
+    popheaplist(pc_must_drop_stack);
+    popstacklist(pc_must_drop_stack);
     declared=0;
   } /* if */
   if (lastst!=tRETURN) {
@@ -5501,11 +5517,11 @@ static void compound(int stmt_sameline)
   if (lastst!=tRETURN)
     destructsymbols(&loctab,nestlevel);
   if (lastst!=tRETURN) {
-    popheaplist();
-    popstacklist(1);
+    popheaplist(true);
+    popstacklist(true);
   } else {
-    popheaplist();
-    popstacklist(0);
+    popheaplist(true);
+    popstacklist(false);
   }
   testsymbols(&loctab,nestlevel,FALSE,TRUE);        /* look for unused block locals */
   declared=save_decl;
@@ -5873,7 +5889,7 @@ static int dofor(void)
   setlabel(wq[wqEXIT]);
   delwhile();
 
-  popheaplist();
+  popheaplist(true);
 
   assert(nestlevel>=save_nestlevel);
   if (nestlevel>save_nestlevel) {
@@ -5881,13 +5897,13 @@ static int dofor(void)
      * variable in "expr1".
      */
     destructsymbols(&loctab,nestlevel);
-    popstacklist(1);
+    popstacklist(true);
     testsymbols(&loctab,nestlevel,FALSE,TRUE);  /* look for unused block locals */
     declared=save_decl;
     delete_symbols(&loctab,nestlevel,FALSE,TRUE);
     nestlevel=save_nestlevel;     /* reset 'compound statement' nesting level */
   } else {
-    popstacklist(0);
+    popstacklist(false);
   } /* if */
 
   index=endlessloop ? tENDLESS : tFOR;
@@ -6201,8 +6217,10 @@ static void doreturn(void)
     rettype|=uRETNONE;                  /* function does not return anything */
   } /* if */
   destructsymbols(&loctab,0);           /* call destructor for *all* locals */
-  genheapfree(-1);
-  genstackfree(-1);                     /* free everything on the stack */
+  if (pc_must_drop_stack) {
+    genheapfree(-1);
+    genstackfree(-1);                   /* free everything on the stack */
+  }
   ffret();
 }
 

--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -5516,13 +5516,10 @@ static void compound(int stmt_sameline)
   } /* while */
   if (lastst!=tRETURN)
     destructsymbols(&loctab,nestlevel);
-  if (lastst!=tRETURN) {
-    popheaplist(true);
-    popstacklist(true);
-  } else {
-    popheaplist(true);
-    popstacklist(false);
-  }
+
+  popheaplist(lastst != tRETURN);
+  popstacklist(lastst != tRETURN);
+
   testsymbols(&loctab,nestlevel,FALSE,TRUE);        /* look for unused block locals */
   declared=save_decl;
   delete_symbols(&loctab,nestlevel,FALSE,TRUE);     /* erase local symbols, but

--- a/compiler/sc3.cpp
+++ b/compiler/sc3.cpp
@@ -940,7 +940,7 @@ int lvalexpr(svalue *sval)
     SC3ExpressionParser parser;
     sval->lvalue = parser.evaluate(&sval->val);
   }
-  popheaplist();
+  popheaplist(true);
   errorset(sEXPRRELEASE, 0);
 
   return sval->val.ident;
@@ -955,7 +955,7 @@ int expression(cell *val,int *tag,symbol **symptr,int chkfuncresult,value *_lval
   if (parser.evaluate(&lval))
     rvalue(&lval);
   /* scrap any arrays left on the heap */
-  popheaplist();
+  popheaplist(true);
 
   if (lval.ident==iCONSTEXPR && val!=NULL)    /* constant expression */
     *val=lval.constval;
@@ -2977,7 +2977,7 @@ SC3ExpressionParser::callfunction(symbol *sym, const svalue *aImplicitThis, valu
    * this function has as a result (in other words, scrap all arrays on the
    * heap that caused by expressions in the function arguments)
    */
-  popheaplist();
+  popheaplist(true);
 }
 
 /*  dbltest

--- a/compiler/sc6.cpp
+++ b/compiler/sc6.cpp
@@ -915,7 +915,7 @@ static void assemble_to_buffer(MemoryBuffer *buffer, void *fin)
   // Set up the code section.
   code->header().codesize = code_buffer.length() * sizeof(cell);
   code->header().cellsize = sizeof(cell);
-  code->header().codeversion = SmxConsts::CODE_VERSION_SM_LEGACY;
+  code->header().codeversion = (pc_code_version) ? pc_code_version : SmxConsts::CODE_VERSION_SM_LEGACY;
   code->header().flags = CODEFLAG_DEBUG;
   code->header().main = 0;
   code->header().code = sizeof(sp_file_code_t);

--- a/compiler/sc6.cpp
+++ b/compiler/sc6.cpp
@@ -915,7 +915,7 @@ static void assemble_to_buffer(MemoryBuffer *buffer, void *fin)
   // Set up the code section.
   code->header().codesize = code_buffer.length() * sizeof(cell);
   code->header().cellsize = sizeof(cell);
-  code->header().codeversion = SmxConsts::CODE_VERSION_JIT_1_1;
+  code->header().codeversion = SmxConsts::CODE_VERSION_SM_LEGACY;
   code->header().flags = CODEFLAG_DEBUG;
   code->header().main = 0;
   code->header().code = sizeof(sp_file_code_t);

--- a/compiler/sctracker.cpp
+++ b/compiler/sctracker.cpp
@@ -330,15 +330,17 @@ int markstack(int type, int size)
 /**
  * Generates code to free all heap allocations on a tracker
  */
-void _heap_freeusage(memuse_list_t *heap, int dofree)
+void _heap_freeusage(memuse_list_t *heap, bool dofree, bool codegen)
 {
   memuse_t *cur=heap->head;
   memuse_t *tmp;
   while (cur) {
-    if (cur->type == MEMUSE_STATIC) {
-      modheap((-1)*cur->size*sizeof(cell));
-    } else {
-      modheap_i();
+    if (codegen) {
+      if (cur->type == MEMUSE_STATIC) {
+        modheap((-1)*cur->size*sizeof(cell));
+      } else {
+        modheap_i();
+      }
     }
     if (dofree) {
       tmp=cur->prev;
@@ -383,12 +385,12 @@ void _stack_genusage(memuse_list_t *stack, int dofree)
 /**
  * Pops a heap list and frees it.
  */
-void popheaplist()
+void popheaplist(bool codegen)
 {
   memuse_list_t *oldlist;
   assert(heapusage!=NULL);
 
-  _heap_freeusage(heapusage, 1);
+  _heap_freeusage(heapusage, true, codegen);
   assert(heapusage->head==NULL);
 
   oldlist=heapusage->prev;
@@ -411,12 +413,12 @@ void genheapfree(int stop_id)
   memuse_list_t *curlist = heapusage;
   while (curlist && curlist->list_id > stop_id)
   {
-    _heap_freeusage(curlist, 0);
+    _heap_freeusage(curlist, false, true);
     curlist = curlist->prev;
   }
 }
 
-void popstacklist(int codegen)
+void popstacklist(bool codegen)
 {
   memuse_list_t *oldlist;
   assert(stackusage != NULL);

--- a/compiler/sctracker.h
+++ b/compiler/sctracker.h
@@ -154,14 +154,14 @@ bool can_redef_layout_spec(LayoutSpec olddef, LayoutSpec newdef);
  */
 void pushheaplist();
 memuse_list_t *popsaveheaplist();
-void popheaplist();
+void popheaplist(bool codegen);
 int markheap(int type, int size);
 
 /**
  * Stack functions
  */
 void pushstacklist();
-void popstacklist(int codegen);
+void popstacklist(bool codegen);
 int markstack(int type, int size);
 /**
  * Generates code to free mem usage, but does not pop the list.  

--- a/exp/compiler/smx-builder.cpp
+++ b/exp/compiler/smx-builder.cpp
@@ -33,7 +33,7 @@ class FakeCodeSection : public SmxSection
 
     cod.codesize = sizeof(cod);
     cod.cellsize = 4;
-    cod.codeversion = SmxConsts::CODE_VERSION_REJECT;
+    cod.codeversion = SmxConsts::CODE_VERSION_ALWAYS_REJECT;
 
     return fwrite(&cod, sizeof(cod), 1, fp) == 1;
   }

--- a/include/smx/smx-headers.h
+++ b/include/smx/smx-headers.h
@@ -60,17 +60,14 @@ struct SmxConsts
   static const uint8_t FILE_COMPRESSION_NONE = 0;
   static const uint8_t FILE_COMPRESSION_GZ = 1;
 
-  // SourcePawn 1.
-  static const uint8_t CODE_VERSION_JIT_1_0 = 9;
-  static const uint8_t CODE_VERSION_JIT_1_1 = 10;
-  static const uint8_t CODE_VERSION_JIT_1_7 = 11;
-  static const uint8_t CODE_VERSION_SP1_MIN = CODE_VERSION_JIT_1_0;
-  static const uint8_t CODE_VERSION_SP1_MAX = CODE_VERSION_JIT_1_1;
-
-  // For SP1 consumers, the container version may not be checked, but usually
-  // the code version is. This constant allows newer containers to be rejected
-  // in those applications.
-  static const uint8_t CODE_VERSION_REJECT = 0x7F;
+  // Version 9: Initial version.
+  // Version 10: DEBUG code flag removed; no bytecode changes.
+  // Version 11: Not used; no changes.
+  // Version 12: PROC/RETN semantic changes.
+  static const uint8_t CODE_VERSION_MINIMUM = 9;
+  static const uint8_t CODE_VERSION_SM_LEGACY = 10;
+  static const uint8_t CODE_VERSION_CURRENT = 12;
+  static const uint8_t CODE_VERSION_ALWAYS_REJECT = 0x7f;
 };
 
 // These structures are byte-packed.

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -12,7 +12,7 @@ def main():
                       help="Optional test folder or test file")
   parser.add_argument('--disable-phopt', default=False, action='store_true',
                       help="Disable the peephole optimizer when compiling")
-  parser.add_argument('--spcomp', type=str, help="Path to spcomp", required=True)
+  parser.add_argument('--spcomp', type=str, help="spcomp invocation string", required=True)
   parser.add_argument('--shell', type=str, help="Path to shell", required=True)
   args = parser.parse_args()
 
@@ -85,7 +85,8 @@ class TestRunner(object):
   def __init__(self, args, tempFolder):
     super(TestRunner, self).__init__()
     self.args = args
-    self.spcomp = os.path.abspath(args.spcomp)
+    self.spcomp = args.spcomp.split(' ')
+    self.spcomp[0] = os.path.abspath(self.spcomp[0])
     self.shell = os.path.abspath(args.shell)
     self.tmp_folder = tempFolder
     self.inc_folder = os.path.dirname(os.path.abspath(__file__))
@@ -159,15 +160,14 @@ class TestRunner(object):
 
     test_path = test.path
     inc_folder = self.inc_folder
-    if os.path.isabs(test_path) and os.path.splitext(self.spcomp)[1] == '.js':
+    if os.path.isabs(test_path) and os.path.splitext(self.spcomp[0])[1] == '.js':
       test_path = '/fakeroot' + test_path
       inc_folder = '/fakeroot' + inc_folder
 
-    argv = [
-      self.spcomp,
+    argv = self.spcomp + [
       '-i' + inc_folder,
     ]
-    if os.path.splitext(self.spcomp)[1] == '.js':
+    if os.path.splitext(self.spcomp[0])[1] == '.js':
       argv = ['node'] + argv
     if self.args.disable_phopt:
       argv += ['-O0']

--- a/tools/testing/test-runtime.sh.in
+++ b/tools/testing/test-runtime.sh.in
@@ -4,6 +4,9 @@ status=0
 echo "Running shell tests..."
 python {source}/tests/runtests.py --spcomp "{spcomp}" --shell "{spshell}" || status=1
 
+echo "Running shell tests with codeversion 12..."
+python {source}/tests/runtests.py --spcomp "{spcomp} -x12" --shell "{spshell}" || status=1
+
 echo "Running shell tests with no optimizer..."
 python {source}/tests/runtests.py --disable-phopt --spcomp "{spcomp}" --shell "{spshell}" || status=1
 

--- a/vm/legacy-image.h
+++ b/vm/legacy-image.h
@@ -14,6 +14,7 @@
 #define _include_sourcepawn_vm_legacy_image_h_
 
 #include <string.h>
+#include <smx/smx-headers.h>
 
 namespace sp {
 
@@ -25,16 +26,10 @@ class LegacyImage
   virtual ~LegacyImage()
   {}
 
-  enum class CodeVersion {
-    Unknown,
-    SP_1_0,
-    SP_1_1
-  };
-
   struct Code {
     const uint8_t *bytes;
     size_t length;
-    CodeVersion version;
+    int version;
   };
   struct Data {
     const uint8_t *bytes;
@@ -77,7 +72,7 @@ class EmptyImage : public LegacyImage
     Code out;
     out.bytes = code_;
     out.length = sizeof(code_);
-    out.version = CodeVersion::SP_1_1;
+    out.version = SmxConsts::CODE_VERSION_SM_LEGACY;
     return out;
   }
   Data DescribeData() const override {

--- a/vm/plugin-context.cpp
+++ b/vm/plugin-context.cpp
@@ -684,7 +684,7 @@ PluginContext::pushAmxFrame()
 {
   if (!pushStack(frm_))
     return false;
-  if (!pushStack(0)) // unused cip
+  if (!pushStack(hp_))
     return false;
   frm_ = sp_;
   return true;
@@ -693,10 +693,9 @@ PluginContext::pushAmxFrame()
 bool
 PluginContext::popAmxFrame()
 {
-  assert(sp_ == frm_);
+  sp_ = frm_;
 
-  cell_t ignore;
-  if (!popStack(&ignore))
+  if (!popStack(&hp_))
     return false;
   if (!popStack(&frm_))
     return false;

--- a/vm/plugin-context.cpp
+++ b/vm/plugin-context.cpp
@@ -50,15 +50,10 @@ PluginContext::PluginContext(PluginRuntime *pRuntime)
   sp_ = mem_size_ - sizeof(cell_t);
   stp_ = sp_;
   frm_ = sp_;
-
-  tracker_.pBase = (ucell_t *)malloc(1024);
-  tracker_.pCur = tracker_.pBase;
-  tracker_.size = 1024 / sizeof(cell_t);
 }
 
 PluginContext::~PluginContext()
 {
-  free(tracker_.pBase);
   delete[] memory_;
 }
 
@@ -504,15 +499,17 @@ PluginContext::GetLocalParams()
 int
 PluginContext::popTrackerAndSetHeap()
 {
-  assert(tracker_.pCur > tracker_.pBase);
+  assert(sp_ >= hp_);
+  assert(hp_ >= cell_t(data_size_));
 
-  tracker_.pCur--;
-  if (tracker_.pCur < tracker_.pBase)
+  if (hp_ - cell_t(data_size_) < sizeof(cell_t))
     return SP_ERROR_TRACKER_BOUNDS;
 
-  ucell_t amt = *tracker_.pCur;
-  if (amt > (hp_ - data_size_))
-    return SP_ERROR_HEAPMIN;
+  hp_ -= sizeof(cell_t);
+  cell_t amt = *reinterpret_cast<cell_t*>(memory_ + hp_);
+
+  if (amt < 0 || hp_ - cell_t(data_size_) < amt)
+    return SP_ERROR_TRACKER_BOUNDS;
 
   hp_ -= amt;
   return SP_ERROR_NONE;
@@ -521,21 +518,13 @@ PluginContext::popTrackerAndSetHeap()
 int
 PluginContext::pushTracker(uint32_t amount)
 {
-  if ((size_t)(tracker_.pCur - tracker_.pBase) >= tracker_.size)
+  if (amount > INT_MAX)
+    return SP_ERROR_TRACKER_BOUNDS;
+  if (sp_ - hp_ < STACK_MARGIN)
     return SP_ERROR_TRACKER_BOUNDS;
 
-  if (tracker_.pCur + 1 - (tracker_.pBase + tracker_.size) == 0) {
-    size_t disp = tracker_.size - 1;
-    tracker_.size *= 2;
-    tracker_.pBase = (ucell_t *)realloc(tracker_.pBase, tracker_.size * sizeof(cell_t));
-
-    if (!tracker_.pBase)
-      return SP_ERROR_TRACKER_BOUNDS;
-
-    tracker_.pCur = tracker_.pBase + disp;
-  }
-
-  *tracker_.pCur++ = amount;
+  *reinterpret_cast<cell_t*>(memory_ + hp_) = amount;
+  hp_ += sizeof(cell_t);
   return SP_ERROR_NONE;
 }
 
@@ -647,9 +636,6 @@ PluginContext::generateFullArray(uint32_t argc, cell_t *argv, int autozero)
   if (dat_hp >= argv - STACK_MARGIN)
     return SP_ERROR_HEAPLOW;
 
-  if (int err = pushTracker(bytes))
-    return err;
-
   cell_t *base = reinterpret_cast<cell_t *>(memory_ + hp_);
   cell_t offs = GenerateArrayIndirectionVectors(base, argv, argc, !!autozero);
   assert(size_t(offs) == cells);
@@ -657,6 +643,9 @@ PluginContext::generateFullArray(uint32_t argc, cell_t *argv, int autozero)
 
   argv[argc - 1] = hp_;
   hp_ = new_hp;
+
+  if (int err = pushTracker(bytes))
+    return err;
   return SP_ERROR_NONE;
 }
 
@@ -671,10 +660,10 @@ PluginContext::generateArray(cell_t dims, cell_t *stk, bool autozero)
 
     uint32_t bytes = size * 4;
 
-    hp_ += bytes;
-    if (uintptr_t(memory_ + hp_) >= uintptr_t(stk))
+    if (uintptr_t(memory_ + hp_ + bytes) >= uintptr_t(stk))
       return SP_ERROR_HEAPLOW;
 
+    hp_ += bytes;
     if (int err = pushTracker(bytes))
       return err;
 

--- a/vm/plugin-context.h
+++ b/vm/plugin-context.h
@@ -19,18 +19,6 @@
 
 namespace sp {
 
-struct HeapTracker
-{
-  HeapTracker()
-   : size(0),
-     pBase(nullptr),
-     pCur(nullptr)
-  {}
-  size_t size; 
-  ucell_t *pBase; 
-  ucell_t *pCur;
-};
-
 static const size_t SP_MAX_RETURN_STACK = 1024;
 static const cell_t STACK_MARGIN = 64; // 16 parameters of safety, I guess
 
@@ -88,9 +76,6 @@ class PluginContext : public BasePluginContext
  public:
   bool IsInExec() override;
 
-  static inline size_t offsetOfTracker() {
-    return offsetof(PluginContext, tracker_);
-  }
   static inline size_t offsetOfSp() {
     return offsetof(PluginContext, sp_);
   }
@@ -132,6 +117,8 @@ class PluginContext : public BasePluginContext
   bool popAmxFrame();
   bool pushStack(cell_t value);
   bool popStack(cell_t* out);
+  bool pushHeap(cell_t value);
+  bool popHeap(cell_t* out);
   bool addStack(cell_t amount);
   bool getFrameValue(cell_t offset, cell_t* out);
   bool setFrameValue(cell_t offset, cell_t value);
@@ -150,9 +137,6 @@ class PluginContext : public BasePluginContext
 
   cell_t *m_pNullVec;
   cell_t *m_pNullString;
-
-  // Tracker for local HEA growth.
-  HeapTracker tracker_;
 
   // "Stack top", for convenience.
   cell_t stp_;

--- a/vm/smx-v1-image.cpp
+++ b/vm/smx-v1-image.cpp
@@ -229,9 +229,9 @@ SmxV1Image::validateCode()
 
   const sp_file_code_t *code =
     reinterpret_cast<const sp_file_code_t *>(buffer() + section->dataoffs);
-  if (code->codeversion < SmxConsts::CODE_VERSION_SP1_MIN)
+  if (code->codeversion < SmxConsts::CODE_VERSION_MINIMUM)
     return error("code version is too old, no longer supported");
-  if (code->codeversion > SmxConsts::CODE_VERSION_SP1_MAX)
+  if (code->codeversion > SmxConsts::CODE_VERSION_CURRENT)
     return error("code version is too new, not supported");
   if (code->cellsize != 4)
     return error("unsupported cellsize");
@@ -424,18 +424,7 @@ SmxV1Image::DescribeCode() const -> Code
   Code code;
   code.bytes = code_.blob();
   code.length = code_.length();
-  switch (code_->codeversion) {
-    case SmxConsts::CODE_VERSION_JIT_1_0:
-      code.version = CodeVersion::SP_1_0;
-      break;
-    case SmxConsts::CODE_VERSION_JIT_1_1:
-      code.version = CodeVersion::SP_1_1;
-      break;
-    default:
-      assert(false);
-      code.version = CodeVersion::Unknown;
-      break;
-  }
+  code.version = code_->codeversion;
   return code;
 }
 

--- a/vm/x86/jit_x86.cpp
+++ b/vm/x86/jit_x86.cpp
@@ -223,9 +223,11 @@ Compiler::emitPrologue()
   __ enterFrame(JitFrameType::Scripted, pcode_start_);
 
   // Push the old frame onto the stack.
+  __ subl(stk, 8);
   __ movl(tmp, Operand(frmAddr()));
-  __ movl(Operand(stk, -4), tmp);
-  __ subl(stk, 8);    // extra unused slot for non-existant CIP
+  __ movl(Operand(stk, 4), tmp);
+  __ movl(tmp, Operand(hpAddr()));
+  __ movl(Operand(stk, 0), tmp);
 
   // Get and store the new frame.
   __ movl(tmp, stk);
@@ -613,8 +615,11 @@ Compiler::visitSTRB_I(cell_t width)
 bool
 Compiler::visitRETN()
 {
-  // Restore the old frame pointer.
+  // Restore the old stack and frame pointer.
+  __ movl(stk, frm);
   __ movl(frm, Operand(stk, 4));              // get the old frm
+  __ movl(tmp, Operand(stk, 0));              // get the old hp
+  __ movl(Operand(hpAddr()), tmp);
   __ addl(stk, 8);                            // pop stack
   __ movl(Operand(frmAddr()), frm);           // store back old frm
   __ addl(frm, dat);                          // relocate


### PR DESCRIPTION
The way RETN works is pretty lame. The compiler is responsible for balancing the stack and heap, despite the fact that the VM can already trivially do that. In fact, the VM *does* do it. The correct sp/hp values are restored after an exception, since the RETN instruction would never be reached.

This balancing requirement makes it harder to improve the compiler, since we have to emit an epilogue at every return site, which places a useless bookkeeping restriction and generates unnecessary bytecode.

There's an argument that requiring a balanced stack at RETN helps catch compiler bugs, but I'd argue those bugs aren't really important. Codegen leaks will be caught if they matter - inside loops, or with recursion. And codegen leaks are extremely rare. We've only had one that I know of, and it only manifested in a loop [1].

As a bonus, changing RETN simplifies some things in the VM. We finally have a reason to remove the hideous HeapTracker data structure which has somehow survived since ~2006 - the sizes of HEA allocations can just be stored in HEA itself. Then in the PROC/RETN paths, we simply store/pop the HEA pointer in the frame (there was a free slot that is used upstream, but not in SourcePawn). The SP pointer was always there to begin with.

Old PROC:
 - Push FRM
 - Push 0
 - FRM = SP

Old RETN:
 - Pop
 - Pop FRM

New PROC:
 - Push FRM
 - Push HP
 - FRM = SP

New RETN:
 - SP = FRM
 - Pop HP
 - Pop FRM

Since a compiler cannot rely on this new functionality without a compatible VM, the bytecode version has received its first ever actual compatibility bump to 12. For now, the compiler still generates version 10 bytecode. An -x12 argument has been added to opt-in to the new semantics.

The VM now has a few more instructions for PROC/RETN, but a v12 compiler should be generating more efficient code. (And possibly as a follow-up we could remove instructions if the function is known not to use HEA.)

[1] https://bugs.alliedmods.net/show_bug.cgi?id=6370