### PR TITLE
Fully support basic floating point operations in spshell.

### DIFF
--- a/include/core/float.inc
+++ b/include/core/float.inc
@@ -1,0 +1,167 @@
+/**
+ * vim: set ts=4 :
+ * =============================================================================
+ * SourceMod (C)2004-2008 AlliedModders LLC.  All rights reserved.
+ * =============================================================================
+ *
+ * This file is part of the SourceMod/SourcePawn SDK.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 3.0, as published by the
+ * Free Software Foundation.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITneSS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * As a special exception, AlliedModders LLC gives you permission to link the
+ * code of this program (as well as its derivative works) to "Half-Life 2," the
+ * "Source Engine," the "SourcePawn JIT," and any Game MODs that run on software
+ * by the Valve Corporation.  You must obey the GNU General Public License in
+ * all respects for all other code used.  Additionally, AlliedModders LLC grants
+ * this exception to all derivative works.  AlliedModders LLC defines further
+ * exceptions, found in LICENSE.txt (as of this writing, version JULY-31-2007),
+ * or <http://www.sourcemod.net/license.php>.
+ *
+ * Version: $Id$
+ */
+ 
+#if defined _core_float_included
+ #endinput
+#endif
+#define _core_float_included
+
+#if !defined __sourcepawn2__
+native float __float_ctor(int value);
+native float __float_add(float a, float b);
+native float __float_sub(float a, float b);
+native float __float_mul(float a, float b);
+native float __float_div(float dividend, float divisor);
+native bool __float_gt(float a, float b);
+native bool __float_ge(float a, float b);
+native bool __float_lt(float a, float b);
+native bool __float_le(float a, float b);
+native bool __float_eq(float a, float b);
+native bool __float_ne(float a, float b);
+native bool __float_not(float a);
+native int __float_to_int(float a);
+
+native float operator*(float oper1, float oper2) = __float_mul;
+native float operator/(float oper1, float oper2) = __float_div;
+native float operator+(float oper1, float oper2) = __float_add;
+native float operator-(float oper1, float oper2) = __float_sub;
+native bool operator!(float oper1) = __float_not;
+native bool operator>(float oper1, float oper2) = __float_gt;
+native bool operator>=(float oper1, float oper2) = __float_ge;
+native bool operator<(float oper1, float oper2) = __float_lt;
+native bool operator<=(float oper1, float oper2) = __float_le;
+native bool operator!=(float oper1, float oper2) = __float_ne;
+native bool operator==(float oper1, float oper2) = __float_eq;
+
+stock float operator++(float oper)
+{
+  return oper+1.0;
+}
+
+stock float operator--(float oper)
+{
+  return oper-1.0;
+}
+
+stock float operator-(float oper)
+{
+  return oper^float cellmin;               /* IEEE values are sign/magnitude */
+}
+
+stock float operator*(float oper1, oper2)
+{
+  return __float_mul(oper1, float(oper2)); /* "*" is commutative */
+}
+
+stock float operator/(float oper1, oper2)
+{
+  return __float_div(oper1, float(oper2));
+}
+
+stock float operator/(oper1, float oper2)
+{
+  return __float_div(float(oper1), oper2);
+}
+
+stock float operator+(float oper1, oper2)
+{
+  return __float_add(oper1, float(oper2));      /* "+" is commutative */
+}
+
+stock float operator-(float oper1, oper2)
+{
+  return __float_sub(oper1, float(oper2));
+}
+
+stock float operator-(oper1, float oper2)
+{
+  return __float_sub(float(oper1), oper2);
+}
+
+stock bool operator==(float oper1, oper2)
+{
+  return __float_eq(oper1, float(oper2));
+}
+
+stock bool operator!=(float oper1, oper2)
+{
+  return __float_ne(oper1, float(oper2));
+}
+
+stock bool operator>(float oper1, oper2)
+{
+  return __float_gt(oper1, float(oper2));
+}
+
+stock bool operator>(oper1, float oper2)
+{
+  return __float_gt(float(oper1), oper2);
+}
+
+stock bool operator>=(float oper1, oper2)
+{
+  return __float_ge(oper1, float(oper2));
+}
+
+stock bool operator>=(oper1, float oper2)
+{
+  return __float_ge(float(oper1), oper2);
+}
+
+stock bool operator<(float oper1, oper2)
+{
+  return __float_lt(oper1, float(oper2));
+}
+
+stock bool operator<(oper1, float oper2)
+{
+  return __float_lt(float(oper1), oper2);
+}
+
+stock bool operator<=(float oper1, oper2)
+{
+  return __float_le(oper1, float(oper2));
+}
+
+stock bool operator<=(oper1, float oper2)
+{
+  return __float_le(float(oper1), oper2);
+}
+
+/**
+ * Forbidden operators.
+ *
+ */
+forward operator%(float oper1, float oper2);
+forward operator%(float oper1, oper2);
+forward operator%(oper1, float oper2);
+#endif // __sourcepawn2__

