### PR TITLE
Remove #pragma rational.

### DIFF
--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -1160,6 +1160,7 @@ static void setconstants(void)
   assert(sc_status==statIDLE);
 
   gTypes.init();
+  assert(sc_rationaltag);
 
   add_constant("true",1,sGLOBAL,1);     /* boolean flags */
   add_constant("false",0,sGLOBAL,1);

--- a/compiler/sc2.cpp
+++ b/compiler/sc2.cpp
@@ -1086,35 +1086,8 @@ static int command(void)
         } else if (strcmp(str,"dynamic")==0) {
           preproc_expr(&pc_stksize,NULL);
         } else if (strcmp(str,"rational")==0) {
-          char name[sNAMEMAX+1];
-          cell digits=0;
-          size_t i;
-          /* first gather all information, start with the tag name */
-          while (*lptr<=' ' && *lptr!='\0')
+          while (*lptr!='\0')
             lptr++;
-          for (i=0; i<sizeof name && alphanum(*lptr); i++,lptr++)
-            name[i]=*lptr;
-          name[i]='\0';
-          /* then the precision (for fixed point arithmetic) */
-          while (*lptr<=' ' && *lptr!='\0')
-            lptr++;
-          if (*lptr=='(') {
-            preproc_expr(&digits,NULL);
-            if (digits<=0 || digits>9) {
-              error(68);        /* invalid rational number precision */
-              digits=0;
-            } /* if */
-            if (*lptr==')')
-              lptr++;
-          } /* if */
-          /* add the tag (make it public) and check the values */
-          int tag=pc_addtag(name);
-          if (sc_rationaltag==0 || (sc_rationaltag==tag && rational_digits==(int)digits)) {
-            sc_rationaltag=tag;
-            rational_digits=(int)digits;
-          } else {
-            error(69);          /* rational number format already set, can only be set once */
-          } /* if */
         } else if (strcmp(str,"semicolon")==0) {
           cell val;
           preproc_expr(&val,NULL);


### PR DESCRIPTION
There's a snowball's chance in hell that we're going to treat rational literals as fixed-point, so I think it's safe to remove `#pragma rational`.