### PR TITLE
Replace codeversion with feature flags.

### DIFF
--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -878,9 +878,12 @@ static void parseoptions(int argc,char **argv,char *oname,char *ename,char *pnam
       case 'x':
         i=(int)strtol(option_value(ptr,argv,argc,&arg),(char **)&ptr,10);
         switch (i) {
+          case 13:
           case 12:
-            pc_code_version = i;
             pc_must_drop_stack = false;
+            /* Fallthrough */
+          case 10:
+            pc_code_version = i;
             break;
           default:
             fprintf(stderr, "unknown code version: %d\n", i);

--- a/compiler/sc6.cpp
+++ b/compiler/sc6.cpp
@@ -919,6 +919,7 @@ static void assemble_to_buffer(MemoryBuffer *buffer, void *fin)
   code->header().flags = CODEFLAG_DEBUG;
   code->header().main = 0;
   code->header().code = sizeof(sp_file_code_t);
+  code->header().features = 0;
   code->setBlob((uint8_t *)code_buffer.buffer(), code_buffer.length() * sizeof(cell));
 
   // Set up the data section. Note pre-SourceMod 1.7, the |memsize| was

--- a/include/smx/smx-headers.h
+++ b/include/smx/smx-headers.h
@@ -66,7 +66,8 @@ struct SmxConsts
   // Version 12: PROC/RETN semantic changes.
   static const uint8_t CODE_VERSION_MINIMUM = 9;
   static const uint8_t CODE_VERSION_SM_LEGACY = 10;
-  static const uint8_t CODE_VERSION_CURRENT = 12;
+  static const uint8_t CODE_VERSION_FEATURE_MASK = 13;
+  static const uint8_t CODE_VERSION_CURRENT = CODE_VERSION_FEATURE_MASK;
   static const uint8_t CODE_VERSION_ALWAYS_REJECT = 0x7f;
 };
 
@@ -161,6 +162,13 @@ typedef struct sp_file_code_s
   uint16_t  flags;       /**< Flags. */
   uint32_t  main;        /**< Address to "main". */
   uint32_t  code;        /**< Offset to bytecode, relative to the start of this section. */
+
+  /* This field is only guaranteed to be present when codeversion >= 13 or
+   * higher. Note that newer spcomp versions will still include a 0-filled
+   * value. This is legal since anything between the end of the code header
+   * and the code buffer is undefined. The field should still be ignored.
+   */
+  uint32_t  features;    /**< List of features flags that this code requires. */
 } sp_file_code_t;
 
 #if defined __GNUC__

--- a/tools/smxtools/smxdasm/V1Types.cs
+++ b/tools/smxtools/smxdasm/V1Types.cs
@@ -34,6 +34,9 @@ namespace smxdasm
         // Offset to the code section.
         public int codeoffs;
 
+        // Feature set.
+        public int features;
+
         public static CodeV1Header From(BinaryReader rd)
         {
             var code = new CodeV1Header();
@@ -43,6 +46,8 @@ namespace smxdasm
             code.Flags = (CodeV1Flags)rd.ReadUInt16();
             code.main = rd.ReadInt32();
             code.codeoffs = rd.ReadInt32();
+            if (code.CodeVersion >= 13)
+              code.features = rd.ReadInt32();
             return code;
         }
     }

--- a/tools/smxtools/smxviewer/MainWindow.cs
+++ b/tools/smxtools/smxviewer/MainWindow.cs
@@ -473,6 +473,7 @@ namespace smxviewer
                 addDetailLine("flags = 0x{0:x} ; {0}", code.Header.Flags, code.Header.Flags.ToString());
                 addDetailLine("main = 0x{0:x}", code.Header.main);
                 addDetailLine("codeoffs = 0x{0:x}", code.Header.codeoffs);
+                addDetailLine("features = 0x{0:x}", code.Header.features);
                 endDetailUpdate();
             }, code);
 

--- a/vm/legacy-image.h
+++ b/vm/legacy-image.h
@@ -30,6 +30,7 @@ class LegacyImage
     const uint8_t *bytes;
     size_t length;
     int version;
+    uint32_t features;
   };
   struct Data {
     const uint8_t *bytes;

--- a/vm/smx-v1-image.cpp
+++ b/vm/smx-v1-image.cpp
@@ -213,7 +213,7 @@ SmxV1Image::validateData()
 
   const uint8_t *blob =
     reinterpret_cast<const uint8_t *>(data) + data->data;
-  data_ = Blob<sp_file_data_t>(section, data, blob, data->datasize);
+  data_ = Blob<sp_file_data_t>(section, data, blob, data->datasize, 0);
   return true;
 }
 
@@ -242,9 +242,16 @@ SmxV1Image::validateCode()
   if (code->codesize > (section->size - code->code))
     return error("invalid code blob");
 
+  uint32_t features = 0;
+  if (code->codeversion >= SmxConsts::CODE_VERSION_FEATURE_MASK)
+    features = code->features;
+
+  if (features)
+    return error("unsupported feature set; code is too new");
+
   const uint8_t *blob =
     reinterpret_cast<const uint8_t *>(code) + code->code;
-  code_ = Blob<sp_file_code_t>(section, code, blob, code->codesize);
+  code_ = Blob<sp_file_code_t>(section, code, blob, code->codesize, features);
   return true;
 }
 
@@ -425,6 +432,7 @@ SmxV1Image::DescribeCode() const -> Code
   code.bytes = code_.blob();
   code.length = code_.length();
   code.version = code_->codeversion;
+  code.features = code_.features();
   return code;
 }
 

--- a/vm/smx-v1-image.h
+++ b/vm/smx-v1-image.h
@@ -74,16 +74,19 @@ class SmxV1Image
      : header_(nullptr),
        section_(nullptr),
        blob_(nullptr),
-       length_(0)
+       length_(0),
+       features_(0)
     {}
     Blob(const Section *header,
          const T *section,
          const uint8_t *blob,
-         size_t length)
+         size_t length,
+         uint32_t features)
      : header_(header),
        section_(section),
        blob_(blob),
-       length_(length)
+       length_(length),
+       features_(features)
     {}
 
     size_t size() const {
@@ -101,12 +104,16 @@ class SmxV1Image
     bool exists() const {
       return !!header_;
     }
+    uint32_t features() const {
+      return features_;
+    }
 
    private:
     const Section *header_;
     const T *section_;
     const uint8_t *blob_;
     size_t length_;
+    uint32_t features_;
   };
 
   template <typename T>


### PR DESCRIPTION
The codeversion field is a little too heavy weight and makes it difficult to support parallel
compiler branches. We ideally need a major/minor system or a feature flag set. In this patch
we opt for feature flags since they also make it easier to develop experimental features.

The version has been bumped to 13 for this patch.

Newer compilers will still emit codeversion=11 by default. The feature bits will still be present,
but set to zero. This is legal since the file format requires ignoring extra data between the
header and code blob, and indeed all old VMs follow this rule.