--- a/include/smx/smx-v1-opcodes.h
+++ b/include/smx/smx-v1-opcodes.h
@@ -237,6 +237,7 @@ namespace sp {
   _U(STKADJUST,      "stackadjust")    \
   _G(ENDPROC,        "endproc")        \
   _U(LDGFN_PRI,      "ldgfn.pri")      \
+  /* Opcodes below this are pseudo-opcodes and are not part of the ABI */ \
   _G(FABS,           "fabs")           \
   _G(FLOAT,          "float")          \
   _G(FLOATADD,       "float.add")      \

--- a/tests/basic/float-math.sp
+++ b/tests/basic/float-math.sp
@@ -25,4 +25,3 @@ public main()
   printfloat(FloatAbs(d));
   printfloat(FloatAbs(a));
 }
-

--- a/tests/float.inc
+++ b/tests/float.inc
@@ -1,49 +1,12 @@
-#if defined _float_included
+#if defined _shell_float_included
  #endinput
 #endif
-#define _float_included
+#define _shell_float_included
 
-#if !defined __sourcepawn2__
-/**
- * Converts an integer into a floating point value.
- *
- * @param value			Integer to convert.
- * @return				Floating point value.
- */
-native float float(int value);
-#endif
+#include <core/float>
 
-native float FloatMul(float oper1, float oper2);
-native float FloatDiv(float dividend, float divisor);
-native float FloatAdd(float oper1, float oper2);
-native float FloatSub(float oper1, float oper2);
 native int RoundToZero(float value);
 native int RoundToCeil(float value);
 native int RoundToFloor(float value);
 native int RoundToNearest(float value);
-native int FloatCompare(float fOne, float fTwo);
 native float FloatAbs(float value);
-
-#if !defined __sourcepawn2__
-#pragma rational Float
-
-native bool __FLOAT_GT__(float a, float b);
-native bool __FLOAT_GE__(float a, float b);
-native bool __FLOAT_LT__(float a, float b);
-native bool __FLOAT_LE__(float a, float b);
-native bool __FLOAT_EQ__(float a, float b);
-native bool __FLOAT_NE__(float a, float b);
-native bool __FLOAT_NOT__(float a);
-
-native float operator*(float oper1, float oper2) = FloatMul;
-native float operator/(float oper1, float oper2) = FloatDiv;
-native float operator+(float oper1, float oper2) = FloatAdd;
-native float operator-(float oper1, float oper2) = FloatSub;
-native bool operator!(float oper1) = __FLOAT_NOT__;
-native bool operator>(float oper1, float oper2) = __FLOAT_GT__;
-native bool operator>=(float oper1, float oper2) = __FLOAT_GE__;
-native bool operator<(float oper1, float oper2) = __FLOAT_LT__;
-native bool operator<=(float oper1, float oper2) = __FLOAT_LE__;
-native bool operator!=(float oper1, float oper2) = __FLOAT_NE__;
-native bool operator==(float oper1, float oper2) = __FLOAT_EQ__;
-#endif // __sourcepawn2__

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -148,6 +148,11 @@ class TestRunner(object):
   def add_test(self, name, path):
     self.tests.append(Test(name, path))
 
