### PR TITLE
Restyle vm/ to use |T*| and |T&| instead of |T *| and |T &|.

### DIFF
--- a/vm/api.cpp
+++ b/vm/api.cpp
@@ -51,22 +51,22 @@ SourcePawnEngine::SourcePawnEngine()
 {
 }
 
-const char *
+const char*
 SourcePawnEngine::GetErrorString(int error)
 {
   return Environment::get()->GetErrorString(error);
 }
 
-void *
+void*
 SourcePawnEngine::ExecAlloc(size_t size)
 {
 #if defined WIN32
   return VirtualAlloc(NULL, size, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
 #elif defined __GNUC__
 # if defined __APPLE__
-  void *base = valloc(size);
+  void* base = valloc(size);
 # else
-  void *base = memalign(sysconf(_SC_PAGESIZE), size);
+  void* base = memalign(sysconf(_SC_PAGESIZE), size);
 # endif
   if (mprotect(base, size, PROT_READ|PROT_WRITE|PROT_EXEC) != 0) {
     free(base);
@@ -76,7 +76,7 @@ SourcePawnEngine::ExecAlloc(size_t size)
 #endif
 }
 
-void *
+void*
 SourcePawnEngine::AllocatePageMemory(size_t size)
 {
   CodeChunk chunk = Environment::get()->AllocateCode(size + sizeof(CodeChunk));
@@ -86,19 +86,19 @@ SourcePawnEngine::AllocatePageMemory(size_t size)
 }
 
 void
-SourcePawnEngine::SetReadExecute(void *ptr)
+SourcePawnEngine::SetReadExecute(void* ptr)
 {
   /* already re */
 }
 
 void
-SourcePawnEngine::SetReadWrite(void *ptr)
+SourcePawnEngine::SetReadWrite(void* ptr)
 {
   /* already rw */
 }
 
 void
-SourcePawnEngine::FreePageMemory(void *ptr)
+SourcePawnEngine::FreePageMemory(void* ptr)
 {
   assert(ptr);
   CodeChunk* hidden = (CodeChunk*)((uint8_t*)ptr - sizeof(CodeChunk));
@@ -106,7 +106,7 @@ SourcePawnEngine::FreePageMemory(void *ptr)
 }
 
 void
-SourcePawnEngine::ExecFree(void *address)
+SourcePawnEngine::ExecFree(void* address)
 {
 #if defined WIN32
   VirtualFree(address, 0, MEM_RELEASE);
@@ -116,26 +116,26 @@ SourcePawnEngine::ExecFree(void *address)
 }
 
 void
-SourcePawnEngine::SetReadWriteExecute(void *ptr)
+SourcePawnEngine::SetReadWriteExecute(void* ptr)
 {
   //:TODO:  g_ExeMemory.SetRWE(ptr);
   SetReadExecute(ptr);
 }
 
-void *
+void*
 SourcePawnEngine::BaseAlloc(size_t size)
 {
   return malloc(size);
 }
 
 void
-SourcePawnEngine::BaseFree(void *memory)
+SourcePawnEngine::BaseFree(void* memory)
 {
   free(memory);
 }
 
-sp_plugin_t *
-SourcePawnEngine::LoadFromFilePointer(FILE *fp, int *err)
+sp_plugin_t*
+SourcePawnEngine::LoadFromFilePointer(FILE* fp, int* err)
 {
   if (err != NULL)
     *err = SP_ERROR_ABORTED;
@@ -143,8 +143,8 @@ SourcePawnEngine::LoadFromFilePointer(FILE *fp, int *err)
   return NULL;
 }
 
-sp_plugin_t *
-SourcePawnEngine::LoadFromMemory(void *base, sp_plugin_t *plugin, int *err)
+sp_plugin_t*
+SourcePawnEngine::LoadFromMemory(void* base, sp_plugin_t* plugin, int* err)
 {
   if (err != NULL)
     *err = SP_ERROR_ABORTED;
@@ -153,15 +153,15 @@ SourcePawnEngine::LoadFromMemory(void *base, sp_plugin_t *plugin, int *err)
 }
 
 int
-SourcePawnEngine::FreeFromMemory(sp_plugin_t *plugin)
+SourcePawnEngine::FreeFromMemory(sp_plugin_t* plugin)
 {
   return SP_ERROR_ABORTED;
 }
 
-IDebugListener *
-SourcePawnEngine::SetDebugListener(IDebugListener *pListener)
+IDebugListener*
+SourcePawnEngine::SetDebugListener(IDebugListener* pListener)
 {
-  IDebugListener *old = Environment::get()->debugger();
+  IDebugListener* old = Environment::get()->debugger();
   Environment::get()->SetDebugger(pListener);
   return old;
 }
@@ -187,7 +187,7 @@ SourcePawnEngine2::SourcePawnEngine2()
 }
 
 size_t
-sp::UTIL_FormatVA(char *buffer, size_t maxlength, const char *fmt, va_list ap)
+sp::UTIL_FormatVA(char* buffer, size_t maxlength, const char* fmt, va_list ap)
 {
   size_t len = vsnprintf(buffer, maxlength, fmt, ap);
 
@@ -199,7 +199,7 @@ sp::UTIL_FormatVA(char *buffer, size_t maxlength, const char *fmt, va_list ap)
 }
 
 size_t
-sp::UTIL_Format(char *buffer, size_t maxlength, const char *fmt, ...)
+sp::UTIL_Format(char* buffer, size_t maxlength, const char* fmt, ...)
 {
   va_list ap;
 
@@ -210,8 +210,8 @@ sp::UTIL_Format(char *buffer, size_t maxlength, const char *fmt, ...)
   return len;
 }
 
-IPluginRuntime *
-SourcePawnEngine2::LoadPlugin(ICompilation *co, const char *file, int *err)
+IPluginRuntime*
+SourcePawnEngine2::LoadPlugin(ICompilation* co, const char* file, int* err)
 {
   if (co) {
     if (err)
@@ -219,10 +219,10 @@ SourcePawnEngine2::LoadPlugin(ICompilation *co, const char *file, int *err)
     return nullptr;
   }
 
-  IPluginRuntime *rt = LoadBinaryFromFile(file, nullptr, 0);
+  IPluginRuntime* rt = LoadBinaryFromFile(file, nullptr, 0);
   if (!rt) {
     if (err) {
-      if (FILE *fp = fopen(file, "rb")) {
+      if (FILE* fp = fopen(file, "rb")) {
         fclose(fp);
         *err = SP_ERROR_FILE_FORMAT;
       } else {
@@ -235,10 +235,10 @@ SourcePawnEngine2::LoadPlugin(ICompilation *co, const char *file, int *err)
   return rt;
 }
 
-IPluginRuntime *
-SourcePawnEngine2::LoadBinaryFromFile(const char *file, char *error, size_t maxlength)
+IPluginRuntime*
+SourcePawnEngine2::LoadBinaryFromFile(const char* file, char* error, size_t maxlength)
 {
-  FILE *fp = fopen(file, "rb");
+  FILE* fp = fopen(file, "rb");
 
   if (!fp) {
     UTIL_Format(error, maxlength, "file not found");
@@ -249,14 +249,14 @@ SourcePawnEngine2::LoadBinaryFromFile(const char *file, char *error, size_t maxl
   fclose(fp);
 
   if (!image->validate()) {
-    const char *errorMessage = image->errorMessage();
+    const char* errorMessage = image->errorMessage();
     if (!errorMessage)
       errorMessage = "file parse error";
     UTIL_Format(error, maxlength, "%s", errorMessage);
     return nullptr;
   }
 
-  PluginRuntime *pRuntime = new PluginRuntime(image.take());
+  PluginRuntime* pRuntime = new PluginRuntime(image.take());
   if (!pRuntime->Initialize()) {
     delete pRuntime;
 
@@ -284,7 +284,7 @@ SourcePawnEngine2::LoadBinaryFromFile(const char *file, char *error, size_t maxl
 }
 
 SPVM_NATIVE_FUNC
-SourcePawnEngine2::CreateFakeNative(SPVM_FAKENATIVE_FUNC callback, void *pData)
+SourcePawnEngine2::CreateFakeNative(SPVM_FAKENATIVE_FUNC callback, void* pData)
 {
   return Environment::get()->stubs()->CreateFakeNativeStub(callback, pData);
 }
@@ -292,14 +292,14 @@ SourcePawnEngine2::CreateFakeNative(SPVM_FAKENATIVE_FUNC callback, void *pData)
 void
 SourcePawnEngine2::DestroyFakeNative(SPVM_NATIVE_FUNC func)
 {
-  return Environment::get()->APIv1()->FreePageMemory((void *)func);
+  return Environment::get()->APIv1()->FreePageMemory((void*)func);
 }
 
 #if !defined(SOURCEPAWN_VERSION)
 # define SOURCEPAWN_VERSION "SourcePawn 1.10"
 #endif
 
-const char *
+const char*
 SourcePawnEngine2::GetEngineName()
 {
   const char* info = "";
@@ -326,16 +326,16 @@ SourcePawnEngine2::GetEngineName()
   return engine_name_;
 }
 
-const char *
+const char*
 SourcePawnEngine2::GetVersionString()
 {
   return SOURCEPAWN_VERSION;
 }
 
-IDebugListener *
-SourcePawnEngine2::SetDebugListener(IDebugListener *listener)
+IDebugListener*
+SourcePawnEngine2::SetDebugListener(IDebugListener* listener)
 {
-  IDebugListener *old = Environment::get()->debugger();
+  IDebugListener* old = Environment::get()->debugger();
   Environment::get()->SetDebugger(listener);
   return old;
 }
@@ -346,13 +346,13 @@ SourcePawnEngine2::GetAPIVersion()
   return SOURCEPAWN_ENGINE2_API_VERSION;
 }
 
-ICompilation *
+ICompilation*
 SourcePawnEngine2::StartCompilation()
 {
   return nullptr;
 }
 
-const char *
+const char*
 SourcePawnEngine2::GetErrorString(int err)
 {
   return Environment::get()->GetErrorString(err);
@@ -369,12 +369,12 @@ SourcePawnEngine2::Shutdown()
 {
 }
 
-IPluginRuntime *
-SourcePawnEngine2::CreateEmptyRuntime(const char *name, uint32_t memory)
+IPluginRuntime*
+SourcePawnEngine2::CreateEmptyRuntime(const char* name, uint32_t memory)
 {
   ke::AutoPtr<EmptyImage> image(new EmptyImage(memory));
 
-  PluginRuntime *rt = new PluginRuntime(image.take());
+  PluginRuntime* rt = new PluginRuntime(image.take());
   if (!rt->Initialize()) {
     delete rt;
     return NULL;
@@ -406,7 +406,7 @@ SourcePawnEngine2::IsJitEnabled()
 }
 
 void
-SourcePawnEngine2::SetProfiler(IProfiler *profiler)
+SourcePawnEngine2::SetProfiler(IProfiler* profiler)
 {
   // Deprecated.
 }
@@ -424,12 +424,12 @@ SourcePawnEngine2::DisableProfiling()
 }
 
 void
-SourcePawnEngine2::SetProfilingTool(IProfilingTool *tool)
+SourcePawnEngine2::SetProfilingTool(IProfilingTool* tool)
 {
   Environment::get()->SetProfiler(tool);
 }
 
-ISourcePawnEnvironment *
+ISourcePawnEnvironment*
 SourcePawnEngine2::Environment()
 {
   return Environment::get();

--- a/vm/api.h
+++ b/vm/api.h
@@ -25,22 +25,22 @@ class SourcePawnEngine : public ISourcePawnEngine
  public:
   SourcePawnEngine();
 
-  sp_plugin_t *LoadFromFilePointer(FILE *fp, int *err) override;
-  sp_plugin_t *LoadFromMemory(void *base, sp_plugin_t *plugin, int *err) override;
-  int FreeFromMemory(sp_plugin_t *plugin) override;
-  void *BaseAlloc(size_t size) override;
-  void BaseFree(void *memory) override;
-  void *ExecAlloc(size_t size) override;
-  void ExecFree(void *address) override;
-  IDebugListener *SetDebugListener(IDebugListener *pListener) override;
+  sp_plugin_t* LoadFromFilePointer(FILE* fp, int* err) override;
+  sp_plugin_t* LoadFromMemory(void* base, sp_plugin_t* plugin, int* err) override;
+  int FreeFromMemory(sp_plugin_t* plugin) override;
+  void* BaseAlloc(size_t size) override;
+  void BaseFree(void* memory) override;
+  void* ExecAlloc(size_t size) override;
+  void ExecFree(void* address) override;
+  IDebugListener* SetDebugListener(IDebugListener* pListener) override;
   unsigned int GetContextCallCount() override;
   unsigned int GetEngineAPIVersion() override;
-  void *AllocatePageMemory(size_t size) override;
-  void SetReadWrite(void *ptr) override;
-  void SetReadExecute(void *ptr) override;
-  void FreePageMemory(void *ptr) override;
-  void SetReadWriteExecute(void *ptr);
-  const char *GetErrorString(int err);
+  void* AllocatePageMemory(size_t size) override;
+  void SetReadWrite(void* ptr) override;
+  void SetReadExecute(void* ptr) override;
+  void FreePageMemory(void* ptr) override;
+  void SetReadWriteExecute(void* ptr);
+  const char* GetErrorString(int err);
 };
 
 class SourcePawnEngine2 : public ISourcePawnEngine2
@@ -49,33 +49,33 @@ class SourcePawnEngine2 : public ISourcePawnEngine2
   SourcePawnEngine2();
 
   unsigned int GetAPIVersion() override;
-  const char *GetEngineName() override;
-  const char *GetVersionString() override;
-  IPluginRuntime *LoadPlugin(ICompilation *co, const char *file, int *err) override;
-  SPVM_NATIVE_FUNC CreateFakeNative(SPVM_FAKENATIVE_FUNC callback, void *pData) override;
+  const char* GetEngineName() override;
+  const char* GetVersionString() override;
+  IPluginRuntime* LoadPlugin(ICompilation* co, const char* file, int* err) override;
+  SPVM_NATIVE_FUNC CreateFakeNative(SPVM_FAKENATIVE_FUNC callback, void* pData) override;
   void DestroyFakeNative(SPVM_NATIVE_FUNC func) override;
-  IDebugListener *SetDebugListener(IDebugListener *listener) override;
-  ICompilation *StartCompilation() override;
-  const char *GetErrorString(int err) override;
+  IDebugListener* SetDebugListener(IDebugListener* listener) override;
+  ICompilation* StartCompilation() override;
+  const char* GetErrorString(int err) override;
   bool Initialize() override;
   void Shutdown() override;
-  IPluginRuntime *CreateEmptyRuntime(const char *name, uint32_t memory) override;
+  IPluginRuntime* CreateEmptyRuntime(const char* name, uint32_t memory) override;
   bool InstallWatchdogTimer(size_t timeout_ms) override;
   bool SetJitEnabled(bool enabled) override;
   bool IsJitEnabled() override;
-  void SetProfiler(IProfiler *profiler) override;
+  void SetProfiler(IProfiler* profiler) override;
   void EnableProfiling() override;
   void DisableProfiling() override;
-  void SetProfilingTool(IProfilingTool *tool) override;
-  IPluginRuntime *LoadBinaryFromFile(const char *file, char *error, size_t maxlength) override;
-  ISourcePawnEnvironment *Environment() override;
+  void SetProfilingTool(IProfilingTool* tool) override;
+  IPluginRuntime* LoadBinaryFromFile(const char* file, char* error, size_t maxlength) override;
+  ISourcePawnEnvironment* Environment() override;
 
  private:
   char engine_name_[256];
 };
 
-extern size_t UTIL_Format(char *buffer, size_t maxlength, const char *fmt, ...);
-extern size_t UTIL_FormatVA(char *buffer, size_t maxlength, const char *fmt, va_list ap);
+extern size_t UTIL_Format(char* buffer, size_t maxlength, const char* fmt, ...);
+extern size_t UTIL_FormatVA(char* buffer, size_t maxlength, const char* fmt, va_list ap);
 
 } // namespace sp
 

--- a/vm/assembler.h
+++ b/vm/assembler.h
@@ -46,7 +46,7 @@ class AssemblerBase
 
  public:
   AssemblerBase() {
-    buffer_ = (uint8_t *)malloc(kMinBufferSize);
+    buffer_ = (uint8_t*)malloc(kMinBufferSize);
     pos_ = buffer_;
     end_ = buffer_ + kMinBufferSize;
     outOfMemory_ = !buffer_;
@@ -82,17 +82,17 @@ class AssemblerBase
   void writeUint32(uint32_t word) {
     write<uint32_t>(word);
   }
-  void writePointer(void *ptr) {
-    write<void *>(ptr);
+  void writePointer(void* ptr) {
+    write<void*>(ptr);
   }
   void writeInt64(int64_t value) {
     write<int64_t>(value);
   }
 
   template <typename T>
-  void write(const T &t) {
+  void write(const T& t) {
     assertCanWrite(sizeof(T));
-    *reinterpret_cast<T *>(pos_) = t;
+    *reinterpret_cast<T*>(pos_) = t;
     pos_ += sizeof(T);
   }
 
@@ -115,7 +115,7 @@ class AssemblerBase
     }
 
     size_t oldpos = size_t(pos_ - buffer_);
-    uint8_t *newbuf = (uint8_t *)realloc(buffer_, oldlength * 2);
+    uint8_t* newbuf = (uint8_t*)realloc(buffer_, oldlength * 2);
     if (!newbuf) {
       // Writes will be safe, though we'll corrupt the instruction stream, so
       // actually using the buffer will be invalid and compilation should be
@@ -140,16 +140,16 @@ class AssemblerBase
   void assertCanWrite(size_t bytes) {
     assert(pos_ + bytes <= end_);
   }
-  uint8_t *buffer() const {
+  uint8_t* buffer() const {
     return buffer_;
   }
 
  private:
-  uint8_t *buffer_;
-  uint8_t *end_;
+  uint8_t* buffer_;
+  uint8_t* end_;
 
  protected:
-  uint8_t *pos_;
+  uint8_t* pos_;
   bool outOfMemory_;
 };
 
@@ -157,12 +157,12 @@ class AssemblerBase
 class AddressValue
 {
  public:
-  explicit AddressValue(void *p)
+  explicit AddressValue(void* p)
     : p_(p)
   {
   }
 
-  void *address() const {
+  void* address() const {
     return p_;
   }
   intptr_t value() const {
@@ -173,14 +173,14 @@ class AddressValue
   }
 
  private:
-  void *p_;
+  void* p_;
 };
 
 // Deprecated; this should only be used on x86.
 class ExternalAddress : public AddressValue
 {
  public:
-  explicit ExternalAddress(void *p)
+  explicit ExternalAddress(void* p)
    : AddressValue(p)
   {}
 };

--- a/vm/base-context.cpp
+++ b/vm/base-context.cpp
@@ -26,7 +26,7 @@ BasePluginContext::~BasePluginContext()
 }
 
 void
-BasePluginContext::SetKey(int k, void *value)
+BasePluginContext::SetKey(int k, void* value)
 {
   if (k < 1 || k > 4)
     return;
@@ -36,7 +36,7 @@ BasePluginContext::SetKey(int k, void *value)
 }
 
 bool
-BasePluginContext::GetKey(int k, void **value)
+BasePluginContext::GetKey(int k, void** value)
 {
   if (k < 1 || k > 4 || m_keys_set[k - 1] == false)
     return false;
@@ -45,26 +45,26 @@ BasePluginContext::GetKey(int k, void **value)
   return true;
 }
 
-SourceMod::IdentityToken_t *
+SourceMod::IdentityToken_t*
 BasePluginContext::GetIdentity()
 {
-  SourceMod::IdentityToken_t *tok;
+  SourceMod::IdentityToken_t* tok;
 
-  if (GetKey(1, (void **)&tok))
+  if (GetKey(1, (void**)&tok))
     return tok;
   return NULL;
 }
 
-IVirtualMachine *
+IVirtualMachine*
 BasePluginContext::GetVirtualMachine()
 {
   return NULL;
 }
 
-sp_context_t *
+sp_context_t*
 BasePluginContext::GetContext()
 {
-  return reinterpret_cast<sp_context_t *>((IPluginContext * )this);
+  return reinterpret_cast<sp_context_t*>((IPluginContext * )this);
 }
 
 bool
@@ -74,31 +74,31 @@ BasePluginContext::IsDebugging()
 }
 
 int
-BasePluginContext::SetDebugBreak(void *newpfn, void *oldpfn)
+BasePluginContext::SetDebugBreak(void* newpfn, void* oldpfn)
 {
   return SP_ERROR_ABORTED;
 }
 
-IPluginDebugInfo *
+IPluginDebugInfo*
 BasePluginContext::GetDebugInfo()
 {
   return NULL;
 }
 
 int
-BasePluginContext::Execute(uint32_t code_addr, cell_t *result)
+BasePluginContext::Execute(uint32_t code_addr, cell_t* result)
 {
   return SP_ERROR_ABORTED;
 }
 
 int
-BasePluginContext::BindNatives(const sp_nativeinfo_t *natives, unsigned int num, int overwrite)
+BasePluginContext::BindNatives(const sp_nativeinfo_t* natives, unsigned int num, int overwrite)
 {
   return SP_ERROR_ABORTED;
 }
 
 int
-BasePluginContext::BindNative(const sp_nativeinfo_t *native)
+BasePluginContext::BindNative(const sp_nativeinfo_t* native)
 {
   return SP_ERROR_ABORTED;
 }
@@ -128,32 +128,32 @@ BasePluginContext::PushCellsFromArray(cell_t array[], unsigned int numcells)
 }
 
 int
-BasePluginContext::PushCellArray(cell_t *local_addr, cell_t **phys_addr, cell_t array[], unsigned int numcells)
+BasePluginContext::PushCellArray(cell_t* local_addr, cell_t** phys_addr, cell_t array[], unsigned int numcells)
 {
   return SP_ERROR_ABORTED;
 }
 
 int
-BasePluginContext::PushString(cell_t *local_addr, char **phys_addr, const char *string)
+BasePluginContext::PushString(cell_t* local_addr, char** phys_addr, const char* string)
 {
   return SP_ERROR_ABORTED;
 }
 
 int
-BasePluginContext::Execute2(IPluginFunction *function, const cell_t *params, unsigned int num_params, cell_t *result)
+BasePluginContext::Execute2(IPluginFunction* function, const cell_t* params, unsigned int num_params, cell_t* result)
 {
   ReportErrorNumber(SP_ERROR_ABORTED);
   return SP_ERROR_ABORTED;
 }
 
-ISourcePawnEngine2 *
+ISourcePawnEngine2*
 BasePluginContext::APIv2()
 {
   return env_->APIv2();
 }
 
 void
-BasePluginContext::ReportError(const char *fmt, ...)
+BasePluginContext::ReportError(const char* fmt, ...)
 {
   va_list ap;
   va_start(ap, fmt);
@@ -162,13 +162,13 @@ BasePluginContext::ReportError(const char *fmt, ...)
 }
 
 void
-BasePluginContext::ReportErrorVA(const char *fmt, va_list ap)
+BasePluginContext::ReportErrorVA(const char* fmt, va_list ap)
 {
   env_->ReportErrorVA(fmt, ap);
 }
 
 void
-BasePluginContext::ReportFatalError(const char *fmt, ...)
+BasePluginContext::ReportFatalError(const char* fmt, ...)
 {
   va_list ap;
   va_start(ap, fmt);
@@ -177,7 +177,7 @@ BasePluginContext::ReportFatalError(const char *fmt, ...)
 }
 
 void
-BasePluginContext::ReportFatalErrorVA(const char *fmt, va_list ap)
+BasePluginContext::ReportFatalErrorVA(const char* fmt, va_list ap)
 {
   env_->ReportErrorVA(SP_ERROR_FATAL, fmt, ap);
 }
@@ -196,7 +196,7 @@ BasePluginContext::ClearLastNativeError()
 }
 
 cell_t
-BasePluginContext::ThrowNativeErrorEx(int error, const char *msg, ...)
+BasePluginContext::ThrowNativeErrorEx(int error, const char* msg, ...)
 {
   va_list ap;
   va_start(ap, msg);
@@ -209,7 +209,7 @@ BasePluginContext::ThrowNativeErrorEx(int error, const char *msg, ...)
 }
 
 cell_t
-BasePluginContext::ThrowNativeError(const char *msg, ...)
+BasePluginContext::ThrowNativeError(const char* msg, ...)
 {
   va_list ap;
   va_start(ap, msg);
@@ -221,14 +221,14 @@ BasePluginContext::ThrowNativeError(const char *msg, ...)
 int
 BasePluginContext::GetLastNativeError()
 {
-  Environment *env = env_;
+  Environment* env = env_;
   if (!env->hasPendingException())
     return SP_ERROR_NONE;
   return env->getPendingExceptionCode();
 }
 
 cell_t
-BasePluginContext::BlamePluginError(SourcePawn::IPluginFunction *pf, const char *msg, ...)
+BasePluginContext::BlamePluginError(SourcePawn::IPluginFunction* pf, const char* msg, ...)
 {
   va_list ap;
   va_start(ap, msg);
@@ -237,15 +237,15 @@ BasePluginContext::BlamePluginError(SourcePawn::IPluginFunction *pf, const char 
   return 0;
 }
 
-IFrameIterator *
+IFrameIterator*
 BasePluginContext::CreateFrameIterator()
 {
-  FrameIterator *it = new FrameIterator();
+  FrameIterator* it = new FrameIterator();
   return it;
 }
 
 void
-BasePluginContext::DestroyFrameIterator(IFrameIterator *it)
+BasePluginContext::DestroyFrameIterator(IFrameIterator* it)
 {
   delete static_cast<FrameIterator*>(it);
 }

--- a/vm/base-context.h
+++ b/vm/base-context.h
@@ -27,45 +27,45 @@ public:
   virtual ~BasePluginContext();
 
   // Generic API access.
-  void SetKey(int k, void *value) override;
-  bool GetKey(int k, void **value) override;
-  SourceMod::IdentityToken_t *GetIdentity() override;
-  SourcePawn::ISourcePawnEngine2 *APIv2() override;
-  void ReportError(const char *fmt, ...) override;
-  void ReportErrorVA(const char *fmt, va_list ap) override;
-  void ReportFatalError(const char *fmt, ...) override;
-  void ReportFatalErrorVA(const char *fmt, va_list ap) override;
+  void SetKey(int k, void* value) override;
+  bool GetKey(int k, void** value) override;
+  SourceMod::IdentityToken_t* GetIdentity() override;
+  SourcePawn::ISourcePawnEngine2* APIv2() override;
+  void ReportError(const char* fmt, ...) override;
+  void ReportErrorVA(const char* fmt, va_list ap) override;
+  void ReportFatalError(const char* fmt, ...) override;
+  void ReportFatalErrorVA(const char* fmt, va_list ap) override;
   void ReportErrorNumber(int error) override;
   void ClearLastNativeError() override;
-  cell_t ThrowNativeErrorEx(int error, const char *msg, ...) override;
-  cell_t ThrowNativeError(const char *msg, ...) override;
+  cell_t ThrowNativeErrorEx(int error, const char* msg, ...) override;
+  cell_t ThrowNativeError(const char* msg, ...) override;
   int GetLastNativeError() override;
-  cell_t BlamePluginError(SourcePawn::IPluginFunction *pf, const char *msg, ...) override;
-  IFrameIterator *CreateFrameIterator() override;
-  void DestroyFrameIterator(IFrameIterator *it) override;
+  cell_t BlamePluginError(SourcePawn::IPluginFunction* pf, const char* msg, ...) override;
+  IFrameIterator* CreateFrameIterator() override;
+  void DestroyFrameIterator(IFrameIterator* it) override;
   
   // Removed functions.
   int PushCell(cell_t value) override;
-  int PushCellArray(cell_t *local_addr, cell_t **phys_addr, cell_t array[], unsigned int numcells) override;
-  int PushString(cell_t *local_addr, char **phys_addr, const char *string) override;
+  int PushCellArray(cell_t* local_addr, cell_t** phys_addr, cell_t array[], unsigned int numcells) override;
+  int PushString(cell_t* local_addr, char** phys_addr, const char* string) override;
   int PushCellsFromArray(cell_t array[], unsigned int numcells) override;
-  int BindNatives(const sp_nativeinfo_t *natives, unsigned int num, int overwrite) override;
-  int BindNative(const sp_nativeinfo_t *native) override;
+  int BindNatives(const sp_nativeinfo_t* natives, unsigned int num, int overwrite) override;
+  int BindNative(const sp_nativeinfo_t* native) override;
   int BindNativeToAny(SPVM_NATIVE_FUNC native) override;
   int BindNativeToIndex(uint32_t index, SPVM_NATIVE_FUNC native) override;
-  SourcePawn::IVirtualMachine *GetVirtualMachine() override;
-  sp_context_t *GetContext() override;
+  SourcePawn::IVirtualMachine* GetVirtualMachine() override;
+  sp_context_t* GetContext() override;
   bool IsDebugging() override;
-  int SetDebugBreak(void *newpfn, void *oldpfn) override;
-  SourcePawn::IPluginDebugInfo *GetDebugInfo() override;
-  int Execute(uint32_t code_addr, cell_t *result) override;
-  int Execute2(SourcePawn::IPluginFunction *function, const cell_t *params, unsigned int num_params, cell_t *result) override;
+  int SetDebugBreak(void* newpfn, void* oldpfn) override;
+  SourcePawn::IPluginDebugInfo* GetDebugInfo() override;
+  int Execute(uint32_t code_addr, cell_t* result) override;
+  int Execute2(SourcePawn::IPluginFunction* function, const cell_t* params, unsigned int num_params, cell_t* result) override;
 
 protected:
-  Environment *env_;
+  Environment* env_;
 
 private:
-  void *m_keys[4];
+  void* m_keys[4];
   bool m_keys_set[4];
 };
 

--- a/vm/builtins.cpp
+++ b/vm/builtins.cpp
@@ -50,7 +50,7 @@ BuiltinNatives::Lookup(const char* name)
 }
 
 static cell_t
-FloatCtor(IPluginContext *pCtx, const cell_t *params)
+FloatCtor(IPluginContext* pCtx, const cell_t* params)
 {
   float val = static_cast<float>(params[1]);
 
@@ -58,7 +58,7 @@ FloatCtor(IPluginContext *pCtx, const cell_t *params)
 }
 
 static cell_t
-FloatAdd(IPluginContext *pCtx, const cell_t *params)
+FloatAdd(IPluginContext* pCtx, const cell_t* params)
 {
   float val = sp_ctof(params[1]) + sp_ctof(params[2]);
 
@@ -66,7 +66,7 @@ FloatAdd(IPluginContext *pCtx, const cell_t *params)
 }
 
 static cell_t
-FloatSub(IPluginContext *pCtx, const cell_t *params)
+FloatSub(IPluginContext* pCtx, const cell_t* params)
 {
   float val = sp_ctof(params[1]) - sp_ctof(params[2]);
 
@@ -74,7 +74,7 @@ FloatSub(IPluginContext *pCtx, const cell_t *params)
 }
 
 static cell_t
-FloatMul(IPluginContext *pCtx, const cell_t *params)
+FloatMul(IPluginContext* pCtx, const cell_t* params)
 {
   float val = sp_ctof(params[1]) * sp_ctof(params[2]);
 
@@ -82,7 +82,7 @@ FloatMul(IPluginContext *pCtx, const cell_t *params)
 }
 
 static cell_t
-FloatDiv(IPluginContext *pCtx, const cell_t *params)
+FloatDiv(IPluginContext* pCtx, const cell_t* params)
 {
   float val = sp_ctof(params[1]) / sp_ctof(params[2]);
 
@@ -90,43 +90,43 @@ FloatDiv(IPluginContext *pCtx, const cell_t *params)
 }
 
 static cell_t
-FloatGt(IPluginContext *pCtx, const cell_t *params)
+FloatGt(IPluginContext* pCtx, const cell_t* params)
 {
   return !!(sp_ctof(params[1]) > sp_ctof(params[2]));
 }
 
 static cell_t
-FloatGe(IPluginContext *pCtx, const cell_t *params)
+FloatGe(IPluginContext* pCtx, const cell_t* params)
 {
   return !!(sp_ctof(params[1]) >= sp_ctof(params[2]));
 }
 
 static cell_t
-FloatLt(IPluginContext *pCtx, const cell_t *params)
+FloatLt(IPluginContext* pCtx, const cell_t* params)
 {
   return !!(sp_ctof(params[1]) < sp_ctof(params[2]));
 }
 
 static cell_t
-FloatLe(IPluginContext *pCtx, const cell_t *params)
+FloatLe(IPluginContext* pCtx, const cell_t* params)
 {
   return !!(sp_ctof(params[1]) <= sp_ctof(params[2]));
 }
 
 static cell_t
-FloatEq(IPluginContext *pCtx, const cell_t *params)
+FloatEq(IPluginContext* pCtx, const cell_t* params)
 {
   return !!(sp_ctof(params[1]) == sp_ctof(params[2]));
 }
 
 static cell_t
-FloatNe(IPluginContext *pCtx, const cell_t *params)
+FloatNe(IPluginContext* pCtx, const cell_t* params)
 {
   return !!(sp_ctof(params[1]) != sp_ctof(params[2]));
 }
 
 static cell_t
-FloatNot(IPluginContext *pCtx, const cell_t *params)
+FloatNot(IPluginContext* pCtx, const cell_t* params)
 {
   float val = sp_ctof(params[1]);
   if (ke::IsNaN(val))

--- a/vm/code-stubs-null.cpp
+++ b/vm/code-stubs-null.cpp
@@ -30,7 +30,7 @@ CodeStubs::CompileInvokeStub()
 }
 
 SPVM_NATIVE_FUNC
-CodeStubs::CreateFakeNativeStub(SPVM_FAKENATIVE_FUNC callback, void *pData)
+CodeStubs::CreateFakeNativeStub(SPVM_FAKENATIVE_FUNC callback, void* pData)
 {
   assert(false);
   return (SPVM_NATIVE_FUNC)nullptr;

--- a/vm/code-stubs.cpp
+++ b/vm/code-stubs.cpp
@@ -15,7 +15,7 @@
 
 using namespace sp;
 
-CodeStubs::CodeStubs(Environment *env)
+CodeStubs::CodeStubs(Environment* env)
  : env_(env),
    return_stub_(nullptr)
 {

--- a/vm/code-stubs.h
+++ b/vm/code-stubs.h
@@ -22,34 +22,34 @@ namespace sp {
 class PluginContext;
 class Environment;
 
-typedef int (*InvokeStubFn)(PluginContext *cx, void *code, cell_t *rval);
+typedef int (*InvokeStubFn)(PluginContext* cx, void* code, cell_t* rval);
 
 class CodeStubs
 {
  public:
-  CodeStubs(Environment *env);
+  CodeStubs(Environment* env);
 
  public:
   bool Initialize();
 
-  SPVM_NATIVE_FUNC CreateFakeNativeStub(SPVM_FAKENATIVE_FUNC callback, void *userData);
+  SPVM_NATIVE_FUNC CreateFakeNativeStub(SPVM_FAKENATIVE_FUNC callback, void* userData);
 
   InvokeStubFn InvokeStub() const {
     return (InvokeStubFn)invoke_stub_.address();
   }
-  void *ReturnStub() const {
+  void* ReturnStub() const {
     return return_stub_;
   }
-  void *LegacyNativeStub();
+  void* LegacyNativeStub();
 
  private:
   bool InitializeFeatureDetection();
   bool CompileInvokeStub();
 
  private:
-  Environment *env_;
+  Environment* env_;
   CodeChunk invoke_stub_;
-  void *return_stub_;   // Owned by invoke_stub_.
+  void* return_stub_;   // Owned by invoke_stub_.
 };
 
 }

--- a/vm/compiled-function.cpp
+++ b/vm/compiled-function.cpp
@@ -18,8 +18,8 @@ using namespace sp;
 
 CompiledFunction::CompiledFunction(const CodeChunk& code,
                                    cell_t pcode_offs,
-                                   FixedArray<LoopEdge> *edges,
-                                   FixedArray<CipMapEntry> *cipmap)
+                                   FixedArray<LoopEdge>* edges,
+                                   FixedArray<CipMapEntry>* cipmap)
   : code_(code),
     code_offset_(pcode_offs),
     edges_(edges),
@@ -31,10 +31,10 @@ CompiledFunction::~CompiledFunction()
 {
 }
 
-static int cip_map_entry_cmp(const void *a1, const void *aEntry)
+static int cip_map_entry_cmp(const void* a1, const void* aEntry)
 {
   uint32_t pcoffs = (uint32_t)(intptr_t)a1;
-  const CipMapEntry *entry = reinterpret_cast<const CipMapEntry *>(aEntry);
+  const CipMapEntry* entry = reinterpret_cast<const CipMapEntry*>(aEntry);
   if (pcoffs < entry->pcoffs)
     return -1;
   if (pcoffs == entry->pcoffs)
@@ -43,7 +43,7 @@ static int cip_map_entry_cmp(const void *a1, const void *aEntry)
 }
 
 ucell_t
-CompiledFunction::FindCipByPc(void *pc)
+CompiledFunction::FindCipByPc(void* pc)
 {
   if (uintptr_t(pc) < uintptr_t(code_.address()))
     return kInvalidCip;
@@ -52,8 +52,8 @@ CompiledFunction::FindCipByPc(void *pc)
   if (pcoffs > code_.bytes())
     return kInvalidCip;
 
-  void *ptr = bsearch(
-    (void *)(uintptr_t)pcoffs,
+  void* ptr = bsearch(
+    (void*)(uintptr_t)pcoffs,
     cip_map_->buffer(),
     cip_map_->length(),
     sizeof(CipMapEntry),
@@ -65,5 +65,5 @@ CompiledFunction::FindCipByPc(void *pc)
     return kInvalidCip;
   }
 
-  return code_offset_ + reinterpret_cast<CipMapEntry *>(ptr)->cipoffs;
+  return code_offset_ + reinterpret_cast<CipMapEntry*>(ptr)->cipoffs;
 }

--- a/vm/compiled-function.h
+++ b/vm/compiled-function.h
@@ -49,12 +49,12 @@ class CompiledFunction
  public:
   CompiledFunction(const CodeChunk& code,
                    cell_t pcode_offs,
-                   FixedArray<LoopEdge> *edges,
-                   FixedArray<CipMapEntry> *cip_map);
+                   FixedArray<LoopEdge>* edges,
+                   FixedArray<CipMapEntry>* cip_map);
   ~CompiledFunction();
 
  public:
-  void *GetEntryAddress() const {
+  void* GetEntryAddress() const {
     return code_.address();
   }
   cell_t GetCodeOffset() const {
@@ -63,11 +63,11 @@ class CompiledFunction
   uint32_t NumLoopEdges() const {
     return edges_->length();
   }
-  LoopEdge &GetLoopEdge(size_t i) {
+  LoopEdge& GetLoopEdge(size_t i) {
     return edges_->at(i);
   }
 
-  ucell_t FindCipByPc(void *pc);
+  ucell_t FindCipByPc(void* pc);
 
  private:
   CodeChunk code_;

--- a/vm/dll_exports.cpp
+++ b/vm/dll_exports.cpp
@@ -28,17 +28,17 @@ public:
 	int ApiVersion() override {
 		return SOURCEPAWN_API_VERSION;
 	}
-	ISourcePawnEnvironment *NewEnvironment() override {
+	ISourcePawnEnvironment* NewEnvironment() override {
 		return Environment::New();
 	}
-	ISourcePawnEnvironment *CurrentEnvironment() override {
+	ISourcePawnEnvironment* CurrentEnvironment() override {
 		return Environment::get();
 	}
 } sFactory;
 
 #define MIN_API_VERSION 0x0207
 
-EXPORTFUNC ISourcePawnFactory *
+EXPORTFUNC ISourcePawnFactory*
 GetSourcePawnFactory(int apiVersion)
 {
 	if (apiVersion < MIN_API_VERSION || apiVersion > SOURCEPAWN_API_VERSION)
@@ -54,17 +54,17 @@ extern "C" void __cxa_pure_virtual(void)
 {
 }
 
-void *operator new(size_t size)
+void* operator new(size_t size)
 {
 	return malloc(size);
 }
 
-void *operator new[](size_t size) 
+void* operator new[](size_t size) 
 {
 	return malloc(size);
 }
 
-void operator delete(void *ptr) _GLIBCXX_USE_NOEXCEPT
+void operator delete(void* ptr) _GLIBCXX_USE_NOEXCEPT
 {
 	free(ptr);
 }

--- a/vm/environment.cpp
+++ b/vm/environment.cpp
@@ -29,7 +29,7 @@
 using namespace sp;
 using namespace SourcePawn;
 
-static Environment *sEnvironment = nullptr;
+static Environment* sEnvironment = nullptr;
 
 Environment::Environment()
  : debugger_(nullptr),
@@ -50,7 +50,7 @@ Environment::~Environment()
 {
 }
 
-Environment *
+Environment*
 Environment::New()
 {
   assert(!sEnvironment);
@@ -67,7 +67,7 @@ Environment::New()
   return sEnvironment;
 }
 
-Environment *
+Environment*
 Environment::get()
 {
   return sEnvironment;
@@ -130,19 +130,19 @@ Environment::InstallWatchdogTimer(int timeout_ms)
   return watchdog_timer_->Initialize(timeout_ms);
 }
 
-ISourcePawnEngine *
+ISourcePawnEngine*
 Environment::APIv1()
 {
   return api_v1_;
 }
 
-ISourcePawnEngine2 *
+ISourcePawnEngine2*
 Environment::APIv2()
 {
   return api_v2_;
 }
 
-static const char *sErrorMsgTable[] = 
+static const char* sErrorMsgTable[] = 
 {
   NULL,
   "Unrecognizable file format",
@@ -179,7 +179,7 @@ static const char *sErrorMsgTable[] =
   "Fatal error"
 };
 
-const char *
+const char*
 Environment::GetErrorString(int error)
 {
   if (error < 1 || error > int(sizeof(sErrorMsgTable) / sizeof(sErrorMsgTable[0])))
@@ -194,23 +194,23 @@ Environment::AllocateCode(size_t size)
 }
 
 void
-Environment::RegisterRuntime(PluginRuntime *rt)
+Environment::RegisterRuntime(PluginRuntime* rt)
 {
   mutex_.AssertCurrentThreadOwns();
   runtimes_.append(rt);
 }
 
 void
-Environment::DeregisterRuntime(PluginRuntime *rt)
+Environment::DeregisterRuntime(PluginRuntime* rt)
 {
   mutex_.AssertCurrentThreadOwns();
   runtimes_.remove(rt);
 }
 
 static inline void
-SwapLoopEdge(uint8_t *code, LoopEdge &e)
+SwapLoopEdge(uint8_t* code, LoopEdge& e)
 {
-  int32_t *loc = reinterpret_cast<int32_t *>(code + e.offset - 4);
+  int32_t* loc = reinterpret_cast<int32_t*>(code + e.offset - 4);
   int32_t new_disp32 = e.disp32;
   e.disp32 = *loc;
   *loc = new_disp32;
@@ -221,15 +221,15 @@ Environment::PatchAllJumpsForTimeout()
 {
   mutex_.AssertCurrentThreadOwns();
   for (ke::InlineList<PluginRuntime>::iterator iter = runtimes_.begin(); iter != runtimes_.end(); iter++) {
-    PluginRuntime *rt = *iter;
+    PluginRuntime* rt = *iter;
 
     const Vector<RefPtr<MethodInfo>>& methods = rt->AllMethods();
     for (size_t i = 0; i < methods.length(); i++) {
-      CompiledFunction *fun = methods[i]->jit();
+      CompiledFunction* fun = methods[i]->jit();
       if (!fun)
         continue;
 
-      uint8_t *base = reinterpret_cast<uint8_t *>(fun->GetEntryAddress());
+      uint8_t* base = reinterpret_cast<uint8_t*>(fun->GetEntryAddress());
 
       for (size_t j = 0; j < fun->NumLoopEdges(); j++)
         SwapLoopEdge(base, fun->GetLoopEdge(j));
@@ -242,15 +242,15 @@ Environment::UnpatchAllJumpsFromTimeout()
 {
   mutex_.AssertCurrentThreadOwns();
   for (ke::InlineList<PluginRuntime>::iterator iter = runtimes_.begin(); iter != runtimes_.end(); iter++) {
-    PluginRuntime *rt = *iter;
+    PluginRuntime* rt = *iter;
 
     const Vector<RefPtr<MethodInfo>>& methods = rt->AllMethods();
     for (size_t i = 0; i < methods.length(); i++) {
-      CompiledFunction *fun = methods[i]->jit();
+      CompiledFunction* fun = methods[i]->jit();
       if (!fun)
         continue;
 
-      uint8_t *base = reinterpret_cast<uint8_t *>(fun->GetEntryAddress());
+      uint8_t* base = reinterpret_cast<uint8_t*>(fun->GetEntryAddress());
 
       for (size_t j = 0; j < fun->NumLoopEdges(); j++)
         SwapLoopEdge(base, fun->GetLoopEdge(j));
@@ -292,7 +292,7 @@ Environment::Invoke(PluginContext* cx,
 void
 Environment::ReportError(int code)
 {
-  const char *message = GetErrorString(code);
+  const char* message = GetErrorString(code);
   if (!message) {
     char buffer[255];
     UTIL_Format(buffer, sizeof(buffer), "Unknown error code %d", code);
@@ -302,19 +302,19 @@ Environment::ReportError(int code)
   }
 }
 
-ErrorReport::ErrorReport(int code, const char *message, PluginContext *cx, SourcePawn::IPluginFunction *pf)
+ErrorReport::ErrorReport(int code, const char* message, PluginContext* cx, SourcePawn::IPluginFunction* pf)
    : code_(code),
      message_(message),
      context_(cx),
      blame_(pf)
   {}
 
-const char *
+const char*
 ErrorReport::Message() const {
   return message_;
 }
 
-IPluginFunction *
+IPluginFunction*
 ErrorReport::Blame() const {
   return blame_;
 }
@@ -343,7 +343,7 @@ ErrorReport::IsFatal() const {
   }
 }
 
-IPluginContext *
+IPluginContext*
 ErrorReport::Context() const {
   return context_;
 }
@@ -354,13 +354,13 @@ ErrorReport::Code() const {
 }
 
 void
-Environment::ReportErrorVA(const char *fmt, va_list ap)
+Environment::ReportErrorVA(const char* fmt, va_list ap)
 {
   ReportErrorVA(SP_ERROR_USER, fmt, ap);
 }
 
 void
-Environment::ReportErrorVA(int code, const char *fmt, va_list ap)
+Environment::ReportErrorVA(int code, const char* fmt, va_list ap)
 {
   // :TODO: right-size the string rather than rely on this buffer.
   char buffer[1024];
@@ -369,7 +369,7 @@ Environment::ReportErrorVA(int code, const char *fmt, va_list ap)
 }
 
 void
-Environment::ReportErrorFmt(int code, const char *message, ...)
+Environment::ReportErrorFmt(int code, const char* message, ...)
 {
   va_list ap;
   va_start(ap, message);
@@ -378,13 +378,13 @@ Environment::ReportErrorFmt(int code, const char *message, ...)
 }
 
 void
-Environment::ReportError(int code, const char *message)
+Environment::ReportError(int code, const char* message)
 {
   ErrorReport report(code, message, top_ ? top_->cx() : nullptr, nullptr);
   DispatchReport(report);
 }
 
-void Environment::BlamePluginErrorVA(SourcePawn::IPluginFunction *pf, const char *fmt, va_list ap)
+void Environment::BlamePluginErrorVA(SourcePawn::IPluginFunction* pf, const char* fmt, va_list ap)
 {
   // :TODO: right-size the string rather than rely on this buffer.
   char buffer[1024];
@@ -394,7 +394,7 @@ void Environment::BlamePluginErrorVA(SourcePawn::IPluginFunction *pf, const char
 }
 
 void
-Environment::DispatchReport(const ErrorReport &report)
+Environment::DispatchReport(const ErrorReport& report)
 {
   FrameIterator iter;
 
@@ -413,14 +413,14 @@ Environment::DispatchReport(const ErrorReport &report)
 }
 
 void
-Environment::EnterExceptionHandlingScope(ExceptionHandler *handler)
+Environment::EnterExceptionHandlingScope(ExceptionHandler* handler)
 {
   handler->next_ = eh_top_;
   eh_top_ = handler;
 }
 
 void
-Environment::LeaveExceptionHandlingScope(ExceptionHandler *handler)
+Environment::LeaveExceptionHandlingScope(ExceptionHandler* handler)
 {
   assert(handler == eh_top_);
   eh_top_ = eh_top_->next_;
@@ -432,7 +432,7 @@ Environment::LeaveExceptionHandlingScope(ExceptionHandler *handler)
 }
 
 bool
-Environment::HasPendingException(const ExceptionHandler *handler)
+Environment::HasPendingException(const ExceptionHandler* handler)
 {
   // Note here and elsewhere - this is not a sanity assert. In the future, the
   // API may need to query the handler.
@@ -440,8 +440,8 @@ Environment::HasPendingException(const ExceptionHandler *handler)
   return hasPendingException();
 }
 
-const char *
-Environment::GetPendingExceptionMessage(const ExceptionHandler *handler)
+const char*
+Environment::GetPendingExceptionMessage(const ExceptionHandler* handler)
 {
   // Note here and elsewhere - this is not a sanity assert. In the future, the
   // API may need to query the handler.
@@ -469,7 +469,7 @@ Environment::getPendingExceptionCode() const
 }
 
 void
-Environment::enterInvoke(InvokeFrame *frame)
+Environment::enterInvoke(InvokeFrame* frame)
 {
   if (!top_)
     frame_id_++;

--- a/vm/environment.h
+++ b/vm/environment.h
@@ -43,38 +43,38 @@ class Environment : public ISourcePawnEnvironment
   Environment();
   ~Environment();
 
-  static Environment *New();
+  static Environment* New();
 
   void Shutdown() override;
-  ISourcePawnEngine *APIv1() override;
-  ISourcePawnEngine2 *APIv2() override;
+  ISourcePawnEngine* APIv1() override;
+  ISourcePawnEngine2* APIv2() override;
   int ApiVersion() override {
     return SOURCEPAWN_API_VERSION;
   }
 
   // Access the current Environment.
-  static Environment *get();
+  static Environment* get();
 
   bool InstallWatchdogTimer(int timeout_ms);
 
-  void EnterExceptionHandlingScope(ExceptionHandler *handler) override;
-  void LeaveExceptionHandlingScope(ExceptionHandler *handler) override;
-  bool HasPendingException(const ExceptionHandler *handler) override;
-  const char *GetPendingExceptionMessage(const ExceptionHandler *handler) override;
+  void EnterExceptionHandlingScope(ExceptionHandler* handler) override;
+  void LeaveExceptionHandlingScope(ExceptionHandler* handler) override;
+  bool HasPendingException(const ExceptionHandler* handler) override;
+  const char* GetPendingExceptionMessage(const ExceptionHandler* handler) override;
 
   // Runtime functions.
-  const char *GetErrorString(int err);
+  const char* GetErrorString(int err);
   void ReportError(int code);
-  void ReportError(int code, const char *message);
-  void ReportErrorFmt(int code, const char *message, ...);
-  void ReportErrorVA(const char *fmt, va_list ap);
-  void ReportErrorVA(int code, const char *fmt, va_list ap);
-  void BlamePluginErrorVA(SourcePawn::IPluginFunction *pf, const char *fmt, va_list ap);
+  void ReportError(int code, const char* message);
+  void ReportErrorFmt(int code, const char* message, ...);
+  void ReportErrorVA(const char* fmt, va_list ap);
+  void ReportErrorVA(int code, const char* fmt, va_list ap);
+  void BlamePluginErrorVA(SourcePawn::IPluginFunction* pf, const char* fmt, va_list ap);
 
   // Allocate and free executable memory.
   CodeChunk AllocateCode(size_t size);
 
-  CodeStubs *stubs() {
+  CodeStubs* stubs() {
     return code_stubs_;
   }
   BuiltinNatives* builtins() {
@@ -82,21 +82,21 @@ class Environment : public ISourcePawnEnvironment
   }
 
   // Runtime management.
-  void RegisterRuntime(PluginRuntime *rt);
-  void DeregisterRuntime(PluginRuntime *rt);
+  void RegisterRuntime(PluginRuntime* rt);
+  void DeregisterRuntime(PluginRuntime* rt);
   void PatchAllJumpsForTimeout();
   void UnpatchAllJumpsFromTimeout();
-  ke::Mutex *lock() {
+  ke::Mutex* lock() {
     return &mutex_;
   }
 
   bool Invoke(PluginContext* cx, const RefPtr<MethodInfo>& method, cell_t* result);
 
   // Helpers.
-  void SetProfiler(IProfilingTool *profiler) {
+  void SetProfiler(IProfilingTool* profiler) {
     profiler_ = profiler;
   }
-  IProfilingTool *profiler() const {
+  IProfilingTool* profiler() const {
     return profiler_;
   }
   bool IsProfilingEnabled() const {
@@ -109,14 +109,14 @@ class Environment : public ISourcePawnEnvironment
   bool IsJitEnabled() const {
     return jit_enabled_;
   }
-  void SetDebugger(IDebugListener *debugger) {
+  void SetDebugger(IDebugListener* debugger) {
     debugger_ = debugger;
   }
-  IDebugListener *debugger() const {
+  IDebugListener* debugger() const {
     return debugger_;
   }
 
-  WatchdogTimer *watchdog() const {
+  WatchdogTimer* watchdog() const {
     return watchdog_timer_;
   }
 
@@ -132,11 +132,11 @@ class Environment : public ISourcePawnEnvironment
     return !!top_;
   }
 
-  void enterInvoke(InvokeFrame *frame);
+  void enterInvoke(InvokeFrame* frame);
   void leaveJitInvoke(JitInvokeFrame* frame);
   void leaveInvoke();
 
-  InvokeFrame *top() const {
+  InvokeFrame* top() const {
     return top_;
   }
   intptr_t* exit_fp() const {
@@ -161,7 +161,7 @@ class Environment : public ISourcePawnEnvironment
  private:
   bool Initialize();
 
-  void DispatchReport(const ErrorReport &report);
+  void DispatchReport(const ErrorReport& report);
 
  private:
   ke::AutoPtr<ISourcePawnEngine> api_v1_;
@@ -170,12 +170,12 @@ class Environment : public ISourcePawnEnvironment
   ke::AutoPtr<BuiltinNatives> builtins_;
   ke::Mutex mutex_;
 
-  IDebugListener *debugger_;
-  ExceptionHandler *eh_top_;
+  IDebugListener* debugger_;
+  ExceptionHandler* eh_top_;
   int exception_code_;
   char exception_message_[1024];
 
-  IProfilingTool *profiler_;
+  IProfilingTool* profiler_;
   bool jit_enabled_;
   bool profiling_enabled_;
 
@@ -186,14 +186,14 @@ class Environment : public ISourcePawnEnvironment
 
   uintptr_t frame_id_;
 
-  InvokeFrame *top_;
+  InvokeFrame* top_;
   intptr_t* exit_fp_;
 };
 
 class EnterProfileScope
 {
  public:
-  EnterProfileScope(const char *group, const char *name)
+  EnterProfileScope(const char* group, const char* name)
   {
     if (Environment::get()->IsProfilingEnabled())
       Environment::get()->profiler()->EnterScope(group, name);
@@ -209,20 +209,20 @@ class EnterProfileScope
 class ErrorReport : public SourcePawn::IErrorReport
 {
   public:
-  ErrorReport(int code, const char *message, PluginContext *cx, SourcePawn::IPluginFunction *pf);
+  ErrorReport(int code, const char* message, PluginContext* cx, SourcePawn::IPluginFunction* pf);
 
   public: //IErrorReport
-  const char *Message() const override;
+  const char* Message() const override;
   int Code() const override;
-  IPluginFunction *Blame() const override;
+  IPluginFunction* Blame() const override;
   bool IsFatal() const override;
-  IPluginContext *Context() const override;
+  IPluginContext* Context() const override;
 
  private:
   int code_;
-  const char *message_;
-  PluginContext *context_;
-  IPluginFunction *blame_;
+  const char* message_;
+  PluginContext* context_;
+  IPluginFunction* blame_;
 };
 
 } // namespace sp

--- a/vm/file-utils.cpp
+++ b/vm/file-utils.cpp
@@ -14,7 +14,7 @@
 using namespace sp;
 
 FileType
-sp::DetectFileType(FILE *fp)
+sp::DetectFileType(FILE* fp)
 {
   uint32_t magic = 0;
   if (fread(&magic, sizeof(uint32_t), 1, fp) != 1)
@@ -26,7 +26,7 @@ sp::DetectFileType(FILE *fp)
   return FileType::UNKNOWN;
 }
 
-FileReader::FileReader(FILE *fp)
+FileReader::FileReader(FILE* fp)
  : length_(0)
 {
   if (fseek(fp, 0, SEEK_END) != 0)

--- a/vm/file-utils.h
+++ b/vm/file-utils.h
@@ -22,15 +22,15 @@ enum class FileType {
   SPFF
 };
 
-FileType DetectFileType(FILE *fp);
+FileType DetectFileType(FILE* fp);
 
 class FileReader
 {
  public:
-  FileReader(FILE *fp);
+  FileReader(FILE* fp);
   FileReader(ke::UniquePtr<uint8_t[]>&& buffer, size_t length);
 
-  const uint8_t *buffer() const {
+  const uint8_t* buffer() const {
     return buffer_.get();
   }
   size_t length() const {

--- a/vm/jit.cpp
+++ b/vm/jit.cpp
@@ -35,16 +35,16 @@ using namespace SourcePawn;
 
 #define __ masm.
 
-CompilerBase::CompilerBase(PluginRuntime *rt, cell_t pcode_offs)
+CompilerBase::CompilerBase(PluginRuntime* rt, cell_t pcode_offs)
  : env_(Environment::get()),
    rt_(rt),
    context_(rt->GetBaseContext()),
    image_(rt_->image()),
    error_(SP_ERROR_NONE),
    pcode_start_(pcode_offs),
-   code_start_(reinterpret_cast<const cell_t *>(rt_->code().bytes + pcode_start_)),
+   code_start_(reinterpret_cast<const cell_t*>(rt_->code().bytes + pcode_start_)),
    op_cip_(nullptr),
-   code_end_(reinterpret_cast<const cell_t *>(rt_->code().bytes + rt_->code().length)),
+   code_end_(reinterpret_cast<const cell_t*>(rt_->code().bytes + rt_->code().length)),
    jump_map_(nullptr)
 {
   size_t nmaxops = rt_->code().length / sizeof(cell_t) + 1;
@@ -56,12 +56,12 @@ CompilerBase::~CompilerBase()
   delete [] jump_map_;
 }
 
-CompiledFunction *
-CompilerBase::Compile(PluginContext* cx, RefPtr<MethodInfo> method, int *err)
+CompiledFunction*
+CompilerBase::Compile(PluginContext* cx, RefPtr<MethodInfo> method, int* err)
 {
   Compiler cc(cx->runtime(), method->pcode_offset());
 
-  CompiledFunction *fun = cc.emit();
+  CompiledFunction* fun = cc.emit();
   if (!fun) {
     *err = cc.error();
     return nullptr;
@@ -85,7 +85,7 @@ CompilerBase::emit()
   SpewOpcode(rt_, code_start_, reader.cip());
 #endif
 
-  const cell_t *codeseg = reinterpret_cast<const cell_t *>(rt_->code().bytes);
+  const cell_t* codeseg = reinterpret_cast<const cell_t*>(rt_->code().bytes);
 
   emitPrologue();
 
@@ -121,7 +121,7 @@ CompilerBase::emit()
   // For each backward jump, emit a little thunk so we can exit from a timeout.
   // Track the offset of where the thunk is, so the watchdog timer can patch it.
   for (size_t i = 0; i < backward_jumps_.length(); i++) {
-    BackwardJump &jump = backward_jumps_[i];
+    BackwardJump& jump = backward_jumps_[i];
     jump.timeout_offset = masm.pc();
     __ call(&throw_timeout_);
     emitCipMapping(jump.cip);
@@ -154,7 +154,7 @@ CompilerBase::emit()
   AutoPtr<FixedArray<LoopEdge>> edges(
     new FixedArray<LoopEdge>(backward_jumps_.length()));
   for (size_t i = 0; i < backward_jumps_.length(); i++) {
-    const BackwardJump &jump = backward_jumps_[i];
+    const BackwardJump& jump = backward_jumps_[i];
     edges->at(i).offset = jump.pc;
     edges->at(i).disp32 = int32_t(jump.timeout_offset) - int32_t(jump.pc);
   }
@@ -220,7 +220,7 @@ CompilerBase::reportError(int err)
 }
 
 int
-CompilerBase::CompileFromThunk(PluginContext* cx, cell_t pcode_offs, void **addrp, uint8_t* pc)
+CompilerBase::CompileFromThunk(PluginContext* cx, cell_t pcode_offs, void** addrp, uint8_t* pc)
 {
   // If the watchdog timer has declared a timeout, we must process it now,
   // and possibly refuse to compile, since otherwise we will compile a
@@ -236,7 +236,7 @@ CompilerBase::CompileFromThunk(PluginContext* cx, cell_t pcode_offs, void **addr
   if (err != SP_ERROR_NONE)
     return err;
 
-  CompiledFunction *fn = method->jit();
+  CompiledFunction* fn = method->jit();
   if (!fn) {
     fn = Compile(cx, method, &err);
     if (!fn)
@@ -262,7 +262,7 @@ CompilerBase::CompileFromThunk(PluginContext* cx, cell_t pcode_offs, void **addr
 void*
 CompilerBase::find_entry_fp()
 {
-  void *fp = nullptr;
+  void* fp = nullptr;
 
   for (JitFrameIterator iter(Environment::get()); !iter.done(); iter.next()) {
     FrameLayout* frame = iter.frame();

--- a/vm/jit.h
+++ b/vm/jit.h
@@ -39,13 +39,13 @@ struct BackwardJump {
   // The pc at the jump instruction (i.e. after it).
   uint32_t pc;
   // The cip of the jump.
-  const cell_t *cip;
+  const cell_t* cip;
   // The offset of the timeout thunk. This is filled in at the end.
   uint32_t timeout_offset;
 
   BackwardJump()
   {}
-  BackwardJump(uint32_t pc, const cell_t *cip)
+  BackwardJump(uint32_t pc, const cell_t* cip)
    : pc(pc),
      cip(cip)
   {}
@@ -56,10 +56,10 @@ class CompilerBase : public PcodeVisitor
   friend class ErrorPath;
 
  public:
-  CompilerBase(PluginRuntime *rt, cell_t pcode_offs);
+  CompilerBase(PluginRuntime* rt, cell_t pcode_offs);
   virtual ~CompilerBase();
 
-  static CompiledFunction *Compile(PluginContext* cx, RefPtr<MethodInfo> method, int *err);
+  static CompiledFunction* Compile(PluginContext* cx, RefPtr<MethodInfo> method, int* err);
 
   int error() const {
     return error_;
@@ -74,7 +74,7 @@ class CompilerBase : public PcodeVisitor
   virtual void emitOutOfBoundsErrorPath(OutOfBoundsErrorPath* path) = 0;
 
   // Helpers.
-  static int CompileFromThunk(PluginContext* cx, cell_t pcode_offs, void **addrp, uint8_t* pc);
+  static int CompileFromThunk(PluginContext* cx, cell_t pcode_offs, void** addrp, uint8_t* pc);
   static void* find_entry_fp();
   static void InvokeReportError(int err);
   static void InvokeReportTimeout();
@@ -86,7 +86,7 @@ class CompilerBase : public PcodeVisitor
   // Map a return address (i.e. an exit point from a function) to its source
   // cip. This lets us avoid tracking the cip during runtime. These are
   // sorted by definition since we assemble and emit in forward order.
-  void emitCipMapping(const cell_t *cip) {
+  void emitCipMapping(const cell_t* cip) {
     CipMapEntry entry;
     entry.cipoffs = uintptr_t(cip) - uintptr_t(code_start_);
     entry.pcoffs = masm.pc();
@@ -100,20 +100,20 @@ class CompilerBase : public PcodeVisitor
   void reportError(int err);
 
  protected:
-  Environment *env_;
-  PluginRuntime *rt_;
-  PluginContext *context_;
-  LegacyImage *image_;
+  Environment* env_;
+  PluginRuntime* rt_;
+  PluginContext* context_;
+  LegacyImage* image_;
   PoolScope scope_;
   int error_;
   uint32_t pcode_start_;
-  const cell_t *code_start_;
-  const cell_t *op_cip_;
-  const cell_t *code_end_;
+  const cell_t* code_start_;
+  const cell_t* op_cip_;
+  const cell_t* code_end_;
 
   MacroAssembler masm;
 
-  Label *jump_map_;
+  Label* jump_map_;
 
   ke::Vector<OutOfLinePath*> ool_paths_;
 

--- a/vm/legacy-image.h
+++ b/vm/legacy-image.h
@@ -27,13 +27,13 @@ class LegacyImage
   {}
 
   struct Code {
-    const uint8_t *bytes;
+    const uint8_t* bytes;
     size_t length;
     int version;
     uint32_t features;
   };
   struct Data {
-    const uint8_t *bytes;
+    const uint8_t* bytes;
     size_t length;
   };
 
@@ -41,19 +41,19 @@ class LegacyImage
   virtual Code DescribeCode() const = 0;
   virtual Data DescribeData() const = 0;
   virtual size_t NumNatives() const = 0;
-  virtual const char *GetNative(size_t index) const = 0;
-  virtual bool FindNative(const char *name, size_t *indexp) const = 0;
+  virtual const char* GetNative(size_t index) const = 0;
+  virtual bool FindNative(const char* name, size_t* indexp) const = 0;
   virtual size_t NumPublics() const = 0;
-  virtual void GetPublic(size_t index, uint32_t *offsetp, const char **namep) const = 0;
-  virtual bool FindPublic(const char *name, size_t *indexp) const = 0;
+  virtual void GetPublic(size_t index, uint32_t* offsetp, const char** namep) const = 0;
+  virtual bool FindPublic(const char* name, size_t* indexp) const = 0;
   virtual size_t NumPubvars() const = 0;
-  virtual void GetPubvar(size_t index, uint32_t *offsetp, const char **namep) const = 0;
-  virtual bool FindPubvar(const char *name, size_t *indexp) const = 0;
+  virtual void GetPubvar(size_t index, uint32_t* offsetp, const char** namep) const = 0;
+  virtual bool FindPubvar(const char* name, size_t* indexp) const = 0;
   virtual size_t HeapSize() const = 0;
   virtual size_t ImageSize() const = 0;
-  virtual const char *LookupFile(uint32_t code_offset) = 0;
-  virtual const char *LookupFunction(uint32_t code_offset) = 0;
-  virtual bool LookupLine(uint32_t code_offset, uint32_t *line) = 0;
+  virtual const char* LookupFile(uint32_t code_offset) = 0;
+  virtual const char* LookupFunction(uint32_t code_offset) = 0;
+  virtual bool LookupLine(uint32_t code_offset, uint32_t* line) = 0;
 };
 
 class EmptyImage : public LegacyImage
@@ -85,26 +85,26 @@ class EmptyImage : public LegacyImage
   size_t NumNatives() const override {
     return 0;
   }
-  const char *GetNative(size_t index) const override {
+  const char* GetNative(size_t index) const override {
     return nullptr;
   }
-  bool FindNative(const char *name, size_t *indexp) const override {
+  bool FindNative(const char* name, size_t* indexp) const override {
     return false;
   }
   size_t NumPublics() const override {
     return 0;
   }
-  void GetPublic(size_t index, uint32_t *offsetp, const char **namep) const override {
+  void GetPublic(size_t index, uint32_t* offsetp, const char** namep) const override {
   }
-  bool FindPublic(const char *name, size_t *indexp) const override {
+  bool FindPublic(const char* name, size_t* indexp) const override {
     return false;
   }
   size_t NumPubvars() const override {
     return 0;
   }
-  void GetPubvar(size_t index, uint32_t *offsetp, const char **namep) const override {
+  void GetPubvar(size_t index, uint32_t* offsetp, const char** namep) const override {
   }
-  bool FindPubvar(const char *name, size_t *indexp) const override {
+  bool FindPubvar(const char* name, size_t* indexp) const override {
     return false;
   }
   size_t HeapSize() const override {
@@ -113,13 +113,13 @@ class EmptyImage : public LegacyImage
   size_t ImageSize() const override {
     return 0;
   }
-  const char *LookupFile(uint32_t code_offset) override {
+  const char* LookupFile(uint32_t code_offset) override {
     return nullptr;
   }
-  const char *LookupFunction(uint32_t code_offset) override {
+  const char* LookupFunction(uint32_t code_offset) override {
     return nullptr;
   }
-  bool LookupLine(uint32_t code_offset, uint32_t *line) override {
+  bool LookupLine(uint32_t code_offset, uint32_t* line) override {
     return false;
   }
 

--- a/vm/linking.cpp
+++ b/vm/linking.cpp
@@ -16,7 +16,7 @@
 using namespace sp;
 
 CodeChunk
-sp::LinkCode(Environment *env, Assembler &masm)
+sp::LinkCode(Environment* env, Assembler& masm)
 {
   if (masm.outOfMemory())
     return CodeChunk();
@@ -29,16 +29,16 @@ sp::LinkCode(Environment *env, Assembler &masm)
   return code;
 }
 
-uint8_t *
-sp::LinkCodeToLegacyPtr(Environment *env, Assembler &masm)
+uint8_t*
+sp::LinkCodeToLegacyPtr(Environment* env, Assembler& masm)
 {
   if (masm.outOfMemory())
     return nullptr;
 
-  void *code = env->APIv1()->AllocatePageMemory(masm.length());
+  void* code = env->APIv1()->AllocatePageMemory(masm.length());
   if (!code)
     return nullptr;
 
   masm.emitToExecutableMemory(code);
-  return reinterpret_cast<uint8_t *>(code);
+  return reinterpret_cast<uint8_t*>(code);
 }

--- a/vm/linking.h
+++ b/vm/linking.h
@@ -20,8 +20,8 @@ namespace sp {
 
 class Environment;
 
-CodeChunk LinkCode(Environment *env, Assembler& masm);
-uint8_t *LinkCodeToLegacyPtr(Environment *env, Assembler& masm);
+CodeChunk LinkCode(Environment* env, Assembler& masm);
+uint8_t* LinkCodeToLegacyPtr(Environment* env, Assembler& masm);
 
 }
 

--- a/vm/null-frame-layout.h
+++ b/vm/null-frame-layout.h
@@ -44,7 +44,7 @@ struct FrameLayout
   // This is -offsetof(FrameLayout, prev_ebp).
   static const intptr_t kOffsetFromFp = 0;
 
-  static inline FrameLayout* FromFp(intptr_t *fp) {
+  static inline FrameLayout* FromFp(intptr_t* fp) {
     return nullptr;
   }
 };

--- a/vm/opcodes.cpp
+++ b/vm/opcodes.cpp
@@ -33,7 +33,7 @@
 using namespace sp;
 using namespace SourcePawn;
 
-const char *OpcodeNames[] = {
+const char* OpcodeNames[] = {
 #define _(op, text) text,
   OPCODE_LIST(_, _)
 #undef _
@@ -42,9 +42,9 @@ const char *OpcodeNames[] = {
 
 #ifdef JIT_SPEW
 void
-SourcePawn::SpewOpcode(PluginRuntime *runtime, const cell_t *start, const cell_t *cip)
+SourcePawn::SpewOpcode(PluginRuntime* runtime, const cell_t* start, const cell_t* cip)
 {
-  fprintf(stdout, "  [%05d:%04d]", cip - (cell_t *)runtime->code().bytes, cip - start);
+  fprintf(stdout, "  [%05d:%04d]", cip - (cell_t*)runtime->code().bytes, cip - start);
 
   if (*cip >= OPCODES_LAST) {
     fprintf(stdout, " unknown-opcode\n");
@@ -85,7 +85,7 @@ SourcePawn::SpewOpcode(PluginRuntime *runtime, const cell_t *start, const cell_t
     case OP_JSLEQ:
       fprintf(stdout, "%05d:%04d",
         cip[1] / 4,
-        ((cell_t *)runtime->code().bytes + cip[1] / 4) - start);
+        ((cell_t*)runtime->code().bytes + cip[1] / 4) - start);
       break;
 
     case OP_SYSREQ_C:

--- a/vm/opcodes.h
+++ b/vm/opcodes.h
@@ -38,7 +38,7 @@
 
 namespace SourcePawn {
 #ifdef JIT_SPEW
-	void SpewOpcode(sp::PluginRuntime *runtime, const cell_t *start, const cell_t *cip);
+	void SpewOpcode(sp::PluginRuntime* runtime, const cell_t* start, const cell_t* cip);
 #endif
 }
 

--- a/vm/outofline-asm.h
+++ b/vm/outofline-asm.h
@@ -52,7 +52,7 @@ class ErrorPath : public OutOfLinePath
 
   bool emit(Compiler* cc) override;
 
-  const cell_t *cip;
+  const cell_t* cip;
   int err;
 };
 

--- a/vm/pcode-reader.h
+++ b/vm/pcode-reader.h
@@ -609,7 +609,7 @@ class PcodeReader
 
       return visitor_->visitSWITCH(
         defaultOffset,
-        reinterpret_cast<const CaseTableEntry *>(table),
+        reinterpret_cast<const CaseTableEntry*>(table),
         ncases);
     }
 

--- a/vm/plugin-context.cpp
+++ b/vm/plugin-context.cpp
@@ -28,7 +28,7 @@ using namespace SourcePawn;
 
 static const size_t kMinHeapSize = 16384;
 
-PluginContext::PluginContext(PluginRuntime *pRuntime)
+PluginContext::PluginContext(PluginRuntime* pRuntime)
  : m_pRuntime(pRuntime),
    memory_(nullptr),
    data_size_(m_pRuntime->data().length),
@@ -69,7 +69,7 @@ PluginContext::Initialize()
   /* Initialize the null references */
   uint32_t index;
   if (FindPubvarByName("NULL_VECTOR", &index) == SP_ERROR_NONE) {
-    sp_pubvar_t *pubvar;
+    sp_pubvar_t* pubvar;
     GetPubvarByIndex(index, &pubvar);
     m_pNullVec = pubvar->offs;
   } else {
@@ -77,7 +77,7 @@ PluginContext::Initialize()
   }
 
   if (FindPubvarByName("NULL_STRING", &index) == SP_ERROR_NONE) {
-    sp_pubvar_t *pubvar;
+    sp_pubvar_t* pubvar;
     GetPubvarByIndex(index, &pubvar);
     m_pNullString = pubvar->offs;
   } else {
@@ -88,9 +88,9 @@ PluginContext::Initialize()
 }
 
 int
-PluginContext::HeapAlloc(unsigned int cells, cell_t *local_addr, cell_t **phys_addr)
+PluginContext::HeapAlloc(unsigned int cells, cell_t* local_addr, cell_t** phys_addr)
 {
-  cell_t *addr;
+  cell_t* addr;
   ucell_t realmem;
 
 #if 0
@@ -110,7 +110,7 @@ PluginContext::HeapAlloc(unsigned int cells, cell_t *local_addr, cell_t **phys_a
   if ((cell_t)(sp_ - hp_ - realmem) < STACKMARGIN)
     return SP_ERROR_HEAPLOW;
 
-  addr = (cell_t *)(memory_ + hp_);
+  addr = (cell_t*)(memory_ + hp_);
   /* store size of allocation in cells */
   *addr = (cell_t)cells;
   addr++;
@@ -130,14 +130,14 @@ int
 PluginContext::HeapPop(cell_t local_addr)
 {
   cell_t cellcount;
-  cell_t *addr;
+  cell_t* addr;
 
   /* check the bounds of this address */
   local_addr -= sizeof(cell_t);
   if (local_addr < (cell_t)data_size_ || local_addr >= sp_)
     return SP_ERROR_INVALID_ADDRESS;
 
-  addr = (cell_t *)(memory_ + local_addr);
+  addr = (cell_t*)(memory_ + local_addr);
   cellcount = (*addr) * sizeof(cell_t);
   /* check if this memory count looks valid */
   if ((signed)(hp_ - cellcount - sizeof(cell_t)) != local_addr)
@@ -161,13 +161,13 @@ PluginContext::HeapRelease(cell_t local_addr)
 }
 
 int
-PluginContext::FindNativeByName(const char *name, uint32_t *index)
+PluginContext::FindNativeByName(const char* name, uint32_t* index)
 {
   return m_pRuntime->FindNativeByName(name, index);
 }
 
 int
-PluginContext::GetNativeByIndex(uint32_t index, sp_native_t **native)
+PluginContext::GetNativeByIndex(uint32_t index, sp_native_t** native)
 {
   return m_pRuntime->GetNativeByIndex(index, native);
 }
@@ -179,13 +179,13 @@ PluginContext::GetNativesNum()
 }
 
 int
-PluginContext::FindPublicByName(const char *name, uint32_t *index)
+PluginContext::FindPublicByName(const char* name, uint32_t* index)
 {
   return m_pRuntime->FindPublicByName(name, index);
 }
 
 int
-PluginContext::GetPublicByIndex(uint32_t index, sp_public_t **pblic)
+PluginContext::GetPublicByIndex(uint32_t index, sp_public_t** pblic)
 {
   return m_pRuntime->GetPublicByIndex(index, pblic);
 }
@@ -197,19 +197,19 @@ PluginContext::GetPublicsNum()
 }
 
 int
-PluginContext::GetPubvarByIndex(uint32_t index, sp_pubvar_t **pubvar)
+PluginContext::GetPubvarByIndex(uint32_t index, sp_pubvar_t** pubvar)
 {
   return m_pRuntime->GetPubvarByIndex(index, pubvar);
 }
 
 int
-PluginContext::FindPubvarByName(const char *name, uint32_t *index)
+PluginContext::FindPubvarByName(const char* name, uint32_t* index)
 {
   return m_pRuntime->FindPubvarByName(name, index);
 }
 
 int
-PluginContext::GetPubvarAddrs(uint32_t index, cell_t *local_addr, cell_t **phys_addr)
+PluginContext::GetPubvarAddrs(uint32_t index, cell_t* local_addr, cell_t** phys_addr)
 {
   return m_pRuntime->GetPubvarAddrs(index, local_addr, phys_addr);
 }
@@ -221,7 +221,7 @@ PluginContext::GetPubVarsNum()
 }
 
 int
-PluginContext::LocalToPhysAddr(cell_t local_addr, cell_t **phys_addr)
+PluginContext::LocalToPhysAddr(cell_t local_addr, cell_t** phys_addr)
 {
   if (((local_addr >= hp_) && (local_addr < sp_)) ||
       (local_addr < 0) || ((ucell_t)local_addr >= mem_size_))
@@ -230,28 +230,28 @@ PluginContext::LocalToPhysAddr(cell_t local_addr, cell_t **phys_addr)
   }
 
   if (phys_addr)
-    *phys_addr = (cell_t *)(memory_ + local_addr);
+    *phys_addr = (cell_t*)(memory_ + local_addr);
 
   return SP_ERROR_NONE;
 }
 
 int
-PluginContext::LocalToString(cell_t local_addr, char **addr)
+PluginContext::LocalToString(cell_t local_addr, char** addr)
 {
   if (((local_addr >= hp_) && (local_addr < sp_)) ||
       (local_addr < 0) || ((ucell_t)local_addr >= mem_size_))
   {
     return SP_ERROR_INVALID_ADDRESS;
   }
-  *addr = (char *)(memory_ + local_addr);
+  *addr = (char*)(memory_ + local_addr);
 
   return SP_ERROR_NONE;
 }
 
 int
-PluginContext::StringToLocal(cell_t local_addr, size_t bytes, const char *source)
+PluginContext::StringToLocal(cell_t local_addr, size_t bytes, const char* source)
 {
-  char *dest;
+  char* dest;
   size_t len;
 
   if (((local_addr >= hp_) && (local_addr < sp_)) ||
@@ -264,7 +264,7 @@ PluginContext::StringToLocal(cell_t local_addr, size_t bytes, const char *source
     return SP_ERROR_NONE;
 
   len = strlen(source);
-  dest = (char *)(memory_ + local_addr);
+  dest = (char*)(memory_ + local_addr);
 
   if (len >= bytes)
     len = bytes - 1;
@@ -276,7 +276,7 @@ PluginContext::StringToLocal(cell_t local_addr, size_t bytes, const char *source
 }
 
 static inline int
-__CheckValidChar(char *c)
+__CheckValidChar(char* c)
 {
   int count;
   int bytecount = 0;
@@ -311,9 +311,9 @@ __CheckValidChar(char *c)
 }
 
 int
-PluginContext::StringToLocalUTF8(cell_t local_addr, size_t maxbytes, const char *source, size_t *wrtnbytes)
+PluginContext::StringToLocalUTF8(cell_t local_addr, size_t maxbytes, const char* source, size_t* wrtnbytes)
 {
-  char *dest;
+  char* dest;
   size_t len;
   bool needtocheck = false;
 
@@ -328,7 +328,7 @@ PluginContext::StringToLocalUTF8(cell_t local_addr, size_t maxbytes, const char 
     return SP_ERROR_NONE;
 
   len = strlen(source);
-  dest = (char *)(memory_ + local_addr);
+  dest = (char*)(memory_ + local_addr);
 
   if ((size_t)len >= maxbytes) {
     len = maxbytes - 1;
@@ -346,32 +346,32 @@ PluginContext::StringToLocalUTF8(cell_t local_addr, size_t maxbytes, const char 
   return SP_ERROR_NONE;
 }
 
-IPluginFunction *
+IPluginFunction*
 PluginContext::GetFunctionById(funcid_t func_id)
 {
   return m_pRuntime->GetFunctionById(func_id);
 }
 
-IPluginFunction *
-PluginContext::GetFunctionByName(const char *public_name)
+IPluginFunction*
+PluginContext::GetFunctionByName(const char* public_name)
 {
   return m_pRuntime->GetFunctionByName(public_name);
 }
 
 int
-PluginContext::LocalToStringNULL(cell_t local_addr, char **addr)
+PluginContext::LocalToStringNULL(cell_t local_addr, char** addr)
 {
   int err;
   if ((err = LocalToString(local_addr, addr)) != SP_ERROR_NONE)
     return err;
 
-  if ((cell_t *)*addr == m_pNullString)
+  if ((cell_t*)*addr == m_pNullString)
     *addr = NULL;
 
   return SP_ERROR_NONE;
 }
 
-cell_t *
+cell_t*
 PluginContext::GetNullRef(SP_NULL_TYPE type)
 {
   if (type == SP_NULL_VECTOR)
@@ -383,7 +383,7 @@ PluginContext::GetNullRef(SP_NULL_TYPE type)
 bool
 PluginContext::IsInExec()
 {
-  for (InvokeFrame *ivk = env_->top(); ivk; ivk = ivk->prev()) {
+  for (InvokeFrame* ivk = env_->top(); ivk; ivk = ivk->prev()) {
     if (ivk->cx() == this)
       return true;
   }
@@ -391,7 +391,7 @@ PluginContext::IsInExec()
 }
 
 bool
-PluginContext::Invoke(funcid_t fnid, const cell_t *params, unsigned int num_params, cell_t *result)
+PluginContext::Invoke(funcid_t fnid, const cell_t* params, unsigned int num_params, cell_t* result)
 {
   EnterProfileScope profileScope("SourcePawn", "EnterJIT");
 
@@ -403,7 +403,7 @@ PluginContext::Invoke(funcid_t fnid, const cell_t *params, unsigned int num_para
   assert((fnid & 1) != 0);
 
   unsigned public_id = fnid >> 1;
-  ScriptedInvoker *cfun = m_pRuntime->GetPublicFunction(public_id);
+  ScriptedInvoker* cfun = m_pRuntime->GetPublicFunction(public_id);
   if (!cfun) {
     ReportErrorNumber(SP_ERROR_NOT_FOUND);
     return false;
@@ -450,7 +450,7 @@ PluginContext::Invoke(funcid_t fnid, const cell_t *params, unsigned int num_para
 
   /* Push parameters */
   sp_ -= sizeof(cell_t) * (num_params + 1);
-  cell_t *sp = (cell_t *)(memory_ + sp_);
+  cell_t* sp = (cell_t*)(memory_ + sp_);
 
   sp[0] = num_params;
   for (unsigned int i = 0; i < num_params; i++)
@@ -484,16 +484,16 @@ PluginContext::Invoke(funcid_t fnid, const cell_t *params, unsigned int num_para
   return ok;
 }
 
-IPluginRuntime *
+IPluginRuntime*
 PluginContext::GetRuntime()
 {
   return m_pRuntime;
 }
 
-cell_t *
+cell_t*
 PluginContext::GetLocalParams()
 {
-  return (cell_t *)(memory_ + frm_ + (2 * sizeof(cell_t)));
+  return (cell_t*)(memory_ + frm_ + (2 * sizeof(cell_t)));
 }
 
 int
@@ -530,17 +530,17 @@ PluginContext::pushTracker(uint32_t amount)
 
 struct array_creation_t
 {
-  const cell_t *dim_list;     /* Dimension sizes */
+  const cell_t* dim_list;     /* Dimension sizes */
   cell_t dim_count;           /* Number of dimensions */
-  cell_t *data_offs;          /* Current offset AFTER the indirection vectors (data) */
-  cell_t *base;               /* array base */
+  cell_t* data_offs;          /* Current offset AFTER the indirection vectors (data) */
+  cell_t* base;               /* array base */
 };
 
 static cell_t
-GenerateInnerArrayIndirectionVectors(array_creation_t *ar, int dim, cell_t cur_offs)
+GenerateInnerArrayIndirectionVectors(array_creation_t* ar, int dim, cell_t cur_offs)
 {
   cell_t write_offs = cur_offs;
-  cell_t *data_offs = ar->data_offs;
+  cell_t* data_offs = ar->data_offs;
 
   cur_offs += ar->dim_list[dim];
 
@@ -571,7 +571,7 @@ GenerateInnerArrayIndirectionVectors(array_creation_t *ar, int dim, cell_t cur_o
 }
 
 static cell_t
-calc_indirection(const array_creation_t *ar, cell_t dim)
+calc_indirection(const array_creation_t* ar, cell_t dim)
 {
   cell_t size = ar->dim_list[dim];
   if (dim < ar->dim_count - 2)
@@ -580,7 +580,7 @@ calc_indirection(const array_creation_t *ar, cell_t dim)
 }
 
 static cell_t
-GenerateArrayIndirectionVectors(cell_t *arraybase, cell_t dims[], cell_t _dimcount)
+GenerateArrayIndirectionVectors(cell_t* arraybase, cell_t dims[], cell_t _dimcount)
 {
   array_creation_t ar;
   cell_t data_offs;
@@ -655,7 +655,7 @@ GenerateAbsoluteIndirectionVectors(abs_iv_data_t& info, cell_t dim)
 }
 
 int
-PluginContext::generateFullArray(uint32_t argc, cell_t *argv, int autozero)
+PluginContext::generateFullArray(uint32_t argc, cell_t* argv, int autozero)
 {
   // Calculate how many cells are needed.
   if (argv[0] <= 0)
@@ -689,13 +689,13 @@ PluginContext::generateFullArray(uint32_t argc, cell_t *argv, int autozero)
     return SP_ERROR_ARRAY_TOO_BIG;
 
   uint32_t new_hp = hp_ + bytes;
-  cell_t *dat_hp = reinterpret_cast<cell_t *>(memory_ + new_hp);
+  cell_t* dat_hp = reinterpret_cast<cell_t*>(memory_ + new_hp);
 
   // argv, coincidentally, is STK.
   if (dat_hp >= argv - STACK_MARGIN)
     return SP_ERROR_HEAPLOW;
 
-  cell_t *base = reinterpret_cast<cell_t *>(memory_ + hp_);
+  cell_t* base = reinterpret_cast<cell_t*>(memory_ + hp_);
   LegacyImage* image = runtime()->image();
 
   if (image->DescribeCode().features & SmxConsts::kCodeFeatureDirectArrays) {
@@ -729,7 +729,7 @@ PluginContext::generateFullArray(uint32_t argc, cell_t *argv, int autozero)
 }
 
 int
-PluginContext::generateArray(cell_t dims, cell_t *stk, bool autozero)
+PluginContext::generateArray(cell_t dims, cell_t* stk, bool autozero)
 {
   if (dims == 1) {
     uint32_t size = *stk;
@@ -844,7 +844,7 @@ PluginContext::setFrameValue(cell_t offset, cell_t value)
 bool
 PluginContext::getCellValue(cell_t address, cell_t* out)
 {
-  assert((uintptr_t)(const void *)out % sizeof(cell_t) == 0);
+  assert((uintptr_t)(const void*)out % sizeof(cell_t) == 0);
 
   cell_t* ptr = throwIfBadAddress(address);
   if (!ptr)

--- a/vm/plugin-context.h
+++ b/vm/plugin-context.h
@@ -28,48 +28,48 @@ class PluginContext;
 class PluginContext : public BasePluginContext
 {
  public:
-  PluginContext(PluginRuntime *pRuntime);
+  PluginContext(PluginRuntime* pRuntime);
   ~PluginContext() override;
 
   bool Initialize();
 
  public: //IPluginContext
-  int HeapAlloc(unsigned int cells, cell_t *local_addr, cell_t **phys_addr) override;
+  int HeapAlloc(unsigned int cells, cell_t* local_addr, cell_t** phys_addr) override;
   int HeapPop(cell_t local_addr) override;
   int HeapRelease(cell_t local_addr) override;
-  int FindNativeByName(const char *name, uint32_t *index) override;
-  int GetNativeByIndex(uint32_t index, sp_native_t **native) override;
+  int FindNativeByName(const char* name, uint32_t* index) override;
+  int GetNativeByIndex(uint32_t index, sp_native_t** native) override;
   uint32_t GetNativesNum() override;
-  int FindPublicByName(const char *name, uint32_t *index) override;
-  int GetPublicByIndex(uint32_t index, sp_public_t **publicptr) override;
+  int FindPublicByName(const char* name, uint32_t* index) override;
+  int GetPublicByIndex(uint32_t index, sp_public_t** publicptr) override;
   uint32_t GetPublicsNum() override;
-  int GetPubvarByIndex(uint32_t index, sp_pubvar_t **pubvar) override;
-  int FindPubvarByName(const char *name, uint32_t *index) override;
-  int GetPubvarAddrs(uint32_t index, cell_t *local_addr, cell_t **phys_addr) override;
+  int GetPubvarByIndex(uint32_t index, sp_pubvar_t** pubvar) override;
+  int FindPubvarByName(const char* name, uint32_t* index) override;
+  int GetPubvarAddrs(uint32_t index, cell_t* local_addr, cell_t** phys_addr) override;
   uint32_t GetPubVarsNum() override;
-  int LocalToPhysAddr(cell_t local_addr, cell_t **phys_addr) override;
-  int LocalToString(cell_t local_addr, char **addr) override;
-  int StringToLocal(cell_t local_addr, size_t chars, const char *source) override;
-  int StringToLocalUTF8(cell_t local_addr, size_t maxbytes, const char *source, size_t *wrtnbytes) override;
-  IPluginFunction *GetFunctionByName(const char *public_name) override;
-  IPluginFunction *GetFunctionById(funcid_t func_id) override;
-  cell_t *GetNullRef(SP_NULL_TYPE type) override;
-  int LocalToStringNULL(cell_t local_addr, char **addr) override;
-  IPluginRuntime *GetRuntime() override;
-  cell_t *GetLocalParams() override;
+  int LocalToPhysAddr(cell_t local_addr, cell_t** phys_addr) override;
+  int LocalToString(cell_t local_addr, char** addr) override;
+  int StringToLocal(cell_t local_addr, size_t chars, const char* source) override;
+  int StringToLocalUTF8(cell_t local_addr, size_t maxbytes, const char* source, size_t* wrtnbytes) override;
+  IPluginFunction* GetFunctionByName(const char* public_name) override;
+  IPluginFunction* GetFunctionById(funcid_t func_id) override;
+  cell_t* GetNullRef(SP_NULL_TYPE type) override;
+  int LocalToStringNULL(cell_t local_addr, char** addr) override;
+  IPluginRuntime* GetRuntime() override;
+  cell_t* GetLocalParams() override;
 
-  bool Invoke(funcid_t fnid, const cell_t *params, unsigned int num_params, cell_t *result);
+  bool Invoke(funcid_t fnid, const cell_t* params, unsigned int num_params, cell_t* result);
 
   size_t HeapSize() const {
     return mem_size_;
   }
-  uint8_t *memory() const {
+  uint8_t* memory() const {
     return memory_;
   }
   size_t DataSize() const {
     return data_size_;
   }
-  PluginRuntime *runtime() const {
+  PluginRuntime* runtime() const {
     return m_pRuntime;
   }
 
@@ -86,13 +86,13 @@ class PluginContext : public BasePluginContext
     return offsetof(PluginContext, memory_);
   }
 
-  int32_t *addressOfSp() {
+  int32_t* addressOfSp() {
     return &sp_;
   }
-  cell_t *addressOfFrm() {
+  cell_t* addressOfFrm() {
     return &frm_;
   }
-  cell_t *addressOfHp() {
+  cell_t* addressOfHp() {
     return &hp_;
   }
 
@@ -109,8 +109,8 @@ class PluginContext : public BasePluginContext
   int popTrackerAndSetHeap();
   int pushTracker(uint32_t amount);
 
-  int generateArray(cell_t dims, cell_t *stk, bool autozero);
-  int generateFullArray(uint32_t argc, cell_t *argv, int autozero);
+  int generateArray(cell_t dims, cell_t* stk, bool autozero);
+  int generateFullArray(uint32_t argc, cell_t* argv, int autozero);
 
   // These functions will report an error on failure.
   bool pushAmxFrame();
@@ -134,13 +134,13 @@ class PluginContext : public BasePluginContext
   cell_t* throwIfBadAddress(cell_t addr);
 
  private:
-  PluginRuntime *m_pRuntime;
-  uint8_t *memory_;
+  PluginRuntime* m_pRuntime;
+  uint8_t* memory_;
   uint32_t data_size_;
   uint32_t mem_size_;
 
-  cell_t *m_pNullVec;
-  cell_t *m_pNullString;
+  cell_t* m_pNullVec;
+  cell_t* m_pNullString;
 
   // "Stack top", for convenience.
   cell_t stp_;

--- a/vm/plugin-runtime.cpp
+++ b/vm/plugin-runtime.cpp
@@ -27,7 +27,7 @@
 using namespace sp;
 using namespace SourcePawn;
 
-PluginRuntime::PluginRuntime(LegacyImage *image)
+PluginRuntime::PluginRuntime(LegacyImage* image)
  : image_(image),
    paused_(false),
    computed_code_hash_(false),
@@ -83,10 +83,10 @@ PluginRuntime::Initialize()
     return false;
   memset(pubvars_.get(), 0, sizeof(sp_pubvar_t) * image_->NumPubvars());
 
-  entrypoints_ = MakeUnique<ScriptedInvoker *[]>(image_->NumPublics());
+  entrypoints_ = MakeUnique<ScriptedInvoker*[]>(image_->NumPublics());
   if (!entrypoints_)
     return false;
-  memset(entrypoints_.get(), 0, sizeof(ScriptedInvoker *) * image_->NumPublics());
+  memset(entrypoints_.get(), 0, sizeof(ScriptedInvoker*) * image_->NumPublics());
 
   context_ = new PluginContext(this);
   if (!context_->Initialize())
@@ -101,7 +101,7 @@ PluginRuntime::Initialize()
 }
 
 struct NativeMapping {
-  const char *name;
+  const char* name;
   unsigned opcode;
 };
 
@@ -147,8 +147,8 @@ PluginRuntime::SetupFloatNativeRemapping()
 {
   float_table_ = MakeUnique<floattbl_t[]>(image_->NumNatives());
   for (size_t i = 0; i < image_->NumNatives(); i++) {
-    const char *name = image_->GetNative(i);
-    const NativeMapping *iter = sNativeMap;
+    const char* name = image_->GetNative(i);
+    const NativeMapping* iter = sNativeMap;
     while (iter->name) {
       if (strcmp(name, iter->name) == 0) {
         float_table_[i].found = true;
@@ -192,7 +192,7 @@ PluginRuntime::GetNativeReplacement(size_t index)
 }
 
 void
-PluginRuntime::SetNames(const char *fullname, const char *name)
+PluginRuntime::SetNames(const char* fullname, const char* name)
 {
   name_ = name;
   full_name_ = fullname;
@@ -250,7 +250,7 @@ PluginRuntime::AllMethods() const
 }
 
 int
-PluginRuntime::FindNativeByName(const char *name, uint32_t *index)
+PluginRuntime::FindNativeByName(const char* name, uint32_t* index)
 {
   size_t idx;
   if (!image_->FindNative(name, &idx))
@@ -263,13 +263,13 @@ PluginRuntime::FindNativeByName(const char *name, uint32_t *index)
 }
 
 int
-PluginRuntime::GetNativeByIndex(uint32_t index, sp_native_t **native)
+PluginRuntime::GetNativeByIndex(uint32_t index, sp_native_t** native)
 {
   return SP_ERROR_PARAM;
 }
 
 int
-PluginRuntime::UpdateNativeBinding(uint32_t index, SPVM_NATIVE_FUNC pfn, uint32_t flags, void *data)
+PluginRuntime::UpdateNativeBinding(uint32_t index, SPVM_NATIVE_FUNC pfn, uint32_t flags, void* data)
 {
   if (index >= image_->NumNatives())
     return SP_ERROR_INDEX;
@@ -294,7 +294,7 @@ PluginRuntime::UpdateNativeBinding(uint32_t index, SPVM_NATIVE_FUNC pfn, uint32_
   return SP_ERROR_NONE;
 }
 
-const sp_native_t *
+const sp_native_t*
 PluginRuntime::GetNative(uint32_t index)
 {
   if (index >= image_->NumNatives())
@@ -313,7 +313,7 @@ PluginRuntime::GetNativesNum()
 }
 
 int
-PluginRuntime::FindPublicByName(const char *name, uint32_t *index)
+PluginRuntime::FindPublicByName(const char* name, uint32_t* index)
 {
   size_t idx;
   if (!image_->FindPublic(name, &idx))
@@ -325,12 +325,12 @@ PluginRuntime::FindPublicByName(const char *name, uint32_t *index)
 }
 
 int
-PluginRuntime::GetPublicByIndex(uint32_t index, sp_public_t **out)
+PluginRuntime::GetPublicByIndex(uint32_t index, sp_public_t** out)
 {
   if (index >= image_->NumPublics())
     return SP_ERROR_INDEX;
 
-  sp_public_t &entry = publics_[index];
+  sp_public_t& entry = publics_[index];
   if (!entry.name) {
     uint32_t offset;
     image_->GetPublic(index, &offset, &entry.name);
@@ -350,12 +350,12 @@ PluginRuntime::GetPublicsNum()
 }
 
 int
-PluginRuntime::GetPubvarByIndex(uint32_t index, sp_pubvar_t **out)
+PluginRuntime::GetPubvarByIndex(uint32_t index, sp_pubvar_t** out)
 {
   if (index >= image_->NumPubvars())
     return SP_ERROR_INDEX;
 
-  sp_pubvar_t *pubvar = &pubvars_[index];
+  sp_pubvar_t* pubvar = &pubvars_[index];
   if (!pubvar->name) {
     uint32_t offset;
     image_->GetPubvar(index, &offset, &pubvar->name);
@@ -369,7 +369,7 @@ PluginRuntime::GetPubvarByIndex(uint32_t index, sp_pubvar_t **out)
 }
 
 int
-PluginRuntime::FindPubvarByName(const char *name, uint32_t *index)
+PluginRuntime::FindPubvarByName(const char* name, uint32_t* index)
 {
   size_t idx;
   if (!image_->FindPubvar(name, &idx))
@@ -381,7 +381,7 @@ PluginRuntime::FindPubvarByName(const char *name, uint32_t *index)
 }
 
 int
-PluginRuntime::GetPubvarAddrs(uint32_t index, cell_t *local_addr, cell_t **phys_addr)
+PluginRuntime::GetPubvarAddrs(uint32_t index, cell_t* local_addr, cell_t** phys_addr)
 {
   if (index >= image_->NumPubvars())
     return SP_ERROR_INDEX;
@@ -401,22 +401,22 @@ PluginRuntime::GetPubVarsNum()
   return image_->NumPubvars();
 }
 
-IPluginContext *
+IPluginContext*
 PluginRuntime::GetDefaultContext()
 {
   return context_;
 }
 
-IPluginDebugInfo *
+IPluginDebugInfo*
 PluginRuntime::GetDebugInfo()
 {
   return this;
 }
 
-IPluginFunction *
+IPluginFunction*
 PluginRuntime::GetFunctionById(funcid_t func_id)
 {
-  ScriptedInvoker *pFunc = NULL;
+  ScriptedInvoker* pFunc = NULL;
 
   if (func_id & 1) {
     func_id >>= 1;
@@ -432,13 +432,13 @@ PluginRuntime::GetFunctionById(funcid_t func_id)
   return pFunc;
 }
 
-ScriptedInvoker *
+ScriptedInvoker*
 PluginRuntime::GetPublicFunction(size_t index)
 {
   assert(index < image_->NumPublics());
-  ScriptedInvoker *pFunc = entrypoints_[index];
+  ScriptedInvoker* pFunc = entrypoints_[index];
   if (!pFunc) {
-    sp_public_t *pub = NULL;
+    sp_public_t* pub = NULL;
     GetPublicByIndex(index, &pub);
     if (pub)
       entrypoints_[index] = new ScriptedInvoker(this, (index << 1) | 1, index);
@@ -448,8 +448,8 @@ PluginRuntime::GetPublicFunction(size_t index)
   return pFunc;
 }
 
-IPluginFunction *
-PluginRuntime::GetFunctionByName(const char *public_name)
+IPluginFunction*
+PluginRuntime::GetFunctionByName(const char* public_name)
 {
   uint32_t index;
 
@@ -487,12 +487,12 @@ PluginRuntime::GetMemUsage()
          context_->HeapSize();
 }
 
-unsigned char *
+unsigned char*
 PluginRuntime::GetCodeHash()
 {
   if (!computed_code_hash_) {
     MD5 md5_pcode;
-    md5_pcode.update((const unsigned char *)code_.bytes, code_.length);
+    md5_pcode.update((const unsigned char*)code_.bytes, code_.length);
     md5_pcode.finalize();
     md5_pcode.raw_digest(code_hash_);
     computed_code_hash_ = true;
@@ -500,12 +500,12 @@ PluginRuntime::GetCodeHash()
   return code_hash_;
 }
 
-unsigned char *
+unsigned char*
 PluginRuntime::GetDataHash()
 {
   if (!computed_data_hash_) {
     MD5 md5_data;
-    md5_data.update((const unsigned char *)data_.bytes, data_.length);
+    md5_data.update((const unsigned char*)data_.bytes, data_.length);
     md5_data.finalize();
     md5_data.raw_digest(data_hash_);
     computed_data_hash_ = true;
@@ -513,20 +513,20 @@ PluginRuntime::GetDataHash()
   return data_hash_;
 }
 
-PluginContext *
+PluginContext*
 PluginRuntime::GetBaseContext()
 {
   return context_;
 }
 
 int
-PluginRuntime::ApplyCompilationOptions(ICompilation *co)
+PluginRuntime::ApplyCompilationOptions(ICompilation* co)
 {
   return SP_ERROR_NONE;
 }
 
 int
-PluginRuntime::LookupLine(ucell_t addr, uint32_t *line)
+PluginRuntime::LookupLine(ucell_t addr, uint32_t* line)
 {
   if (!image_->LookupLine(addr, line))
     return SP_ERROR_NOT_FOUND;
@@ -534,9 +534,9 @@ PluginRuntime::LookupLine(ucell_t addr, uint32_t *line)
 }
 
 int
-PluginRuntime::LookupFunction(ucell_t addr, const char **out)
+PluginRuntime::LookupFunction(ucell_t addr, const char** out)
 {
-  const char *name = image_->LookupFunction(addr);
+  const char* name = image_->LookupFunction(addr);
   if (!name)
     return SP_ERROR_NOT_FOUND;
   if (out)
@@ -545,9 +545,9 @@ PluginRuntime::LookupFunction(ucell_t addr, const char **out)
 }
 
 int
-PluginRuntime::LookupFile(ucell_t addr, const char **out)
+PluginRuntime::LookupFile(ucell_t addr, const char** out)
 {
-  const char *name = image_->LookupFile(addr);
+  const char* name = image_->LookupFile(addr);
   if (!name)
     return SP_ERROR_NOT_FOUND;
   if (out)

--- a/vm/plugin-runtime.h
+++ b/vm/plugin-runtime.h
@@ -54,42 +54,42 @@ class PluginRuntime
     public ke::InlineListNode<PluginRuntime>
 {
  public:
-  PluginRuntime(LegacyImage *image);
+  PluginRuntime(LegacyImage* image);
   ~PluginRuntime();
 
   bool Initialize();
 
  public:
   virtual bool IsDebugging() override;
-  virtual IPluginDebugInfo *GetDebugInfo() override;
-  virtual int FindNativeByName(const char *name, uint32_t *index) override;
-  virtual int GetNativeByIndex(uint32_t index, sp_native_t **native) override;
+  virtual IPluginDebugInfo* GetDebugInfo() override;
+  virtual int FindNativeByName(const char* name, uint32_t* index) override;
+  virtual int GetNativeByIndex(uint32_t index, sp_native_t** native) override;
   virtual uint32_t GetNativesNum() override;
-  virtual int FindPublicByName(const char *name, uint32_t *index) override;
-  virtual int GetPublicByIndex(uint32_t index, sp_public_t **publicptr) override;
+  virtual int FindPublicByName(const char* name, uint32_t* index) override;
+  virtual int GetPublicByIndex(uint32_t index, sp_public_t** publicptr) override;
   virtual uint32_t GetPublicsNum() override;
-  virtual int GetPubvarByIndex(uint32_t index, sp_pubvar_t **pubvar) override;
-  virtual int FindPubvarByName(const char *name, uint32_t *index) override;
-  virtual int GetPubvarAddrs(uint32_t index, cell_t *local_addr, cell_t **phys_addr) override;
+  virtual int GetPubvarByIndex(uint32_t index, sp_pubvar_t** pubvar) override;
+  virtual int FindPubvarByName(const char* name, uint32_t* index) override;
+  virtual int GetPubvarAddrs(uint32_t index, cell_t* local_addr, cell_t** phys_addr) override;
   virtual uint32_t GetPubVarsNum() override;
-  virtual IPluginFunction *GetFunctionByName(const char *public_name) override;
-  virtual IPluginFunction *GetFunctionById(funcid_t func_id) override;
-  virtual IPluginContext *GetDefaultContext() override;
-  virtual int ApplyCompilationOptions(ICompilation *co) override;
+  virtual IPluginFunction* GetFunctionByName(const char* public_name) override;
+  virtual IPluginFunction* GetFunctionById(funcid_t func_id) override;
+  virtual IPluginContext* GetDefaultContext() override;
+  virtual int ApplyCompilationOptions(ICompilation* co) override;
   virtual void SetPauseState(bool paused) override;
   virtual bool IsPaused() override;
   virtual size_t GetMemUsage() override;
-  virtual unsigned char *GetCodeHash() override;
-  virtual unsigned char *GetDataHash() override;
-  void SetNames(const char *fullname, const char *name);
+  virtual unsigned char* GetCodeHash() override;
+  virtual unsigned char* GetDataHash() override;
+  void SetNames(const char* fullname, const char* name);
   unsigned GetNativeReplacement(size_t index);
-  ScriptedInvoker *GetPublicFunction(size_t index);
-  int UpdateNativeBinding(uint32_t index, SPVM_NATIVE_FUNC pfn, uint32_t flags, void *data) override;
-  const sp_native_t *GetNative(uint32_t index) override;
-  int LookupLine(ucell_t addr, uint32_t *line) override;
-  int LookupFunction(ucell_t addr, const char **name) override;
-  int LookupFile(ucell_t addr, const char **filename) override;
-  const char *GetFilename() override {
+  ScriptedInvoker* GetPublicFunction(size_t index);
+  int UpdateNativeBinding(uint32_t index, SPVM_NATIVE_FUNC pfn, uint32_t flags, void* data) override;
+  const sp_native_t* GetNative(uint32_t index) override;
+  int LookupLine(ucell_t addr, uint32_t* line) override;
+  int LookupFunction(ucell_t addr, const char** name) override;
+  int LookupFile(ucell_t addr, const char** filename) override;
+  const char* GetFilename() override {
     return full_name_.chars();
   }
 
@@ -110,9 +110,9 @@ class PluginRuntime
     return &natives_[index];
   }
 
-  PluginContext *GetBaseContext();
+  PluginContext* GetBaseContext();
 
-  const char *Name() const {
+  const char* Name() const {
     return name_.chars();
   }
 
@@ -124,13 +124,13 @@ class PluginRuntime
   typedef LegacyImage::Code Code;
   typedef LegacyImage::Data Data;
 
-  const Code &code() const {
+  const Code& code() const {
     return code_;
   }
-  const Data &data() const {
+  const Data& data() const {
     return data_;
   }
-  LegacyImage *image() const {
+  LegacyImage* image() const {
     return image_;
   }
   PluginContext* context() const {

--- a/vm/pool-allocator.cpp
+++ b/vm/pool-allocator.cpp
@@ -66,7 +66,7 @@ PoolAllocator::FreeDefault()
   sAllocatorTLS = nullptr;
 }
 
-char *
+char*
 PoolAllocator::enter()
 {
   scope_depth_++;
@@ -76,7 +76,7 @@ PoolAllocator::enter()
 }
 
 void
-PoolAllocator::leave(char *pos)
+PoolAllocator::leave(char* pos)
 {
   assert(scope_depth_);
   unwind(pos);
@@ -84,12 +84,12 @@ PoolAllocator::leave(char *pos)
 }
 
 void
-PoolAllocator::unwind(char *pos)
+PoolAllocator::unwind(char* pos)
 {
   while (last_) {
     if (pos && pos >= last_->base && pos < last_->end)
       break;
-    Pool *prev = last_->prev;
+    Pool* prev = last_->prev;
     {
       if (last_->size() <= kMaxReserveSize &&
         (!reserved_ || reserved_->size() < last_->size()))
@@ -112,26 +112,26 @@ PoolAllocator::unwind(char *pos)
   last_->ptr = pos;
 }
 
-void *
+void*
 PoolAllocator::slowAllocate(size_t actualBytes)
 {
   size_t bytesNeeded = actualBytes + sizeof(Pool);
   if (bytesNeeded < kDefaultPoolSize)
     bytesNeeded = kDefaultPoolSize;
 
-  Pool *pool;
+  Pool* pool;
   if (reserved_ && reserved_->size() >= bytesNeeded) {
     pool = reserved_;
     reserved_ = nullptr;
   } else {
-    pool = (Pool *)malloc(bytesNeeded);
+    pool = (Pool*)malloc(bytesNeeded);
     if (!pool) {
       fprintf(stderr, "OUT OF POOL MEMORY\n");
       abort();
       return nullptr;
     }
-    pool->base = (char *)(pool + 1);
-    pool->end = (char *)pool + bytesNeeded;
+    pool->base = (char*)(pool + 1);
+    pool->end = (char*)pool + bytesNeeded;
   }
   pool->ptr = pool->base + actualBytes;
   pool->prev = last_;
@@ -170,17 +170,17 @@ PoolAllocationPolicy::reportAllocationOverflow()
   abort();
 }
 
-void *
+void*
 PoolAllocationPolicy::am_malloc(size_t bytes)
 {
-  void *p = sAllocatorTLS.get()->rawAllocate(bytes);
+  void* p = sAllocatorTLS.get()->rawAllocate(bytes);
   if (!p)
     reportOutOfMemory();
   return p;
 }
 
 void
-PoolAllocationPolicy::am_free(void *ptr)
+PoolAllocationPolicy::am_free(void* ptr)
 {
 }
 

--- a/vm/pool-allocator.h
+++ b/vm/pool-allocator.h
@@ -34,10 +34,10 @@ using namespace ke;
 class PoolAllocator
 {
   struct Pool {
-    char *base;
-    char *ptr;
-    char *end;
-    Pool *prev;
+    char* base;
+    char* ptr;
+    char* end;
+    Pool* prev;
 
     size_t size() const {
       return size_t(end - base);
@@ -48,13 +48,13 @@ class PoolAllocator
   static const size_t kMaxReserveSize = 64 * 1024;
 
  private:
-  Pool *reserved_;
-  Pool *last_;
+  Pool* reserved_;
+  Pool* last_;
   size_t scope_depth_;
 
  private:
-  void unwind(char *pos);
-  void *slowAllocate(size_t actualBytes);
+  void unwind(char* pos);
+  void* slowAllocate(size_t actualBytes);
 
  public:
   PoolAllocator();
@@ -64,11 +64,11 @@ class PoolAllocator
   static PoolAllocator& DefaultForThread();
   static void FreeDefault();
 
-  void memoryUsage(size_t *allocated, size_t *reserved, size_t *bookkeeping) const {
+  void memoryUsage(size_t* allocated, size_t* reserved, size_t* bookkeeping) const {
     *allocated = 0;
     *reserved = 0;
     *bookkeeping = 0;
-    for (Pool *cursor = last_; cursor; cursor = cursor->prev) {
+    for (Pool* cursor = last_; cursor; cursor = cursor->prev) {
       *allocated += size_t(cursor->ptr - cursor->base);
       *reserved += size_t(cursor->end - cursor->base);
       *bookkeeping += sizeof(Pool);
@@ -79,31 +79,31 @@ class PoolAllocator
     }
   }
 
-  void *rawAllocate(size_t bytes) {
+  void* rawAllocate(size_t bytes) {
     // Guarantee malloc alignment.
     size_t actualBytes = Align(bytes, kMallocAlignment);
     if (!last_ || (size_t(last_->end - last_->ptr) < actualBytes))
       return slowAllocate(actualBytes);
-    char *ptr = last_->ptr;
+    char* ptr = last_->ptr;
     last_->ptr += actualBytes;
     return ptr;
   }
 
   template <typename T>
-  T *alloc(size_t count = 1) {
+  T* alloc(size_t count = 1) {
     if (!IsUintPtrMultiplySafe(count, sizeof(T))) {
       fprintf(stderr, "allocation overflow\n");
       return nullptr;
     }
-    void *ptr = rawAllocate(count * sizeof(T));
+    void* ptr = rawAllocate(count * sizeof(T));
     if (!ptr)
       return nullptr;
 
-    return reinterpret_cast<T *>(ptr);
+    return reinterpret_cast<T*>(ptr);
   }
 
-  char *enter();
-  void leave(char *position);
+  char* enter();
+  void leave(char* position);
 };
 
 class PoolScope
@@ -114,8 +114,8 @@ class PoolScope
   ~PoolScope();
 
  private:
-  PoolScope(const PoolScope &other) = delete;
-  PoolScope &operator =(const PoolScope &other) = delete;
+  PoolScope(const PoolScope& other) = delete;
+  PoolScope& operator =(const PoolScope& other) = delete;
 
  private:
   PoolAllocator& pool_;
@@ -125,30 +125,30 @@ class PoolScope
 class PoolObject
 {
  public:
-  void *operator new(size_t size) {
+  void* operator new(size_t size) {
     return PoolAllocator::DefaultForThread().rawAllocate(size);
   }
-  void *operator new [](size_t size) {
+  void* operator new [](size_t size) {
     return PoolAllocator::DefaultForThread().rawAllocate(size);
   }
-  void *operator new(size_t size, PoolAllocator &pool) {
+  void* operator new(size_t size, PoolAllocator& pool) {
     return pool.rawAllocate(size);
   }
-  void *operator new [](size_t size, PoolAllocator &pool) {
+  void* operator new [](size_t size, PoolAllocator& pool) {
     return pool.rawAllocate(size);
   }
   
   // Using delete on pool-allocated objects is illegal.
-  void operator delete(void *ptr) {
+  void operator delete(void* ptr) {
     assert(false);
   }
-  void operator delete [](void *ptr) {
+  void operator delete [](void* ptr) {
     assert(false);
   }
-  void operator delete(void *ptr, PoolAllocator &pool) {
+  void operator delete(void* ptr, PoolAllocator& pool) {
     assert(false);
   }
-  void operator delete [](void *ptr, PoolAllocator &pool) {
+  void operator delete [](void* ptr, PoolAllocator& pool) {
     assert(false);
   }
 };
@@ -160,8 +160,8 @@ class PoolAllocationPolicy
   void reportOutOfMemory();
 
  public:
-  void *am_malloc(size_t bytes);
-  void am_free(void *ptr);
+  void* am_malloc(size_t bytes);
+  void am_free(void* ptr);
 };
 
 template <typename T>

--- a/vm/scripted-invoker.cpp
+++ b/vm/scripted-invoker.cpp
@@ -20,13 +20,13 @@
 #include "method-info.h"
 
 /********************
-* FUNCTION CALLING *
+* FUNCTION CALLING*
 ********************/
 
 using namespace sp;
 using namespace SourcePawn;
 
-ScriptedInvoker::ScriptedInvoker(PluginRuntime *runtime, funcid_t id, uint32_t pub_id)
+ScriptedInvoker::ScriptedInvoker(PluginRuntime* runtime, funcid_t id, uint32_t pub_id)
  : env_(Environment::get()),
    context_(runtime->GetBaseContext()),
    m_curparam(0),
@@ -55,20 +55,20 @@ ScriptedInvoker::IsRunnable()
 }
 
 int
-ScriptedInvoker::CallFunction(const cell_t *params, unsigned int num_params, cell_t *result)
+ScriptedInvoker::CallFunction(const cell_t* params, unsigned int num_params, cell_t* result)
 {
   Environment::get()->ReportError(SP_ERROR_ABORTED);
   return SP_ERROR_ABORTED;
 }
 
 int
-ScriptedInvoker::CallFunction2(IPluginContext *pContext, const cell_t *params, unsigned int num_params, cell_t *result)
+ScriptedInvoker::CallFunction2(IPluginContext* pContext, const cell_t* params, unsigned int num_params, cell_t* result)
 {
   Environment::get()->ReportError(SP_ERROR_ABORTED);
   return SP_ERROR_ABORTED;
 }
 
-IPluginContext *
+IPluginContext*
 ScriptedInvoker::GetParentContext()
 {
   return context_;
@@ -87,7 +87,7 @@ int ScriptedInvoker::PushCell(cell_t cell)
 }
 
 int
-ScriptedInvoker::PushCellByRef(cell_t *cell, int flags)
+ScriptedInvoker::PushCellByRef(cell_t* cell, int flags)
 {
   return PushArray(cell, 1, flags);
 }
@@ -101,20 +101,20 @@ ScriptedInvoker::PushFloat(float number)
 }
 
 int
-ScriptedInvoker::PushFloatByRef(float *number, int flags)
+ScriptedInvoker::PushFloatByRef(float* number, int flags)
 {
-  return PushCellByRef((cell_t *)number, flags);
+  return PushCellByRef((cell_t*)number, flags);
 }
 
 int
-ScriptedInvoker::PushArray(cell_t *inarray, unsigned int cells, int copyback)
+ScriptedInvoker::PushArray(cell_t* inarray, unsigned int cells, int copyback)
 {
   if (m_curparam >= SP_MAX_EXEC_PARAMS)
   {
     return SetError(SP_ERROR_PARAMS_MAX);
   }
 
-  ParamInfo *info = &m_info[m_curparam];
+  ParamInfo* info = &m_info[m_curparam];
 
   info->flags = inarray ? copyback : 0;
   info->marked = true;
@@ -128,27 +128,27 @@ ScriptedInvoker::PushArray(cell_t *inarray, unsigned int cells, int copyback)
 }
 
 int
-ScriptedInvoker::PushString(const char *string)
+ScriptedInvoker::PushString(const char* string)
 {
   return _PushString(string, SM_PARAM_STRING_COPY, 0, strlen(string)+1);
 }
 
 int
-ScriptedInvoker::PushStringEx(char *buffer, size_t length, int sz_flags, int cp_flags)
+ScriptedInvoker::PushStringEx(char* buffer, size_t length, int sz_flags, int cp_flags)
 {
   return _PushString(buffer, sz_flags, cp_flags, length);
 }
 
 int
-ScriptedInvoker::_PushString(const char *string, int sz_flags, int cp_flags, size_t len)
+ScriptedInvoker::_PushString(const char* string, int sz_flags, int cp_flags, size_t len)
 {
   if (m_curparam >= SP_MAX_EXEC_PARAMS)
     return SetError(SP_ERROR_PARAMS_MAX);
 
-  ParamInfo *info = &m_info[m_curparam];
+  ParamInfo* info = &m_info[m_curparam];
 
   info->marked = true;
-  info->orig_addr = (cell_t *)string;
+  info->orig_addr = (cell_t*)string;
   info->flags = cp_flags;
   info->size = len;
   info->str.sz_flags = sz_flags;
@@ -170,9 +170,9 @@ ScriptedInvoker::Cancel()
 }
 
 int
-ScriptedInvoker::Execute(cell_t *result)
+ScriptedInvoker::Execute(cell_t* result)
 {
-  Environment *env = Environment::get();
+  Environment* env = Environment::get();
   env->clearPendingException();
 
   // For backward compatibility, we have to clear the exception state.
@@ -196,7 +196,7 @@ ScriptedInvoker::Execute(cell_t *result)
 }
 
 bool
-ScriptedInvoker::Invoke(cell_t *result)
+ScriptedInvoker::Invoke(cell_t* result)
 {
   if (!IsRunnable()) {
     Cancel();
@@ -265,7 +265,7 @@ ScriptedInvoker::Invoke(cell_t *result)
             context_->StringToLocalUTF8(
               temp_info[i].local_addr, 
               temp_info[i].size, 
-              (const char *)temp_info[i].orig_addr,
+              (const char*)temp_info[i].orig_addr,
               NULL);
           }
           /* Copy a binary blob */
@@ -279,7 +279,7 @@ ScriptedInvoker::Invoke(cell_t *result)
             context_->StringToLocal(
               temp_info[i].local_addr,
               temp_info[i].size,
-              (const char *)temp_info[i].orig_addr);
+              (const char*)temp_info[i].orig_addr);
           }
         }
       } /* End array/string calculation */
@@ -326,13 +326,13 @@ ScriptedInvoker::Invoke(cell_t *result)
 }
 
 int
-ScriptedInvoker::Execute2(IPluginContext *ctx, cell_t *result)
+ScriptedInvoker::Execute2(IPluginContext* ctx, cell_t* result)
 {
   Environment::get()->ReportError(SP_ERROR_ABORTED);
   return SP_ERROR_ABORTED;
 }
 
-IPluginRuntime *
+IPluginRuntime*
 ScriptedInvoker::GetParentRuntime()
 {
   return context_->runtime();

--- a/vm/scripted-invoker.h
+++ b/vm/scripted-invoker.h
@@ -32,8 +32,8 @@ struct ParamInfo
   int flags;      /* Copy-back flags */
   bool marked;    /* Whether this is marked as being used */
   cell_t local_addr;  /* Local address to free */
-  cell_t *phys_addr;  /* Physical address of our copy */
-  cell_t *orig_addr;  /* Original address to copy back to */
+  cell_t* phys_addr;  /* Physical address of our copy */
+  cell_t* orig_addr;  /* Original address to copy back to */
   ucell_t size;    /* Size of array in bytes */
   struct {
     bool is_sz;    /* is a string */
@@ -44,36 +44,36 @@ struct ParamInfo
 class ScriptedInvoker : public IPluginFunction
 {
  public:
-  ScriptedInvoker(PluginRuntime *pRuntime, funcid_t fnid, uint32_t pub_id);
+  ScriptedInvoker(PluginRuntime* pRuntime, funcid_t fnid, uint32_t pub_id);
   virtual ~ScriptedInvoker();
 
  public:
   int PushCell(cell_t cell);
-  int PushCellByRef(cell_t *cell, int flags);
+  int PushCellByRef(cell_t* cell, int flags);
   int PushFloat(float number);
-  int PushFloatByRef(float *number, int flags);
-  int PushArray(cell_t *inarray, unsigned int cells, int copyback);
-  int PushString(const char *string);
-  int PushStringEx(char *buffer, size_t length, int sz_flags, int cp_flags);
-  int Execute(cell_t *result);
+  int PushFloatByRef(float* number, int flags);
+  int PushArray(cell_t* inarray, unsigned int cells, int copyback);
+  int PushString(const char* string);
+  int PushStringEx(char* buffer, size_t length, int sz_flags, int cp_flags);
+  int Execute(cell_t* result);
   void Cancel();
-  int CallFunction(const cell_t *params, unsigned int num_params, cell_t *result);
-  IPluginContext *GetParentContext();
-  bool Invoke(cell_t *result);
+  int CallFunction(const cell_t* params, unsigned int num_params, cell_t* result);
+  IPluginContext* GetParentContext();
+  bool Invoke(cell_t* result);
   bool IsRunnable();
   funcid_t GetFunctionID();
-  int Execute2(IPluginContext *ctx, cell_t *result);
-  int CallFunction2(IPluginContext *ctx, 
-    const cell_t *params, 
+  int Execute2(IPluginContext* ctx, cell_t* result);
+  int CallFunction2(IPluginContext* ctx, 
+    const cell_t* params, 
     unsigned int num_params, 
-    cell_t *result);
-  IPluginRuntime *GetParentRuntime();
-  const char *DebugName() {
+    cell_t* result);
+  IPluginRuntime* GetParentRuntime();
+  const char* DebugName() {
     return full_name_.get();
   }
 
  public:
-  sp_public_t *Public() const {
+  sp_public_t* Public() const {
     return public_;
   }
 
@@ -81,19 +81,19 @@ class ScriptedInvoker : public IPluginFunction
   RefPtr<MethodInfo> AcquireMethod();
 
  private:
-  int _PushString(const char *string, int sz_flags, int cp_flags, size_t len);
+  int _PushString(const char* string, int sz_flags, int cp_flags, size_t len);
   int SetError(int err);
 
  private:
-  Environment *env_;
-  PluginContext *context_;
+  Environment* env_;
+  PluginContext* context_;
   cell_t m_params[SP_MAX_EXEC_PARAMS];
   ParamInfo m_info[SP_MAX_EXEC_PARAMS];
   unsigned int m_curparam;
   int m_errorstate;
   funcid_t m_FnId;
   ke::AutoPtr<char[]> full_name_;
-  sp_public_t *public_;
+  sp_public_t* public_;
   RefPtr<MethodInfo> method_;
 };
 

--- a/vm/shell.cpp
+++ b/vm/shell.cpp
@@ -28,7 +28,7 @@ using namespace ke::args;
 using namespace sp;
 using namespace SourcePawn;
 
-Environment *sEnv;
+Environment* sEnv;
 
 static const char*
 BaseFilename(const char* path)
@@ -44,7 +44,7 @@ BaseFilename(const char* path)
 }
 
 static void
-DumpStack(IFrameIterator &iter)
+DumpStack(IFrameIterator& iter)
 {
   int index_count = 0;
   for (; !iter.Done(); iter.Next()) {
@@ -53,14 +53,14 @@ DumpStack(IFrameIterator &iter)
 
     int index = index_count++;
 
-    const char *name = iter.FunctionName();
+    const char* name = iter.FunctionName();
     if (!name) {
       fprintf(stdout, "  [%d] <unknown>\n", index);
       continue;
     }
 
     if (iter.IsScriptedFrame()) {
-      const char *file = iter.FilePath();
+      const char* file = iter.FilePath();
       if (!file)
         file = "<unknown>";
       file = BaseFilename(file);
@@ -74,12 +74,12 @@ DumpStack(IFrameIterator &iter)
 class ShellDebugListener : public IDebugListener
 {
 public:
-  void ReportError(const IErrorReport &report, IFrameIterator &iter) override {
+  void ReportError(const IErrorReport& report, IFrameIterator& iter) override {
     fprintf(stdout, "Exception thrown: %s\n", report.Message());
     DumpStack(iter);
   }
 
-  void OnDebugSpew(const char *msg, ...) override {
+  void OnDebugSpew(const char* msg, ...) override {
 #if !defined(NDEBUG) && defined(DEBUG)
     va_list ap;
     va_start(ap, msg);
@@ -89,24 +89,24 @@ public:
   }
 };
 
-static cell_t Print(IPluginContext *cx, const cell_t *params)
+static cell_t Print(IPluginContext* cx, const cell_t* params)
 {
-  char *p;
+  char* p;
   cx->LocalToString(params[1], &p);
 
   return printf("%s", p);
 }
 
-static cell_t PrintNum(IPluginContext *cx, const cell_t *params)
+static cell_t PrintNum(IPluginContext* cx, const cell_t* params)
 {
   return printf("%d\n", params[1]);
 }
 
-static cell_t PrintNums(IPluginContext *cx, const cell_t *params)
+static cell_t PrintNums(IPluginContext* cx, const cell_t* params)
 {
   for (size_t i = 1; i <= size_t(params[0]); i++) {
     int err;
-    cell_t *addr;
+    cell_t* addr;
     if ((err = cx->LocalToPhysAddr(params[i], &addr)) != SP_ERROR_NONE)
       return cx->ThrowNativeErrorEx(err, "Could not read argument");
     fprintf(stdout, "%d", *addr);
@@ -117,12 +117,12 @@ static cell_t PrintNums(IPluginContext *cx, const cell_t *params)
   return 1;
 }
 
-static cell_t DoNothing(IPluginContext *cx, const cell_t *params)
+static cell_t DoNothing(IPluginContext* cx, const cell_t* params)
 {
   return 1;
 }
 
-static void BindNative(IPluginRuntime *rt, const char *name, SPVM_NATIVE_FUNC fn)
+static void BindNative(IPluginRuntime* rt, const char* name, SPVM_NATIVE_FUNC fn)
 {
   int err;
   uint32_t index;
@@ -132,21 +132,21 @@ static void BindNative(IPluginRuntime *rt, const char *name, SPVM_NATIVE_FUNC fn
   rt->UpdateNativeBinding(index, fn, 0, nullptr);
 }
 
-static cell_t PrintFloat(IPluginContext *cx, const cell_t *params)
+static cell_t PrintFloat(IPluginContext* cx, const cell_t* params)
 {
   return printf("%f\n", sp_ctof(params[1]));
 }
 
-static cell_t WriteFloat(IPluginContext *cx, const cell_t *params)
+static cell_t WriteFloat(IPluginContext* cx, const cell_t* params)
 {
   return printf("%f", sp_ctof(params[1]));
 }
 
-static cell_t DoExecute(IPluginContext *cx, const cell_t *params)
+static cell_t DoExecute(IPluginContext* cx, const cell_t* params)
 {
   int32_t ok = 0;
   for (size_t i = 0; i < size_t(params[2]); i++) {
-    if (IPluginFunction *fn = cx->GetFunctionById(params[1])) {
+    if (IPluginFunction* fn = cx->GetFunctionById(params[1])) {
       if (fn->Execute(nullptr) != SP_ERROR_NONE)
         continue;
       ok++;
@@ -155,10 +155,10 @@ static cell_t DoExecute(IPluginContext *cx, const cell_t *params)
   return ok;
 }
 
-static cell_t DoInvoke(IPluginContext *cx, const cell_t *params)
+static cell_t DoInvoke(IPluginContext* cx, const cell_t* params)
 {
   for (size_t i = 0; i < size_t(params[2]); i++) {
-    if (IPluginFunction *fn = cx->GetFunctionById(params[1])) {
+    if (IPluginFunction* fn = cx->GetFunctionById(params[1])) {
       if (!fn->Invoke())
         return 0;
     }
@@ -166,20 +166,20 @@ static cell_t DoInvoke(IPluginContext *cx, const cell_t *params)
   return 1;
 }
 
-static cell_t DumpStackTrace(IPluginContext *cx, const cell_t *params)
+static cell_t DumpStackTrace(IPluginContext* cx, const cell_t* params)
 {
   FrameIterator iter;
   DumpStack(iter);
   return 0;
 }
 
-static cell_t ReportError(IPluginContext* cx, const cell_t *params)
+static cell_t ReportError(IPluginContext* cx, const cell_t* params)
 {
   cx->ReportError("What the crab?!");
   return 0;
 }
 
-static int Execute(const char *file)
+static int Execute(const char* file)
 {
   char error[255];
   AutoPtr<IPluginRuntime> rtb(sEnv->APIv2()->LoadBinaryFromFile(file, error, sizeof(error)));
@@ -202,11 +202,11 @@ static int Execute(const char *file)
   BindNative(rt, "dump_stack_trace", DumpStackTrace);
   BindNative(rt, "report_error", ReportError);
 
-  IPluginFunction *fun = rt->GetFunctionByName("main");
+  IPluginFunction* fun = rt->GetFunctionByName("main");
   if (!fun)
     return 0;
 
-  IPluginContext *cx = rt->GetDefaultContext();
+  IPluginContext* cx = rt->GetDefaultContext();
 
   int result;
   {
@@ -220,7 +220,7 @@ static int Execute(const char *file)
   return result;
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
 #ifdef __EMSCRIPTEN__
   EM_ASM(

--- a/vm/smx-v1-image.h
+++ b/vm/smx-v1-image.h
@@ -25,16 +25,16 @@ class SmxV1Image
     public LegacyImage
 {
  public:
-  SmxV1Image(FILE *fp);
+  SmxV1Image(FILE* fp);
 
   // This must be called to initialize the reader.
   bool validate();
 
-  const sp_file_hdr_t *hdr() const {
+  const sp_file_hdr_t* hdr() const {
     return hdr_;
   }
 
-  const char *errorMessage() const {
+  const char* errorMessage() const {
     return error_.chars();
   }
 
@@ -42,28 +42,28 @@ class SmxV1Image
   Code DescribeCode() const override;
   Data DescribeData() const override;
   size_t NumNatives() const override;
-  const char *GetNative(size_t index) const override;
-  bool FindNative(const char *name, size_t *indexp) const override;
+  const char* GetNative(size_t index) const override;
+  bool FindNative(const char* name, size_t* indexp) const override;
   size_t NumPublics() const override;
-  void GetPublic(size_t index, uint32_t *offsetp, const char **namep) const override;
-  bool FindPublic(const char *name, size_t *indexp) const override;
+  void GetPublic(size_t index, uint32_t* offsetp, const char** namep) const override;
+  bool FindPublic(const char* name, size_t* indexp) const override;
   size_t NumPubvars() const override;
-  void GetPubvar(size_t index, uint32_t *offsetp, const char **namep) const override;
-  bool FindPubvar(const char *name, size_t *indexp) const override;
+  void GetPubvar(size_t index, uint32_t* offsetp, const char** namep) const override;
+  bool FindPubvar(const char* name, size_t* indexp) const override;
   size_t HeapSize() const override;
   size_t ImageSize() const override;
-  const char *LookupFile(uint32_t code_offset) override;
-  const char *LookupFunction(uint32_t code_offset) override;
-  bool LookupLine(uint32_t code_offset, uint32_t *line) override;
+  const char* LookupFile(uint32_t code_offset) override;
+  const char* LookupFunction(uint32_t code_offset) override;
+  bool LookupLine(uint32_t code_offset, uint32_t* line) override;
 
  private:
    struct Section
    {
-     const char *name;
+     const char* name;
      uint32_t dataoffs;
      uint32_t size;
    };
-  const Section *findSection(const char *name);
+  const Section* findSection(const char* name);
 
  public:
   template <typename T>
@@ -77,9 +77,9 @@ class SmxV1Image
        length_(0),
        features_(0)
     {}
-    Blob(const Section *header,
-         const T *section,
-         const uint8_t *blob,
+    Blob(const Section* header,
+         const T* section,
+         const uint8_t* blob,
          size_t length,
          uint32_t features)
      : header_(header),
@@ -95,7 +95,7 @@ class SmxV1Image
     const T * operator ->() const {
       return section_;
     }
-    const uint8_t *blob() const {
+    const uint8_t* blob() const {
       return blob_;
     }
     size_t length() const {
@@ -109,9 +109,9 @@ class SmxV1Image
     }
 
    private:
-    const Section *header_;
-    const T *section_;
-    const uint8_t *blob_;
+    const Section* header_;
+    const T* section_;
+    const uint8_t* blob_;
     size_t length_;
     uint32_t features_;
   };
@@ -124,7 +124,7 @@ class SmxV1Image
      : section_(nullptr),
        length_(0)
     {}
-    List(const T *section, size_t length)
+    List(const T* section, size_t length)
      : section_(section),
        length_(length)
     {}
@@ -132,7 +132,7 @@ class SmxV1Image
     size_t length() const {
       return length_;
     }
-    const T &operator[](size_t index) const {
+    const T& operator[](size_t index) const {
       assert(index < length());
       return section_[index];
     }
@@ -141,34 +141,34 @@ class SmxV1Image
     }
 
    private:
-    const T *section_;
+    const T* section_;
     size_t length_;
   };
 
  public:
-  const Blob<sp_file_code_t> &code() const {
+  const Blob<sp_file_code_t>& code() const {
     return code_;
   }
-  const Blob<sp_file_data_t> &data() const {
+  const Blob<sp_file_data_t>& data() const {
     return data_;
   }
-  const List<sp_file_publics_t> &publics() const {
+  const List<sp_file_publics_t>& publics() const {
     return publics_;
   }
-  const List<sp_file_natives_t> &natives() const {
+  const List<sp_file_natives_t>& natives() const {
     return natives_;
   }
-  const List<sp_file_pubvars_t> &pubvars() const {
+  const List<sp_file_pubvars_t>& pubvars() const {
     return pubvars_;
   }
 
  protected:
-  bool error(const char *msg) {
+  bool error(const char* msg) {
     error_ = msg;
     return false;
   }
   bool validateName(size_t offset);
-  bool validateSection(const Section *section);
+  bool validateSection(const Section* section);
   bool validateCode();
   bool validateData();
   bool validatePublics();
@@ -179,16 +179,16 @@ class SmxV1Image
 
  private:
   template <typename SymbolType, typename DimType>
-  const char *lookupFunction(const SymbolType *syms, uint32_t addr);
+  const char* lookupFunction(const SymbolType* syms, uint32_t addr);
 
  private:
-  sp_file_hdr_t *hdr_;
+  sp_file_hdr_t* hdr_;
   ke::AString error_;
-  const char *header_strings_;
+  const char* header_strings_;
   ke::Vector<Section> sections_;
 
-  const Section *names_section_;
-  const char *names_;
+  const Section* names_section_;
+  const char* names_;
 
   Blob<sp_file_code_t> code_;
   Blob<sp_file_data_t> data_;
@@ -197,14 +197,14 @@ class SmxV1Image
   List<sp_file_pubvars_t> pubvars_;
   List<sp_file_tag_t> tags_;
 
-  const Section *debug_names_section_;
-  const char *debug_names_;
-  const sp_fdbg_info_t *debug_info_;
+  const Section* debug_names_section_;
+  const char* debug_names_;
+  const sp_fdbg_info_t* debug_info_;
   List<sp_fdbg_file_t> debug_files_;
   List<sp_fdbg_line_t> debug_lines_;
-  const Section *debug_symbols_section_;
-  const sp_fdbg_symbol_t *debug_syms_;
-  const sp_u_fdbg_symbol_t *debug_syms_unpacked_;
+  const Section* debug_symbols_section_;
+  const sp_fdbg_symbol_t* debug_syms_;
+  const sp_u_fdbg_symbol_t* debug_syms_unpacked_;
 };
 
 } // namespace sp

--- a/vm/stack-frames.cpp
+++ b/vm/stack-frames.cpp
@@ -28,7 +28,7 @@ using namespace ke;
 using namespace sp;
 using namespace SourcePawn;
 
-InvokeFrame::InvokeFrame(PluginContext *cx, ucell_t entry_cip)
+InvokeFrame::InvokeFrame(PluginContext* cx, ucell_t entry_cip)
  : prev_(Environment::get()->top()),
    cx_(cx),
    entry_cip_(0)
@@ -71,7 +71,7 @@ InterpInvokeFrame::leaveNativeCall()
   native_index_ = -1;
 }
 
-JitInvokeFrame::JitInvokeFrame(PluginContext *cx, ucell_t entry_cip)
+JitInvokeFrame::JitInvokeFrame(PluginContext* cx, ucell_t entry_cip)
  : InvokeFrame(cx, entry_cip),
    prev_exit_fp_(Environment::get()->exit_fp())
 {
@@ -199,7 +199,7 @@ JitFrameIterator::cip() const
   if (!method)
     return 0;
 
-  CompiledFunction *fn = method->jit();
+  CompiledFunction* fn = method->jit();
   if (!fn)
     return 0;
 
@@ -286,7 +286,7 @@ FrameIterator::LineNumber() const
   return line;
 }
 
-const char *
+const char*
 FrameIterator::FilePath() const
 {
   if (!IsScriptedFrame())
@@ -299,13 +299,13 @@ FrameIterator::FilePath() const
   return runtime_->image()->LookupFile(cip);
 }
 
-const char *
+const char*
 FrameIterator::FunctionName() const
 {
   assert(ivk_);
   if (IsNativeFrame()) {
     uint32_t native_index = frame_cursor_->native_index();
-    const sp_native_t *native = runtime_->GetNative(native_index);
+    const sp_native_t* native = runtime_->GetNative(native_index);
     if (!native)
       return nullptr;
     return native->name;
@@ -331,7 +331,7 @@ FrameIterator::IsScriptedFrame() const
   return frame_cursor_->type() == FrameType::Scripted;
 }
 
-IPluginContext *
+IPluginContext*
 FrameIterator::Context() const
 {
   if (!ivk_)

--- a/vm/stack-frames.h
+++ b/vm/stack-frames.h
@@ -62,7 +62,7 @@ KE_DEFINE_ENUM_OPERATORS(ExitFrameType);
 KE_DEFINE_ENUM_COMPARATORS(ExitFrameType, intptr_t);
 
 static const uintptr_t kExitFrameTypeBits = 3;
-static const uintptr_t kExitFramePayloadBits = (sizeof(void *) * 8) - kExitFrameTypeBits;
+static const uintptr_t kExitFramePayloadBits = (sizeof(void*) * 8) - kExitFrameTypeBits;
 static inline uintptr_t EncodeExitFrameId(ExitFrameType type, uintptr_t payload)
 {
   assert(payload < (uintptr_t(1) << kExitFramePayloadBits));
@@ -84,14 +84,14 @@ class InterpInvokeFrame;
 class InvokeFrame
 {
  protected:
-  InvokeFrame(PluginContext *cx, ucell_t cip);
+  InvokeFrame(PluginContext* cx, ucell_t cip);
   ~InvokeFrame();
 
  public:
-  InvokeFrame *prev() const {
+  InvokeFrame* prev() const {
     return prev_;
   }
-  PluginContext *cx() const {
+  PluginContext* cx() const {
     return cx_;
   }
 
@@ -107,8 +107,8 @@ class InvokeFrame
   }
 
  protected:
-  InvokeFrame *prev_;
-  PluginContext *cx_;
+  InvokeFrame* prev_;
+  PluginContext* cx_;
   ucell_t entry_cip_;
 };
 
@@ -225,10 +225,10 @@ class FrameIterator : public SourcePawn::IFrameIterator
 
   bool IsNativeFrame() const override;
   bool IsScriptedFrame() const override;
-  const char *FunctionName() const override;
-  const char *FilePath() const override;
+  const char* FunctionName() const override;
+  const char* FilePath() const override;
   unsigned LineNumber() const override;
-  IPluginContext *Context() const override;
+  IPluginContext* Context() const override;
   bool IsInternalFrame() const override;
 
  private:

--- a/vm/watchdog_timer.cpp
+++ b/vm/watchdog_timer.cpp
@@ -20,7 +20,7 @@
 
 using namespace sp;
 
-WatchdogTimer::WatchdogTimer(Environment *env)
+WatchdogTimer::WatchdogTimer(Environment* env)
  : env_(env),
    terminate_(false),
    mainthread_(ke::GetCurrentThreadId()),

--- a/vm/watchdog_timer.h
+++ b/vm/watchdog_timer.h
@@ -30,7 +30,7 @@ typedef bool (*WatchdogCallback)();
 class WatchdogTimer
 {
  public:
-  WatchdogTimer(Environment *env);
+  WatchdogTimer(Environment* env);
   ~WatchdogTimer();
 
   bool Initialize(size_t timeout_ms);
@@ -45,7 +45,7 @@ class WatchdogTimer
   void Run();
 
  private:
-  Environment *env_;
+  Environment* env_;
 
   bool terminate_;
   size_t timeout_ms_;

--- a/vm/x64/assembler-x64.cpp
+++ b/vm/x64/assembler-x64.cpp
@@ -16,11 +16,11 @@
 namespace sp {
 
 void
-Assembler::emitToExecutableMemory(void *code)
+Assembler::emitToExecutableMemory(void* code)
 {
   assert(!outOfMemory());
 
-  uint8_t *base = reinterpret_cast<uint8_t *>(code);
+  uint8_t* base = reinterpret_cast<uint8_t*>(code);
   memcpy(base, buffer(), length());
 
   for (size_t i = 0; i < absolute_code_refs_.length(); i++) {

--- a/vm/x64/assembler-x64.h
+++ b/vm/x64/assembler-x64.h
@@ -22,8 +22,8 @@ namespace sp {
 
 struct Register
 {
-  const char *name() const {
-    static const char *names[] = {
+  const char* name() const {
+    static const char* names[] = {
       "rax", "rcx", "rdx", "rbx", "rsp", "rbp", "rsi", "rdi",
       "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15"
     };
@@ -32,10 +32,10 @@ struct Register
 
   int code;
 
-  bool operator == (const Register &other) const {
+  bool operator == (const Register& other) const {
     return code == other.code;
   }
-  bool operator != (const Register &other) const {
+  bool operator != (const Register& other) const {
     return code != other.code;
   }
 
@@ -53,8 +53,8 @@ struct Register
 
 struct FloatRegister
 {
-  const char *name() const {
-    static const char *names[] = {
+  const char* name() const {
+    static const char* names[] = {
       "xmm0", "xmm1", "xmm2", "xmm3", "xmm4", "xmm5", "xmm6", "xmm7",
       "xmm8", "xmm9", "xmm10", "xmm11", "xmm12", "xmm13", "xmm14", "xmm15"
     };
@@ -63,10 +63,10 @@ struct FloatRegister
 
   int code;
 
-  bool operator == (const FloatRegister &other) const {
+  bool operator == (const FloatRegister& other) const {
     return code == other.code;
   }
-  bool operator != (const FloatRegister &other) const {
+  bool operator != (const FloatRegister& other) const {
     return code != other.code;
   }
 
@@ -269,7 +269,7 @@ struct Operand
     // Callers must ensure this is encodable as a 32-bit address.
     KE_RELEASE_ASSERT(address.has32BitEncoding());
     sib(kModeDisp0, NoScale, kNoIndex, rbp);
-    *reinterpret_cast<int32_t *>(bytes_ + 2) = int32_t(address.value());
+    *reinterpret_cast<int32_t*>(bytes_ + 2) = int32_t(address.value());
     length_ = 6;
   }
 
@@ -289,7 +289,7 @@ struct Operand
   }
   void modrm_disp32(Register rm, int32_t disp) {
     modrm(kModeDisp32, rm);
-    *reinterpret_cast<int32_t *>(bytes_ + 1) = disp;
+    *reinterpret_cast<int32_t*>(bytes_ + 1) = disp;
     length_ = 5;
   }
   void sib(uint8_t mode, Scale scale, Register index, Register base) {
@@ -310,7 +310,7 @@ struct Operand
   }
   void sib_disp32(Scale scale, Register index, Register base, int32_t disp) {
     sib(kModeDisp32, scale, index, base);
-    *reinterpret_cast<int32_t *>(bytes_ + 2) = disp;
+    *reinterpret_cast<int32_t*>(bytes_ + 2) = disp;
     length_ = 6;
   }
 
@@ -331,9 +331,9 @@ struct Operand
 class Assembler : public AssemblerBase
 {
  public:
-  void emitToExecutableMemory(void *code);
+  void emitToExecutableMemory(void* code);
 
-  void bind(Label *target) {
+  void bind(Label* target) {
     if (outOfMemory()) {
       // If we ran out of memory, the code stream is potentially invalid and
       // we cannot use the embedded linked list.
@@ -352,7 +352,7 @@ class Assembler : public AssemblerBase
       ptrdiff_t delta = pos_ - (buffer() + offset);
       assert(delta >= INT_MIN && delta <= INT_MAX);
 
-      int32_t *p = reinterpret_cast<int32_t *>(buffer() + offset - 4);
+      int32_t* p = reinterpret_cast<int32_t*>(buffer() + offset - 4);
       status = *p;
       *p = static_cast<int32_t>(delta);
     }
@@ -368,7 +368,7 @@ class Assembler : public AssemblerBase
     label->bind(pc());
   }
 
-  void call(Label *dest) {
+  void call(Label* dest) {
     emit1(0xe8);
     emitJumpTarget(dest);
   }
@@ -386,7 +386,7 @@ class Assembler : public AssemblerBase
     emit1(0xcc);
   }
 
-  void jmp(Label *dest) {
+  void jmp(Label* dest) {
     int8_t d8;
     if (canEmitSmallJump(dest, &d8)) {
       emit2(0xeb, d8);
@@ -400,7 +400,7 @@ class Assembler : public AssemblerBase
     emit1(0xff, 4, target);
   }
 
-  void j(ConditionCode cc, Label *dest) {
+  void j(ConditionCode cc, Label* dest) {
     int8_t d8;
     if (canEmitSmallJump(dest, &d8)) {
       emit2(0x70 + uint8_t(cc), d8);
@@ -575,7 +575,7 @@ class Assembler : public AssemblerBase
   }
 
  private:
-  bool canEmitSmallJump(Label *dest, int8_t *deltap) {
+  bool canEmitSmallJump(Label* dest, int8_t* deltap) {
     if (!dest->bound())
       return false;
 
@@ -586,7 +586,7 @@ class Assembler : public AssemblerBase
     *deltap = static_cast<int8_t>(delta);
     return true;
   }
-  void emitJumpTarget(Label *dest) {
+  void emitJumpTarget(Label* dest) {
     if (dest->bound()) {
       ptrdiff_t delta = ptrdiff_t(dest->offset()) - (position() + 4);
       assert(delta >= INT_MIN && delta <= INT_MAX);

--- a/vm/x64/code-stubs-x64.cpp
+++ b/vm/x64/code-stubs-x64.cpp
@@ -92,12 +92,12 @@ CodeStubs::CompileInvokeStub()
   if (!invoke_stub_.address())
     return false;
 
-  return_stub_ = reinterpret_cast<uint8_t *>(invoke_stub_.address()) + error.offset();
+  return_stub_ = reinterpret_cast<uint8_t*>(invoke_stub_.address()) + error.offset();
   return true;
 }
 
 SPVM_NATIVE_FUNC
-CodeStubs::CreateFakeNativeStub(SPVM_FAKENATIVE_FUNC callback, void *pData)
+CodeStubs::CreateFakeNativeStub(SPVM_FAKENATIVE_FUNC callback, void* pData)
 {
   MacroAssembler masm;
 

--- a/vm/x64/frames-x64.h
+++ b/vm/x64/frames-x64.h
@@ -43,7 +43,7 @@ struct FrameLayout
   // This is -offsetof(FrameLayout, prev_ebp).
   static const intptr_t kOffsetFromFp = -2;
 
-  static inline FrameLayout* FromFp(intptr_t *fp) {
+  static inline FrameLayout* FromFp(intptr_t* fp) {
     return reinterpret_cast<FrameLayout*>(fp + kOffsetFromFp);
   }
 };

--- a/vm/x86/assembler-x86.h
+++ b/vm/x86/assembler-x86.h
@@ -37,8 +37,8 @@
 
 struct Register
 {
-  const char *name() const {
-    static const char *names[] = {
+  const char* name() const {
+    static const char* names[] = {
       "eax", "ecx", "edx", "ebx", "esp", "ebp", "esi", "edi"
     };
     return names[code];
@@ -46,10 +46,10 @@ struct Register
 
   int code;
 
-  bool operator == (const Register &other) const {
+  bool operator == (const Register& other) const {
     return code == other.code;
   }
-  bool operator != (const Register &other) const {
+  bool operator != (const Register& other) const {
     return code != other.code;
   }
 };
@@ -58,8 +58,8 @@ struct Register
 // numbered st0 through st7.
 struct FpuRegister
 {
-  const char *name() const {
-    static const char *names[] = {
+  const char* name() const {
+    static const char* names[] = {
       "st0", "st1", "st2", "st3", "st4", "st5", "st6", "st7"
     };
     return names[code];
@@ -67,18 +67,18 @@ struct FpuRegister
 
   int code;
 
-  bool operator == (const FpuRegister &other) const {
+  bool operator == (const FpuRegister& other) const {
     return code == other.code;
   }
-  bool operator != (const FpuRegister &other) const {
+  bool operator != (const FpuRegister& other) const {
     return code != other.code;
   }
 };
 
 struct FloatRegister
 {
-  const char *name() const {
-    static const char *names[] = {
+  const char* name() const {
+    static const char* names[] = {
       "xmm0", "xmm1", "xmm2", "xmm3", "xmm4", "xmm5", "xmm6", "xmm7"
     };
     return names[code];
@@ -86,10 +86,10 @@ struct FloatRegister
 
   int code;
 
-  bool operator == (const FloatRegister &other) const {
+  bool operator == (const FloatRegister& other) const {
     return code == other.code;
   }
-  bool operator != (const FloatRegister &other) const {
+  bool operator != (const FloatRegister& other) const {
     return code != other.code;
   }
 };
@@ -238,7 +238,7 @@ struct Operand
 
   explicit Operand(ExternalAddress address) {
     modrm(kModeDisp0, kRIP);
-    *reinterpret_cast<const void **>(bytes_ + 1) = address.address();
+    *reinterpret_cast<const void**>(bytes_ + 1) = address.address();
   }
 
   bool isRegister() const {
@@ -286,7 +286,7 @@ struct Operand
   }
   void modrm_disp32(uint8_t rm, int32_t disp) {
     modrm(kModeDisp32, rm);
-    *reinterpret_cast<int32_t *>(bytes_ + 1) = disp;
+    *reinterpret_cast<int32_t*>(bytes_ + 1) = disp;
   }
   void sib(uint8_t mode, Scale scale, uint8_t index, uint8_t base) {
     modrm(mode, kSIB);
@@ -305,7 +305,7 @@ struct Operand
   }
   void sib_disp32(Scale scale, uint8_t index, uint8_t base, int32_t disp) {
     sib(kModeDisp32, scale, index, base);
-    *reinterpret_cast<int32_t *>(bytes_ + 2) = disp;
+    *reinterpret_cast<int32_t*>(bytes_ + 2) = disp;
   }
 
  private:
@@ -328,52 +328,52 @@ class Assembler : public AssemblerBase
   static CPUFeatures X86Features; 
 
  public:
-  static void SetFeatures(const CPUFeatures &features) {
+  static void SetFeatures(const CPUFeatures& features) {
     X86Features = features;
   }
-  static const CPUFeatures &Features() {
+  static const CPUFeatures& Features() {
     return X86Features;
   }
 
   void movl(Register dest, Register src) {
     emit1(0x89, src.code, dest.code);
   }
-  void movl(Register dest, const Operand &src) {
+  void movl(Register dest, const Operand& src) {
     emit1(0x8b, dest.code, src);
   }
-  void movl(const Operand &dest, Register src) {
+  void movl(const Operand& dest, Register src) {
     emit1(0x89, src.code, dest);
   }
   void movl(Register dest, int32_t imm) {
     emit1(0xb8 + dest.code);
     writeInt32(imm);
   }
-  void movl(const Operand &dest, int32_t imm) {
+  void movl(const Operand& dest, int32_t imm) {
     if (dest.isRegister())
       emit1(0xb8 + dest.registerCode());
     else
       emit1(0xc7, 0, dest);
     writeInt32(imm);
   }
-  void movw(const Operand &dest, Register src) {
+  void movw(const Operand& dest, Register src) {
     emit1(0x89, src.code, dest);
   }
-  void movw(Register dest, const Operand &src) {
+  void movw(Register dest, const Operand& src) {
     emit1(0x8b, dest.code, src);
   }
-  void movb(const Operand &dest, Register src) {
+  void movb(const Operand& dest, Register src) {
     emit1(0x88, src.code, dest);
   }
-  void movb(Register dest, const Operand &src) {
+  void movb(Register dest, const Operand& src) {
     emit1(0x8a, dest.code, src);
   }
-  void movzxb(Register dest, const Operand &src) {
+  void movzxb(Register dest, const Operand& src) {
     emit2(0x0f, 0xb6, dest.code, src);
   }
   void movzxb(Register dest, const Register src) {
     emit2(0x0f, 0xb6, dest.code, src.code);
   }
-  void movzxw(Register dest, const Operand &src) {
+  void movzxw(Register dest, const Operand& src) {
     emit2(0x0f, 0xb7, dest.code, src);
   }
   void movzxw(Register dest, const Register src) {
@@ -382,14 +382,14 @@ class Assembler : public AssemblerBase
   void movaps(FloatRegister dest, const FloatRegister src) {
     emit2(0x0f, 0x28, dest.code, src.code);
   }
-  void movaps(FloatRegister dest, const Operand &src) {
+  void movaps(FloatRegister dest, const Operand& src) {
     emit2(0x0f, 0x28, dest.code, src);
   }
-  void movaps(const Operand &dest, FloatRegister src) {
+  void movaps(const Operand& dest, FloatRegister src) {
     emit2(0x0f, 0x29, src.code, dest);
   }
 
-  void lea(Register dest, const Operand &src) {
+  void lea(Register dest, const Operand& src) {
     emit1(0x8d, dest.code, src);
   }
 
@@ -408,7 +408,7 @@ class Assembler : public AssemblerBase
   void shll(Register dest, uint8_t imm) {
     shift_imm(dest.code, 4, imm);
   }
-  void shll(const Operand &dest, uint8_t imm) {
+  void shll(const Operand& dest, uint8_t imm) {
     shift_imm(dest, 4, imm);
   }
   void shrl_cl(Register dest) {
@@ -417,7 +417,7 @@ class Assembler : public AssemblerBase
   void shrl(Register dest, uint8_t imm) {
     shift_imm(dest.code, 5, imm);
   }
-  void shrl(const Operand &dest, uint8_t imm) {
+  void shrl(const Operand& dest, uint8_t imm) {
     shift_imm(dest, 5, imm);
   }
   void sarl_cl(Register dest) {
@@ -426,7 +426,7 @@ class Assembler : public AssemblerBase
   void sarl(Register dest, uint8_t imm) {
     shift_imm(dest.code, 7, imm);
   }
-  void sarl(const Operand &dest, uint8_t imm) {
+  void sarl(const Operand& dest, uint8_t imm) {
     shift_imm(dest, 7, imm);
   }
   void shrd(Register dest, Register src, uint8_t imm) {
@@ -441,86 +441,86 @@ class Assembler : public AssemblerBase
   void cmpb(Register left, int8_t imm8) {
     alu_imm8(7, imm8, Operand(left));
   }
-  void cmpb(const Operand &left, int8_t imm8) {
+  void cmpb(const Operand& left, int8_t imm8) {
     alu_imm8(7, imm8, left);
   }
   void cmpl(Register left, int32_t imm) {
     alu_imm(7, imm, Operand(left));
   }
-  void cmpl(const Operand &left, int32_t imm) {
+  void cmpl(const Operand& left, int32_t imm) {
     alu_imm(7, imm, left);
   }
   void cmpl(Register left, Register right) {
     emit1(0x39, right.code, left.code);
   }
-  void cmpl(const Operand &left, Register right) {
+  void cmpl(const Operand& left, Register right) {
     emit1(0x39, right.code, left);
   }
-  void cmpl(Register left, const Operand &right) {
+  void cmpl(Register left, const Operand& right) {
     emit1(0x3b, left.code, right);
   }
   void andl(Register dest, int32_t imm) {
     alu_imm(4, imm, Operand(dest));
   }
-  void andl(const Operand &dest, int32_t imm) {
+  void andl(const Operand& dest, int32_t imm) {
     alu_imm(4, imm, dest);
   }
   void andl(Register dest, Register src) {
     emit1(0x21, src.code, dest.code);
   }
-  void andl(const Operand &dest, Register src) {
+  void andl(const Operand& dest, Register src) {
     emit1(0x21, src.code, dest);
   }
-  void andl(Register dest, const Operand &src) {
+  void andl(Register dest, const Operand& src) {
     emit1(0x23, dest.code, src);
   }
   void orl(Register dest, Register src) {
     emit1(0x09, src.code, dest.code);
   }
-  void orl(const Operand &dest, Register src) {
+  void orl(const Operand& dest, Register src) {
     emit1(0x09, src.code, dest);
   }
-  void orl(Register dest, const Operand &src) {
+  void orl(Register dest, const Operand& src) {
     emit1(0x0b, dest.code, src);
   }
   void xorl(Register dest, Register src) {
     emit1(0x31, src.code, dest.code);
   }
-  void xorl(const Operand &dest, Register src) {
+  void xorl(const Operand& dest, Register src) {
     emit1(0x31, src.code, dest);
   }
-  void xorl(Register dest, const Operand &src) {
+  void xorl(Register dest, const Operand& src) {
     emit1(0x33, dest.code, src);
   }
 
   void subl(Register dest, Register src) {
     emit1(0x29, src.code, dest.code);
   }
-  void subl(const Operand &dest, Register src) {
+  void subl(const Operand& dest, Register src) {
     emit1(0x29, src.code, dest);
   }
-  void subl(Register dest, const Operand &src) {
+  void subl(Register dest, const Operand& src) {
     emit1(0x2b, dest.code, src);
   }
   void subl(Register dest, int32_t imm) {
     alu_imm(5, imm, Operand(dest));
   }
-  void subl(const Operand &dest, int32_t imm) {
+  void subl(const Operand& dest, int32_t imm) {
     alu_imm(5, imm, dest);
   }
   void addl(Register dest, Register src) {
     emit1(0x01, src.code, dest.code);
   }
-  void addl(const Operand &dest, Register src) {
+  void addl(const Operand& dest, Register src) {
     emit1(0x01, src.code, dest);
   }
-  void addl(Register dest, const Operand &src) {
+  void addl(Register dest, const Operand& src) {
     emit1(0x03, dest.code, src);
   }
   void addl(Register dest, int32_t imm) {
     alu_imm(0, imm, Operand(dest));
   }
-  void addl(const Operand &dest, int32_t imm) {
+  void addl(const Operand& dest, int32_t imm) {
     alu_imm(0, imm, dest);
   }
   void adcl(Register dest, int32_t imm) {
@@ -530,13 +530,13 @@ class Assembler : public AssemblerBase
     alu_imm(2, imm, dest);
   }
 
-  void imull(Register dest, const Operand &src) {
+  void imull(Register dest, const Operand& src) {
     emit2(0x0f, 0xaf, dest.code, src);
   }
   void imull(Register dest, Register src) {
     emit2(0x0f, 0xaf, dest.code, src.code);
   }
-  void imull(Register dest, const Operand &src, int32_t imm) {
+  void imull(Register dest, const Operand& src, int32_t imm) {
     if (imm >= SCHAR_MIN && imm <= SCHAR_MAX) {
       emit1(0x6b, dest.code, src);
       *pos_++ = imm;
@@ -549,7 +549,7 @@ class Assembler : public AssemblerBase
     imull(dest, Operand(src), imm);
   }
 
-  void testl(const Operand &op1, Register op2) {
+  void testl(const Operand& op1, Register op2) {
     emit1(0x85, op2.code, op1);
   }
   void testl(Register op1, Register op2) {
@@ -562,7 +562,7 @@ class Assembler : public AssemblerBase
       emit1(0xf7, 0, op1.code);
     writeInt32(imm);
   }
-  void set(ConditionCode cc, const Operand &dest) {
+  void set(ConditionCode cc, const Operand& dest) {
     emit2(0x0f, 0x90 + uint8_t(cc), 0, dest);
   }
   void set(ConditionCode cc, Register dest) {
@@ -571,19 +571,19 @@ class Assembler : public AssemblerBase
   void negl(Register srcdest) {
     emit1(0xf7, 3, srcdest.code);
   }
-  void negl(const Operand &srcdest) {
+  void negl(const Operand& srcdest) {
     emit1(0xf7, 3, srcdest);
   }
   void notl(Register srcdest) {
     emit1(0xf7, 2, srcdest.code);
   }
-  void notl(const Operand &srcdest) {
+  void notl(const Operand& srcdest) {
     emit1(0xf7, 2, srcdest);
   }
   void idivl(Register dividend) {
     emit1(0xf7, 7, dividend.code);
   }
-  void idivl(const Operand &dividend) {
+  void idivl(const Operand& dividend) {
     emit1(0xf7, 7, dividend);
   }
 
@@ -600,7 +600,7 @@ class Assembler : public AssemblerBase
   void push(Register reg) {
     emit1(0x50 + reg.code);
   }
-  void push(const Operand &src) {
+  void push(const Operand& src) {
     if (src.isRegister())
       emit1(0x50 + src.registerCode());
     else
@@ -610,7 +610,7 @@ class Assembler : public AssemblerBase
     emit1(0x68);
     writeInt32(imm);
   }
-  void push(CodeLabel *src) {
+  void push(CodeLabel* src) {
     emit1(0x68);
     if (src->bound()) {
       writeInt32(int32_t(src->offset()) - (position() + 4));
@@ -624,7 +624,7 @@ class Assembler : public AssemblerBase
   void pop(Register reg) {
     emit1(0x58 + reg.code);
   }
-  void pop(const Operand &src) {
+  void pop(const Operand& src) {
     if (src.isRegister())
       emit1(0x58 + src.registerCode());
     else
@@ -648,49 +648,49 @@ class Assembler : public AssemblerBase
     emit1(0xc9);
   }
 
-  void fld32(const Operand &src) {
+  void fld32(const Operand& src) {
     emit1(0xd9, 0, src);
   }
-  void fild32(const Operand &src) {
+  void fild32(const Operand& src) {
     emit1(0xdb, 0, src);
   }
-  void fistp32(const Operand &dest) {
+  void fistp32(const Operand& dest) {
     emit1(0xdb, 3, dest);
   }
-  void fistp64(const Operand &dest) {
+  void fistp64(const Operand& dest) {
     emit1(0xdf, 7, dest);
   }
-  void fadd32(const Operand &src) {
+  void fadd32(const Operand& src) {
     emit1(0xd8, 0, src);
   }
-  void fsub32(const Operand &src) {
+  void fsub32(const Operand& src) {
     emit1(0xd8, 4, src);
   }
-  void fmul32(const Operand &src) {
+  void fmul32(const Operand& src) {
     emit1(0xd8, 1, src);
   }
-  void fdiv32(const Operand &src) {
+  void fdiv32(const Operand& src) {
     emit1(0xd8, 6, src);
   }
-  void fst32(const Operand &dest) {
+  void fst32(const Operand& dest) {
     emit1(0xd9, 2, dest);
   }
   void fst(FpuRegister src) {
     emit2(0xd9, 0xd0 + src.code);
   }
-  void fstp32(const Operand &dest) {
+  void fstp32(const Operand& dest) {
     emit1(0xd9, 3, dest);
   }
   void fstp(FpuRegister src) {
     emit2(0xdd, 0xd8 + src.code);
   }
-  void fldcw(const Operand &src) {
+  void fldcw(const Operand& src) {
     emit1(0xd9, 5, src);
   }
-  void fstcw(const Operand &dest) {
+  void fstcw(const Operand& dest) {
     emit2(0x9b, 0xd9, 7, dest);
   }
-  void fsubr32(const Operand &src) {
+  void fsubr32(const Operand& src) {
     emit1(0xd8, 5, src);
   }
   void fldz() {
@@ -711,11 +711,11 @@ class Assembler : public AssemblerBase
       emit2(0xdc, 0xc0 + src.code);
   }
 
-  void jmp32(Label *dest) {
+  void jmp32(Label* dest) {
     emit1(0xe9);
     emitJumpTarget(dest);
   }
-  void jmp(Label *dest) {
+  void jmp(Label* dest) {
     int8_t d8;
     if (canEmitSmallJump(dest, &d8)) {
       emit2(0xeb, d8);
@@ -727,14 +727,14 @@ class Assembler : public AssemblerBase
   void jmp(Register target) {
     emit1(0xff, 4, target.code);
   }
-  void jmp(const Operand &target) {
+  void jmp(const Operand& target) {
     emit1(0xff, 4, target);
   }
-  void j32(ConditionCode cc, Label *dest) {
+  void j32(ConditionCode cc, Label* dest) {
     emit2(0x0f, 0x80 + uint8_t(cc));
     emitJumpTarget(dest);
   }
-  void j(ConditionCode cc, Label *dest) {
+  void j(ConditionCode cc, Label* dest) {
     int8_t d8;
     if (canEmitSmallJump(dest, &d8)) {
       emit2(0x70 + uint8_t(cc), d8);
@@ -743,11 +743,11 @@ class Assembler : public AssemblerBase
       emitJumpTarget(dest);
     }
   }
-  void call(Label *dest) {
+  void call(Label* dest) {
     emit1(0xe8);
     emitJumpTarget(dest);
   }
-  void bind(Label *target) {
+  void bind(Label* target) {
     if (outOfMemory()) {
       // If we ran out of memory, the code stream is potentially invalid and
       // we cannot use the embedded linked list.
@@ -766,23 +766,23 @@ class Assembler : public AssemblerBase
       ptrdiff_t delta = pos_ - (buffer() + offset);
       assert(delta >= INT_MIN && delta <= INT_MAX);
 
-      int32_t *p = reinterpret_cast<int32_t *>(buffer() + offset - 4);
+      int32_t* p = reinterpret_cast<int32_t*>(buffer() + offset - 4);
       status = *p;
       *p = delta;
     }
     target->bind(pc());
   }
 
-  void bind(CodeLabel *address) {
+  void bind(CodeLabel* address) {
     if (outOfMemory())
       return;
     if (address->used()) {
       uint32_t offset = CodeLabel::ToOffset(address->status());
-      *reinterpret_cast<int32_t *>(buffer() + offset - 4) = position() - int32_t(offset);
+      *reinterpret_cast<int32_t*>(buffer() + offset - 4) = position() - int32_t(offset);
     }
     address->bind(pc());
   }
-  void movl(Register dest, CodeLabel *src) {
+  void movl(Register dest, CodeLabel* src) {
     emit1(0xb8 + dest.code);
     if (src->bound()) {
       writeInt32(int32_t(src->offset()) - (position() + 4));
@@ -793,7 +793,7 @@ class Assembler : public AssemblerBase
     if (!local_refs_.append(pc()))
       outOfMemory_ = true;
   }
-  void emit_absolute_address(Label *address) {
+  void emit_absolute_address(Label* address) {
     if (address->bound())
       writeUint32(int32_t(address->offset()) - (position() + 4));
     else
@@ -805,7 +805,7 @@ class Assembler : public AssemblerBase
   void call(Register target) {
     emit1(0xff, 2, target.code);
   }
-  void call(const Operand &target) {
+  void call(const Operand& target) {
     emit1(0xff, 2, target);
   }
   void call(const AddressValue& address) {
@@ -829,7 +829,7 @@ class Assembler : public AssemblerBase
 
   // SSE operations can only be used if the feature detection function has
   // been run *and* detected the appropriate level of functionality.
-  void movss(FloatRegister dest, const Operand &src) {
+  void movss(FloatRegister dest, const Operand& src) {
     assert(Features().sse);
     emit3(0xf3, 0x0f, 0x10, dest.code, src);
   }
@@ -837,7 +837,7 @@ class Assembler : public AssemblerBase
     assert(Features().sse);
     emit3(0xf3, 0x0f, 0x2c, dest.code, src.code);
   }
-  void cvttss2si(Register dest, const Operand &src) {
+  void cvttss2si(Register dest, const Operand& src) {
     assert(Features().sse);
     emit3(0xf3, 0x0f, 0x2c, dest.code, src);
   }
@@ -845,7 +845,7 @@ class Assembler : public AssemblerBase
     assert(Features().sse);
     emit3(0xf3, 0x0f, 0x2d, dest.code, src.code);
   }
-  void cvtss2si(Register dest, const Operand &src) {
+  void cvtss2si(Register dest, const Operand& src) {
     assert(Features().sse);
     emit3(0xf3, 0x0f, 0x2d, dest.code, src);
   }
@@ -853,23 +853,23 @@ class Assembler : public AssemblerBase
     assert(Features().sse);
     emit3(0xf3, 0x0f, 0x2a, dest.code, src.code);
   }
-  void cvtsi2ss(FloatRegister dest, const Operand &src) {
+  void cvtsi2ss(FloatRegister dest, const Operand& src) {
     assert(Features().sse);
     emit3(0xf3, 0x0f, 0x2a, dest.code, src);
   }
-  void addss(FloatRegister dest, const Operand &src) {
+  void addss(FloatRegister dest, const Operand& src) {
     assert(Features().sse);
     emit3(0xf3, 0x0f, 0x58, dest.code, src);
   }
-  void subss(FloatRegister dest, const Operand &src) {
+  void subss(FloatRegister dest, const Operand& src) {
     assert(Features().sse);
     emit3(0xf3, 0x0f, 0x5c, dest.code, src);
   }
-  void mulss(FloatRegister dest, const Operand &src) {
+  void mulss(FloatRegister dest, const Operand& src) {
     assert(Features().sse);
     emit3(0xf3, 0x0f, 0x59, dest.code, src);
   }
-  void divss(FloatRegister dest, const Operand &src) {
+  void divss(FloatRegister dest, const Operand& src) {
     assert(Features().sse);
     emit3(0xf3, 0x0f, 0x5e, dest.code, src);
   }
@@ -881,7 +881,7 @@ class Assembler : public AssemblerBase
   void ucomiss(FloatRegister left, FloatRegister right) {
     emit2(0x0f, 0x2e, right.code, left.code);
   }
-  void ucomiss(const Operand &left, FloatRegister right) {
+  void ucomiss(const Operand& left, FloatRegister right) {
     emit2(0x0f, 0x2e, right.code, left);
   }
 
@@ -890,25 +890,25 @@ class Assembler : public AssemblerBase
     assert(Features().sse2);
     emit3(0x66, 0x0f, 0x7e, dest.code, src.code);
   }
-  void movd(Register dest, const Operand &src) {
+  void movd(Register dest, const Operand& src) {
     assert(Features().sse2);
     emit3(0x66, 0x0f, 0x7e, dest.code, src);
   }
 
-  static void PatchRel32Absolute(uint8_t *ip, void *ptr) {
+  static void PatchRel32Absolute(uint8_t* ip, void* ptr) {
     int32_t delta = uint32_t(ptr) - uint32_t(ip);
-    *reinterpret_cast<int32_t *>(ip - 4) = delta;
+    *reinterpret_cast<int32_t*>(ip - 4) = delta;
   }
 
-  void emitToExecutableMemory(void *code) {
+  void emitToExecutableMemory(void* code) {
     assert(!outOfMemory());
 
     // Relocate anything we emitted as rel32 with an external pointer.
-    uint8_t *base = reinterpret_cast<uint8_t *>(code);
+    uint8_t* base = reinterpret_cast<uint8_t*>(code);
     memcpy(base, buffer(), length());
     for (size_t i = 0; i < external_refs_.length(); i++) {
       size_t offset = external_refs_[i];
-      PatchRel32Absolute(base + offset, *reinterpret_cast<void **>(base + offset - 4));
+      PatchRel32Absolute(base + offset, *reinterpret_cast<void**>(base + offset - 4));
     }
 
     // Relocate everything we emitted as an abs32 with an internal offset. Note
@@ -916,8 +916,8 @@ class Assembler : public AssemblerBase
     // and CodeLabel.
     for (size_t i = 0; i < local_refs_.length(); i++) {
       size_t offset = local_refs_[i];
-      int32_t delta = *reinterpret_cast<int32_t *>(base + offset - 4);
-      *reinterpret_cast<void **>(base + offset - 4) = base + offset + delta;
+      int32_t delta = *reinterpret_cast<int32_t*>(base + offset - 4);
+      *reinterpret_cast<void**>(base + offset - 4) = base + offset + delta;
     }
   }
 
@@ -965,8 +965,8 @@ class Assembler : public AssemblerBase
     masm.ret();
   }
 
-  static void RunFeatureDetection(void *code) {
-    typedef void (*fn_t)(int *reg_ecx, int *reg_edx, int *reg_ebx);
+  static void RunFeatureDetection(void* code) {
+    typedef void (*fn_t)(int* reg_ecx, int* reg_edx, int* reg_ebx);
 
     int reg_ecx, reg_edx, reg_ebx;
     ((fn_t)code)(&reg_ecx, &reg_edx, &reg_ebx);
@@ -986,7 +986,7 @@ class Assembler : public AssemblerBase
   }
 
  private:
-  bool canEmitSmallJump(Label *dest, int8_t *deltap) {
+  bool canEmitSmallJump(Label* dest, int8_t* deltap) {
     if (!dest->bound())
       return false;
 
@@ -997,7 +997,7 @@ class Assembler : public AssemblerBase
     *deltap = delta;
     return true;
   }
-  void emitJumpTarget(Label *dest) {
+  void emitJumpTarget(Label* dest) {
     if (dest->bound()) {
       ptrdiff_t delta = ptrdiff_t(dest->offset()) - (position() + 4);
       assert(delta >= INT_MIN && delta <= INT_MAX);
@@ -1007,7 +1007,7 @@ class Assembler : public AssemblerBase
     }
   }
 
-  void emit(uint8_t reg, const Operand &operand) {
+  void emit(uint8_t reg, const Operand& operand) {
     *pos_++ = operand.getByte(0) | (reg << 3);
     size_t length = operand.length();
     for (size_t i = 1; i < length; i++)
@@ -1025,7 +1025,7 @@ class Assembler : public AssemblerBase
     *pos_++ = opcode;
     *pos_++ = (kModeReg << 6) | (reg << 3) | opreg;
   }
-  void emit1(uint8_t opcode, uint8_t reg, const Operand &operand) {
+  void emit1(uint8_t opcode, uint8_t reg, const Operand& operand) {
     ensureSpace();
     assert(reg <= 7);
     *pos_++ = opcode;
@@ -1042,7 +1042,7 @@ class Assembler : public AssemblerBase
     assert(reg <= 7);
     *pos_++ = (kModeReg << 6) | (reg << 3) | opreg;
   }
-  void emit2(uint8_t prefix, uint8_t opcode, uint8_t reg, const Operand &operand) {
+  void emit2(uint8_t prefix, uint8_t opcode, uint8_t reg, const Operand& operand) {
     emit2(prefix, opcode);
     emit(reg, operand);
   }
@@ -1058,18 +1058,18 @@ class Assembler : public AssemblerBase
     assert(reg <= 7);
     *pos_++ = (kModeReg << 6) | (reg << 3) | opreg;
   }
-  void emit3(uint8_t prefix1, uint8_t prefix2, uint8_t opcode, uint8_t reg, const Operand &operand) {
+  void emit3(uint8_t prefix1, uint8_t prefix2, uint8_t opcode, uint8_t reg, const Operand& operand) {
     emit3(prefix1, prefix2, opcode);
     emit(reg, operand);
   }
 
   template <typename T>
-  void shift_cl(const T &t, uint8_t r) {
+  void shift_cl(const T& t, uint8_t r) {
     emit1(0xd3, r, t);
   }
 
   template <typename T>
-  void shift_imm(const T &t, uint8_t r, int32_t imm) {
+  void shift_imm(const T& t, uint8_t r, int32_t imm) {
     if (imm == 1) {
       emit1(0xd1, r, t);
     } else {
@@ -1077,7 +1077,7 @@ class Assembler : public AssemblerBase
       *pos_++ = imm & 0x1F;
     }
   }
-  void alu_imm(uint8_t r, int32_t imm, const Operand &operand) {
+  void alu_imm(uint8_t r, int32_t imm, const Operand& operand) {
     if (imm >= SCHAR_MIN && imm <= SCHAR_MAX) {
       emit1(0x83, r, operand);
       *pos_++ = uint8_t(imm & 0xff);

--- a/vm/x86/code-stubs-x86.cpp
+++ b/vm/x86/code-stubs-x86.cpp
@@ -101,12 +101,12 @@ CodeStubs::CompileInvokeStub()
   if (!invoke_stub_.address())
     return false;
 
-  return_stub_ = reinterpret_cast<uint8_t *>(invoke_stub_.address()) + error.offset();
+  return_stub_ = reinterpret_cast<uint8_t*>(invoke_stub_.address()) + error.offset();
   return true;
 }
 
 SPVM_NATIVE_FUNC
-CodeStubs::CreateFakeNativeStub(SPVM_FAKENATIVE_FUNC callback, void *pData)
+CodeStubs::CreateFakeNativeStub(SPVM_FAKENATIVE_FUNC callback, void* pData)
 {
   Assembler masm;
 
@@ -122,7 +122,7 @@ CodeStubs::CreateFakeNativeStub(SPVM_FAKENATIVE_FUNC callback, void *pData)
   __ push(intptr_t(pData));
   __ push(esi);
   __ push(edi);
-  __ call(ExternalAddress((void *)callback));
+  __ call(ExternalAddress((void*)callback));
   __ movl(esp, ebx);
   __ pop(esi);
   __ pop(edi);

--- a/vm/x86/frames-x86.h
+++ b/vm/x86/frames-x86.h
@@ -46,7 +46,7 @@ struct FrameLayout
   // This is -offsetof(FrameLayout, prev_ebp).
   static const intptr_t kOffsetFromFp = -2;
 
-  static inline FrameLayout* FromFp(intptr_t *fp) {
+  static inline FrameLayout* FromFp(intptr_t* fp) {
     return reinterpret_cast<FrameLayout*>(fp + kOffsetFromFp);
   }
 };

--- a/vm/x86/jit_x86.cpp
+++ b/vm/x86/jit_x86.cpp
@@ -70,7 +70,7 @@ OpToCondition(CompareOp op)
   }
 }
 
-Compiler::Compiler(PluginRuntime *rt, cell_t pcode_offs)
+Compiler::Compiler(PluginRuntime* rt, cell_t pcode_offs)
  : CompilerBase(rt, pcode_offs)
 {
 }
@@ -81,28 +81,28 @@ Compiler::~Compiler()
 
 // No exit frame - error code is returned directly.
 static int
-InvokePushTracker(PluginContext *cx, uint32_t amount)
+InvokePushTracker(PluginContext* cx, uint32_t amount)
 {
   return cx->pushTracker(amount);
 }
 
 // No exit frame - error code is returned directly.
 static int
-InvokePopTrackerAndSetHeap(PluginContext *cx)
+InvokePopTrackerAndSetHeap(PluginContext* cx)
 {
   return cx->popTrackerAndSetHeap();
 }
 
 // No exit frame - error code is returned directly.
 static int
-InvokeGenerateFullArray(PluginContext *cx, uint32_t argc, cell_t *argv, int autozero)
+InvokeGenerateFullArray(PluginContext* cx, uint32_t argc, cell_t* argv, int autozero)
 {
   return cx->generateFullArray(argc, argv, autozero);
 }
 
 // No exit frame - error code is returned directly.
 static int
-InvokeRebaseArray(PluginContext *cx,
+InvokeRebaseArray(PluginContext* cx,
                   cell_t base_addr,
                   cell_t dat_addr,
                   cell_t iv_size,
@@ -1001,7 +1001,7 @@ Compiler::visitHEAP(cell_t amount)
 bool
 Compiler::visitJUMP(cell_t offset)
 {
-  Label *target = labelAt(offset);
+  Label* target = labelAt(offset);
   if (target->bound()) {
     __ jmp32(target);
     backward_jumps_.append(BackwardJump(masm.pc(), op_cip_));
@@ -1014,7 +1014,7 @@ Compiler::visitJUMP(cell_t offset)
 bool
 Compiler::visitJcmp(CompareOp op, cell_t offset)
 {
-  Label *target = labelAt(offset);
+  Label* target = labelAt(offset);
 
   switch (op) {
   case CompareOp::Zero:
@@ -1064,7 +1064,7 @@ Compiler::visitTRACKER_PUSH_C(cell_t amount)
 
   __ push(amount);
   __ push(intptr_t(rt_->GetBaseContext()));
-  __ callWithABI(ExternalAddress((void *)InvokePushTracker));
+  __ callWithABI(ExternalAddress((void*)InvokePushTracker));
   __ addl(esp, 8);
   __ testl(eax, eax);
   jumpOnError(not_zero);
@@ -1084,7 +1084,7 @@ Compiler::visitTRACKER_POP_SETHEAP()
 
   // Get the context pointer and call the sanity checker.
   __ push(intptr_t(rt_->GetBaseContext()));
-  __ callWithABI(ExternalAddress((void *)InvokePopTrackerAndSetHeap));
+  __ callWithABI(ExternalAddress((void*)InvokePopTrackerAndSetHeap));
   __ addl(esp, 4);
   __ testl(eax, eax);
   jumpOnError(not_zero);
@@ -1109,7 +1109,7 @@ Compiler::visitREBASE(cell_t addr, cell_t iv_size, cell_t data_size)
   __ push(addr);
   __ push(pri);
   __ push(intptr_t(rt_->GetBaseContext()));
-  __ callWithABI(ExternalAddress((void *)InvokeRebaseArray));
+  __ callWithABI(ExternalAddress((void*)InvokeRebaseArray));
   __ addl(esp, 8 * sizeof(intptr_t));
   __ testl(eax, eax);
   jumpOnError(not_zero);
@@ -1176,7 +1176,7 @@ Compiler::visitGENARRAY(uint32_t dims, bool autozero)
     __ subl(esp, 8);
     __ push(tmp);
     __ push(intptr_t(rt_->GetBaseContext()));
-    __ callWithABI(ExternalAddress((void *)InvokePushTracker));
+    __ callWithABI(ExternalAddress((void*)InvokePushTracker));
     __ movl(tmp, Operand(esp, 4));
     __ addl(esp, 16);
     __ shrl(tmp, 2);
@@ -1199,13 +1199,13 @@ Compiler::visitGENARRAY(uint32_t dims, bool autozero)
     __ push(pri);
     __ subl(esp, 12);
 
-    // int GenerateArray(cx, vars[], uint32_t, cell_t *, int, unsigned *);
+    // int GenerateArray(cx, vars[], uint32_t, cell_t*, int, unsigned*);
     __ push(autozero ? 1 : 0);
     __ push(stk);
     __ push(dims);
     __ push(intptr_t(context_));
-    __ callWithABI(ExternalAddress((void *)InvokeGenerateFullArray));
-    __ addl(esp, 4 * sizeof(void *) + 12);
+    __ callWithABI(ExternalAddress((void*)InvokeGenerateFullArray));
+    __ addl(esp, 4 * sizeof(void*) + 12);
 
     // restore pri to tmp
     __ pop(tmp);
@@ -1271,19 +1271,19 @@ Compiler::emitCallThunk(CallThunk* thunk)
   // on the stack. Allocate a big block so we're aligned.
   //
   // Note: we add 12 since the push above misaligned the stack.
-  static const size_t kStackNeeded = 5 * sizeof(void *);
+  static const size_t kStackNeeded = 5 * sizeof(void*);
   static const size_t kStackReserve = ke::Align(kStackNeeded, 16);
   __ subl(esp, kStackReserve);
 
   // Set arguments.
-  __ movl(Operand(esp, 3 * sizeof(void *)), eax);
-  __ lea(edx, Operand(esp, 4 * sizeof(void *)));
-  __ movl(Operand(esp, 2 * sizeof(void *)), edx);
-  __ movl(Operand(esp, 1 * sizeof(void *)), intptr_t(thunk->pcode_offset));
-  __ movl(Operand(esp, 0 * sizeof(void *)), intptr_t(context_));
+  __ movl(Operand(esp, 3 * sizeof(void*)), eax);
+  __ lea(edx, Operand(esp, 4 * sizeof(void*)));
+  __ movl(Operand(esp, 2 * sizeof(void*)), edx);
+  __ movl(Operand(esp, 1 * sizeof(void*)), intptr_t(thunk->pcode_offset));
+  __ movl(Operand(esp, 0 * sizeof(void*)), intptr_t(context_));
 
-  __ callWithABI(ExternalAddress((void *)CompileFromThunk));
-  __ movl(edx, Operand(esp, 4 * sizeof(void *)));
+  __ callWithABI(ExternalAddress((void*)CompileFromThunk));
+  __ movl(edx, Operand(esp, 4 * sizeof(void*)));
   __ leaveExitFrame();
 
   __ testl(eax, eax);
@@ -1352,7 +1352,7 @@ Compiler::emitLegacyNativeCall(uint32_t native_index, NativeEntry* native)
 
   // Invoke the native.
   if (immutable)
-    __ callWithABI(ExternalAddress((void *)native->legacy_fn));
+    __ callWithABI(ExternalAddress((void*)native->legacy_fn));
   else
     __ callWithABI(edx);
   __ bind(&return_address);
@@ -1384,7 +1384,7 @@ Compiler::visitSWITCH(cell_t defaultOffset,
                       const CaseTableEntry* cases,
                       size_t ncases)
 {
-  Label *defaultCase = labelAt(defaultOffset);
+  Label* defaultCase = labelAt(defaultOffset);
 
   // Degenerate - 0 cases.
   if (!ncases) {
@@ -1394,7 +1394,7 @@ Compiler::visitSWITCH(cell_t defaultOffset,
 
   // Degenerate - 1 case.
   if (ncases == 1) {
-    Label *maybe = labelAt(cases[0].address);
+    Label* maybe = labelAt(cases[0].address);
     __ cmpl(pri, cases[0].value);
     __ j(equal, maybe);
     __ jmp(defaultCase);
@@ -1444,13 +1444,13 @@ Compiler::visitSWITCH(cell_t defaultOffset,
 
     __ bind(&table);
     for (size_t i = 0; i < ncases; i++) {
-      Label *label = labelAt(cases[i].address);
+      Label* label = labelAt(cases[i].address);
       __ emit_absolute_address(label);
     }
   } else {
     // Slower version. Go through each case and generate a check.
     for (size_t i = 0; i < ncases; i++) {
-      Label *label = labelAt(cases[i].address);
+      Label* label = labelAt(cases[i].address);
       __ cmpl(pri, cases[i].value);
       __ j(equal, label);
     }
@@ -1529,7 +1529,7 @@ Compiler::emitOutOfBoundsErrorPath(OutOfBoundsErrorPath* path)
   __ subl(esp, 8);
   __ push(path->bounds);
   __ push(eax);
-  __ callWithABI(ExternalAddress((void *)ReportOutOfBoundsError));
+  __ callWithABI(ExternalAddress((void*)ReportOutOfBoundsError));
   __ bind(&return_address);
   emitCipMapping(path->cip);
   __ leaveInlineExitFrame();
@@ -1551,7 +1551,7 @@ Compiler::emitErrorHandlers()
     // Align the stack and call.
     __ subl(esp, 12);
     __ push(eax);
-    __ callWithABI(ExternalAddress((void *)InvokeReportError));
+    __ callWithABI(ExternalAddress((void*)InvokeReportError));
     __ leaveExitFrame();
     __ jmp(&return_to_invoke);
   }
@@ -1565,7 +1565,7 @@ Compiler::emitErrorHandlers()
 
     // Since the return stub wipes out the stack, we don't need to addl after
     // the call.
-    __ callWithABI(ExternalAddress((void *)InvokeReportTimeout));
+    __ callWithABI(ExternalAddress((void*)InvokeReportTimeout));
     __ leaveExitFrame();
     __ jmp(&return_reported_error_);
   }
@@ -1586,7 +1586,7 @@ Compiler::emitErrorHandlers()
     // We cannot jump to the return stub just yet. We could be multiple frames
     // deep, and our |ebp| does not match the initial frame. Find and restore
     // it now.
-    __ callWithABI(ExternalAddress((void *)find_entry_fp));
+    __ callWithABI(ExternalAddress((void*)find_entry_fp));
     __ leaveExitFrame();
 
     __ movl(ebp, eax);
@@ -1604,7 +1604,7 @@ Compiler::emitThrowPath(int err)
 void
 CompilerBase::PatchCallThunk(uint8_t* pc, void* target)
 {
-  *(intptr_t *)(pc - 4) = intptr_t(target) - intptr_t(pc);
+  *(intptr_t*)(pc - 4) = intptr_t(target) - intptr_t(pc);
 }
 
 } // namespace sp

--- a/vm/x86/jit_x86.h
+++ b/vm/x86/jit_x86.h
@@ -41,7 +41,7 @@ class Compiler : public CompilerBase
   friend class OutOfBoundsErrorPath;
 
  public:
-  Compiler(PluginRuntime *rt, cell_t pcode_offs);
+  Compiler(PluginRuntime* rt, cell_t pcode_offs);
   ~Compiler();
 
   bool visitLOAD(PawnReg dest, cell_t srcaddr) override;
@@ -162,7 +162,7 @@ class Compiler : public CompilerBase
     return ExternalAddress(context_->addressOfSp());
   }
 
-  Label *labelAt(size_t offset) {
+  Label* labelAt(size_t offset) {
     assert(ke::IsAligned(offset, sizeof(cell_t)));
     assert(offset >= pcode_start_);
     assert(offset < rt_->code().length); 


### PR DESCRIPTION
This is the preferred style in SourcePawn these days. Unfortunately our style for pointers/references is wildly inconsistent and it bugs me. I'd like to bite the bullet this one time and fix it.

The script to do this transformation was cribbed from https://bugzilla.mozilla.org/show_bug.cgi?id=1144366.