+  def fix_path(self, path):
+    if os.path.isabs(path) and os.path.splitext(self.spcomp[0])[1] == '.js':
+      return '/fakeroot' + path
+    return path
+
   def run_test(self, test):
     self.out("{0}:\n".format(test.name))
 
@@ -169,15 +174,12 @@ class TestRunner(object):
   def run_compiler(self, test):
     self.out("  [SMX] ")
 
-    test_path = test.path
-    inc_folder = self.inc_folder
-    if os.path.isabs(test_path) and os.path.splitext(self.spcomp[0])[1] == '.js':
-      test_path = '/fakeroot' + test_path
-      inc_folder = '/fakeroot' + inc_folder
+    test_path = self.fix_path(test.path)
+    inc_folder = self.fix_path(self.inc_folder)
 
     argv = self.spcomp + [
       '-i' + inc_folder,
-      '-i' + os.path.abspath(self.include_path),
+      '-i' + self.fix_path(os.path.abspath(self.include_path)),
     ]
     if os.path.splitext(self.spcomp[0])[1] == '.js':
       argv = ['node'] + argv

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -99,6 +99,17 @@ class TestRunner(object):
     self.numRunFailures = 0
     self.failures = []
 
+    # Walk up the test path looking for an 'include' folder.
+    search_path, _ = os.path.split(self.testpath)
+    while True:
+      include_path = os.path.join(search_path, 'include')
+      if os.path.exists(include_path):
+        break
+      search_path, tail = os.path.split(search_path)
+      if not tail:
+        break
+    self.include_path = include_path
+
   def run(self):
     self.collect_tests()
 
@@ -166,6 +177,7 @@ class TestRunner(object):
 
     argv = self.spcomp + [
       '-i' + inc_folder,
+      '-i' + os.path.abspath(self.include_path),
     ]
     if os.path.splitext(self.spcomp[0])[1] == '.js':
       argv = ['node'] + argv

--- a/vm/AMBuilder
+++ b/vm/AMBuilder
@@ -51,6 +51,7 @@ for arch in Root.archs:
   library.sources += [
     'api.cpp',
     'base-context.cpp',
+    'builtins.cpp',
     'code-allocator.cpp',
     'code-stubs.cpp',
     'compiled-function.cpp',

--- a/vm/builtins.cpp
+++ b/vm/builtins.cpp
@@ -1,0 +1,153 @@
+// vim: set sts=2 ts=8 sw=2 tw=99 et:
+// 
+// Copyright (C) 2006-2018 AlliedModders LLC
+// 
+// This file is part of SourcePawn. SourcePawn is free software: you can
+// redistribute it and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License along with
+// SourcePawn. If not, see http://www.gnu.org/licenses/.
+//
+#include "builtins.h"
+#include <am-float.h>
+#include <math.h>
+
+namespace sp {
+
+using namespace SourcePawn;
+
+extern sp_nativeinfo_t gBuiltinFloatNatives[];
+
+BuiltinNatives::BuiltinNatives()
+{
+}
+
+bool
+BuiltinNatives::Initialize()
+{
+  if (!map_.init(32))
+    return false;
+
+  for (size_t i = 0; gBuiltinFloatNatives[i].name != nullptr; i++) {
+    const sp_nativeinfo_t& entry = gBuiltinFloatNatives[i];
+    NativeMap::Insert p = map_.findForAdd(entry.name);
+    assert(!p.found());
+    map_.add(p, entry.name, entry.func);
+  }
+
+  return true;
+}
+
+SPVM_NATIVE_FUNC
+BuiltinNatives::Lookup(const char* name)
+{
+  NativeMap::Result r = map_.find(name);
+  if (!r.found())
+    return nullptr;
+  return r->value;
+}
+
+static cell_t
+FloatCtor(IPluginContext *pCtx, const cell_t *params)
+{
+  float val = static_cast<float>(params[1]);
+
+  return sp_ftoc(val);
+}
+
+static cell_t
+FloatAdd(IPluginContext *pCtx, const cell_t *params)
+{
+  float val = sp_ctof(params[1]) + sp_ctof(params[2]);
+
+  return sp_ftoc(val);
+}
+
+static cell_t
+FloatSub(IPluginContext *pCtx, const cell_t *params)
+{
+  float val = sp_ctof(params[1]) - sp_ctof(params[2]);
+
+  return sp_ftoc(val);
+}
+
+static cell_t
+FloatMul(IPluginContext *pCtx, const cell_t *params)
+{
+  float val = sp_ctof(params[1]) * sp_ctof(params[2]);
+
+  return sp_ftoc(val);
+}
+
+static cell_t
+FloatDiv(IPluginContext *pCtx, const cell_t *params)
+{
+  float val = sp_ctof(params[1]) / sp_ctof(params[2]);
+
+  return sp_ftoc(val);
+}
+
+static cell_t
+FloatGt(IPluginContext *pCtx, const cell_t *params)
+{
+  return !!(sp_ctof(params[1]) > sp_ctof(params[2]));
+}
+
+static cell_t
+FloatGe(IPluginContext *pCtx, const cell_t *params)
+{
+  return !!(sp_ctof(params[1]) >= sp_ctof(params[2]));
+}
+
+static cell_t
+FloatLt(IPluginContext *pCtx, const cell_t *params)
+{
+  return !!(sp_ctof(params[1]) < sp_ctof(params[2]));
+}
+
+static cell_t
+FloatLe(IPluginContext *pCtx, const cell_t *params)
+{
+  return !!(sp_ctof(params[1]) <= sp_ctof(params[2]));
+}
+
+static cell_t
+FloatEq(IPluginContext *pCtx, const cell_t *params)
+{
+  return !!(sp_ctof(params[1]) == sp_ctof(params[2]));
+}
+
+static cell_t
+FloatNe(IPluginContext *pCtx, const cell_t *params)
+{
+  return !!(sp_ctof(params[1]) != sp_ctof(params[2]));
+}
+
+static cell_t
+FloatNot(IPluginContext *pCtx, const cell_t *params)
+{
+  float val = sp_ctof(params[1]);
+  if (ke::IsNaN(val))
+    return 1;
+  return val ? 0 : 1;
+}
+
+sp_nativeinfo_t gBuiltinFloatNatives[] = {
+  {"__float_ctor",    FloatCtor},
+  {"__float_mul",     FloatMul},
+  {"__float_div",     FloatDiv},
+  {"__float_add",     FloatAdd},
+  {"__float_sub",     FloatSub},
+  {"__float_gt",      FloatGt},
+  {"__float_ge",      FloatGe},
+  {"__float_lt",      FloatLt},
+  {"__float_le",      FloatLe},
+  {"__float_eq",      FloatEq},
+  {"__float_ne",      FloatNe},
+  {"__float_not",     FloatNot},
+  {nullptr,           nullptr},
+};
+
+} // namespace sp

--- a/vm/builtins.h
+++ b/vm/builtins.h
@@ -1,0 +1,49 @@
+// vim: set sts=2 ts=8 sw=2 tw=99 et:
+// 
+// Copyright (C) 2006-2018 AlliedModders LLC
+// 
+// This file is part of SourcePawn. SourcePawn is free software: you can
+// redistribute it and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License along with
+// SourcePawn. If not, see http://www.gnu.org/licenses/.
+//
+#ifndef _include_sourcepawn_vm_builtins_h_
+#define _include_sourcepawn_vm_builtins_h_
+
+#include <sp_vm_types.h>
+#include <amtl/am-hashmap.h>
+#include <string.h>
+
+namespace sp {
+
+class BuiltinNatives
+{
+ public:
+  BuiltinNatives();
+
+  bool Initialize();
+
+  SPVM_NATIVE_FUNC Lookup(const char* name);
+
+ private:
+  struct NativeMapPolicy {
+    static inline bool matches(const char* lookup, const char* key) {
+      return strcmp(lookup, key) == 0;
+    }
+    static inline uint32_t hash(const char* key) {
+      return ke::FastHashCharSequence(key, strlen(key));
+    }
+  };
+  typedef ke::HashMap<const char*,
+                      SPVM_NATIVE_FUNC,
+                      NativeMapPolicy> NativeMap;
+
+  NativeMap map_;
+};
+
+} // namespace sp
+
+#endif // _include_sourcepawn_vm_builtins_h_

--- a/vm/environment.cpp
+++ b/vm/environment.cpp
@@ -23,6 +23,7 @@
 #include "jit.h"
 #endif
 #include "interpreter.h"
+#include "builtins.h"
 #include <stdarg.h>
 
 using namespace sp;
@@ -79,11 +80,14 @@ Environment::Initialize()
   api_v1_ = new SourcePawnEngine();
   api_v2_ = new SourcePawnEngine2();
   watchdog_timer_ = new WatchdogTimer(this);
+  builtins_ = new BuiltinNatives();
   code_alloc_ = new CodeAllocator();
   code_stubs_ = new CodeStubs(this);
 
   // Safe to initialize code now that we have the code cache.
   if (!code_stubs_->Initialize())
+    return false;
+  if (!builtins_->Initialize())
     return false;
 
   return true;
@@ -93,6 +97,7 @@ void
 Environment::Shutdown()
 {
   watchdog_timer_->Shutdown();
+  builtins_ = nullptr;
   code_stubs_ = nullptr;
   code_alloc_ = nullptr;
   PoolAllocator::FreeDefault();

--- a/vm/environment.h
+++ b/vm/environment.h
@@ -29,6 +29,7 @@ class PluginRuntime;
 class CodeStubs;
 class WatchdogTimer;
 class ErrorReport;
+class BuiltinNatives;
 
 // An Environment encapsulates everything that's needed to load and run
 // instances of plugins on a single thread. There can be at most one
@@ -75,6 +76,9 @@ class Environment : public ISourcePawnEnvironment
 
   CodeStubs *stubs() {
     return code_stubs_;
+  }
+  BuiltinNatives* builtins() {
+    return builtins_;
   }
 
   // Runtime management.
@@ -157,11 +161,13 @@ class Environment : public ISourcePawnEnvironment
  private:
   bool Initialize();
 
- private:
   void DispatchReport(const ErrorReport &report);
+
+ private:
   ke::AutoPtr<ISourcePawnEngine> api_v1_;
   ke::AutoPtr<ISourcePawnEngine2> api_v2_;
   ke::AutoPtr<WatchdogTimer> watchdog_timer_;
+  ke::AutoPtr<BuiltinNatives> builtins_;
   ke::Mutex mutex_;
 
   IDebugListener *debugger_;


### PR DESCRIPTION
Currently, floating point functions in SourcePawn are optimized by hardcoding the native names SourceMod uses. The hack is not very rigorous. Nevertheless, it exists, and it's why spshell is able to use float ops despite not having the natives.

Let's finally promote at least some of the floating point library to builtin status. We'll probably see more of this in the future (since it's a nice way to prototype new opcodes too), so this patch introduces a "builtins" mechanism. The actual way things get bound is still tied to float native replacement.

Note that when using the new `<core/float>` include, the native names are different from SourceMod (`__float_sub` instead of `FloatSub`, for example). This again is in anticipation of having other special builtins for underlying features. SourceMod won't be upgraded to the new names - there's no particular reason to, and it would cause some minor disruption.