### PR TITLE
Don't iterate archs in buildscripts.

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -18,6 +18,7 @@
 #
 import os
 import sys
+import copy
 
 def Normalize(path):
   return os.path.abspath(os.path.normpath(path))
@@ -256,31 +257,35 @@ class SourcePawn(object):
     self.spcomp_scripts = [
       os.path.join('compiler', 'AMBuilder'),
     ]
-    self.vm_scripts = [
-      os.path.join('vm', 'AMBuilder'),
-    ]
     self.test_scripts = [
       os.path.join('tools', 'testing', 'Testing.ambuild'),
-    ]
-    self.exp_scripts = [
-      os.path.join('exp', 'compiler', 'AMBuilder'),
-      os.path.join('exp', 'tools', 'docparse', 'AMBuilder'),
     ]
     self.vars = {
       'Root': self.root,
       'SP': self,
     }
+    self.spshell = {}
+    self.spcomp = {}
+    self.libspcomp2 = {}
 
   def BuildSpcomp(self):
     self.EnsureZlib()
-    builder.Build(self.spcomp_scripts, self.vars)
+    for arch in self.root.archs:
+      spcomp = self.BuildForArch('compiler/AMBuilder', arch)
+      self.spcomp[arch] = spcomp
 
   def BuildVM(self):
     self.EnsureZlib()
-    builder.Build(self.vm_scripts, self.vars)
+    for arch in self.root.archs:
+      spshell = self.BuildForArch('vm/AMBuilder', arch)
+      self.spshell[arch] = spshell
 
   def BuildExperimental(self):
-    builder.Build(self.exp_scripts, self.vars)
+    for arch in self.root.archs:
+      libspcomp2 = self.BuildForArch('exp/compiler/AMBuilder', arch)
+      self.libspcomp2[arch] = libspcomp2
+
+      self.BuildForArch('exp/tools/docparse/AMBuilder', arch)
 
   def BuildTests(self):
     builder.Build(self.test_scripts, self.vars)
@@ -297,6 +302,11 @@ class SourcePawn(object):
     zlib_dir = os.path.join('third_party', 'zlib', 'AMBuilder')
     builder.Build([zlib_dir], self.vars)
     self.included_zlib = True
+
+  def BuildForArch(self, scripts, arch):
+    new_vars = copy.copy(self.vars)
+    new_vars['arch'] = arch
+    return builder.Build(scripts, new_vars)
 
 if builder.parent is None:
   root = Config()

--- a/compiler/AMBuilder
+++ b/compiler/AMBuilder
@@ -1,86 +1,84 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python: 
 import os
 
-SP.spcomp = {}
-for arch in Root.archs:
-  binary = Root.Program(builder, 'spcomp', arch)
-  compiler = binary.compiler
-  compiler.includes += [
-    os.path.join(SP.amtl, 'amtl'),
-    os.path.join(SP.amtl),
-    os.path.join(builder.currentSourcePath, '..', 'include'),
-    os.path.join(builder.currentSourcePath, '..', 'third_party'),
-    os.path.join(builder.buildPath, 'includes'),
-    os.path.join(builder.buildPath, builder.buildFolder),
+binary = Root.Program(builder, 'spcomp', arch)
+compiler = binary.compiler
+compiler.includes += [
+  os.path.join(SP.amtl, 'amtl'),
+  os.path.join(SP.amtl),
+  os.path.join(builder.currentSourcePath, '..', 'include'),
+  os.path.join(builder.currentSourcePath, '..', 'third_party'),
+  os.path.join(builder.buildPath, 'includes'),
+  os.path.join(builder.buildPath, builder.buildFolder),
+]
+
+if compiler.like('gcc'):
+  compiler.cflags += [
+    '-Wno-format',
   ]
-
-  if compiler.like('gcc'):
-    compiler.cflags += [
-      '-Wno-format',
-    ]
-    compiler.c_only_flags += ['-std=c99']
-    if builder.target.platform == 'linux':
-      compiler.postlink += ['-lm']
-    compiler.postlink += ['-lstdc++']
-  if compiler.family == 'clang':
-    compiler.cxxflags += [
-      '-Wno-implicit-exception-spec-mismatch',
-    ]
-  if compiler.family == 'gcc':
-    compiler.cflags += [
-      '-Wno-maybe-uninitialized',
-    ]
-    if compiler.version >= '4.6':
-      compiler.cxxflags += ['-Wno-unused-but-set-variable']
-
-  compiler.defines += ['HAVE_STDINT_H']
+  compiler.c_only_flags += ['-std=c99']
   if builder.target.platform == 'linux':
-    compiler.defines += [
-      'LINUX',
-      'AMX_ANSIONLY',
-      '_GNU_SOURCE'
-    ]
-  elif builder.target.platform == 'mac':
-    compiler.defines += [
-      'DARWIN',
-      'AMX_ANSIONLY',
-      'HAVE_SAFESTR'
-    ]
+    compiler.postlink += ['-lm']
+  compiler.postlink += ['-lstdc++']
+if compiler.family == 'clang':
+  compiler.cxxflags += [
+    '-Wno-implicit-exception-spec-mismatch',
+  ]
+if compiler.family == 'gcc':
+  compiler.cflags += [
+    '-Wno-maybe-uninitialized',
+  ]
+  if compiler.version >= '4.6':
+    compiler.cxxflags += ['-Wno-unused-but-set-variable']
 
-  if compiler.like('emscripten'):
-    compiler.defines += [
-      'HAVE_SAFESTR'
-    ]
-
-  binary.sources += [
-    'libpawnc.cpp',
-    'lstring.cpp',
-    'memfile.cpp',
-    'pawncc.cpp',
-    'sc1.cpp',
-    'sc2.cpp',
-    'sc3.cpp',
-    'sc4.cpp',
-    'sc5.cpp',
-    'sc6.cpp',
-    'sc7.cpp',
-    'sci18n.cpp',
-    'sclist.cpp',
-    'scmemfil.cpp',
-    'sctracker.cpp',
-    'scvars.cpp',
-    'smx-builder.cpp',
-    'sp_symhash.cpp',
-    'types.cpp',
-    'expression-parsing.cpp',
+compiler.defines += ['HAVE_STDINT_H']
+if builder.target.platform == 'linux':
+  compiler.defines += [
+    'LINUX',
+    'AMX_ANSIONLY',
+    '_GNU_SOURCE'
+  ]
+elif builder.target.platform == 'mac':
+  compiler.defines += [
+    'DARWIN',
+    'AMX_ANSIONLY',
+    'HAVE_SAFESTR'
   ]
 
-  if builder.target.platform == 'linux' and not compiler.like('emscripten'):
-    compiler.defines += ['ENABLE_BINRELOC']
-    binary.sources.append('binreloc.c')
-
-  binary.compiler.linkflags[0:0] = [
-    SP.zlib[arch],
+if compiler.like('emscripten'):
+  compiler.defines += [
+    'HAVE_SAFESTR'
   ]
 
-  SP.spcomp[arch] = builder.Add(binary)
+binary.sources += [
+  'libpawnc.cpp',
+  'lstring.cpp',
+  'memfile.cpp',
+  'pawncc.cpp',
+  'sc1.cpp',
+  'sc2.cpp',
+  'sc3.cpp',
+  'sc4.cpp',
+  'sc5.cpp',
+  'sc6.cpp',
+  'sc7.cpp',
+  'sci18n.cpp',
+  'sclist.cpp',
+  'scmemfil.cpp',
+  'sctracker.cpp',
+  'scvars.cpp',
+  'smx-builder.cpp',
+  'sp_symhash.cpp',
+  'types.cpp',
+  'expression-parsing.cpp',
+]
+
+if builder.target.platform == 'linux' and not compiler.like('emscripten'):
+  compiler.defines += ['ENABLE_BINRELOC']
+  binary.sources.append('binreloc.c')
+
+binary.compiler.linkflags[0:0] = [
+  SP.zlib[arch],
+]
+
+rvalue = builder.Add(binary)

--- a/exp/compiler/AMBuilder
+++ b/exp/compiler/AMBuilder
@@ -18,71 +18,69 @@
 #
 import os
 
-SP.libspcomp = {}
-for arch in Root.archs:
-  ### CLI
-  binary = Root.StaticLibrary(builder, 'spcomp', arch)
-  binary.compiler.cxxincludes += [
-    os.path.join(builder.sourcePath, 'include'),
-    os.path.join(builder.sourcePath, builder.sourceFolder),
+### CLI
+binary = Root.StaticLibrary(builder, 'spcomp', arch)
+binary.compiler.cxxincludes += [
+  os.path.join(builder.sourcePath, 'include'),
+  os.path.join(builder.sourcePath, builder.sourceFolder),
+]
+
+if binary.compiler.like('gcc'):
+  binary.compiler.cflags += [
+    '-Wno-error=switch',
+    '-Wno-invalid-offsetof',
+  ]
+  binary.compiler.cxxflags += ['-fno-rtti']
+if binary.compiler.like('clang'):
+  binary.compiler.cxxflags += [
+    '-Wno-implicit-exception-spec-mismatch',
+    '-Wno-error=unused-private-field',
+    '-Wno-unused-const-variable',
   ]
 
-  if binary.compiler.like('gcc'):
-    binary.compiler.cflags += [
-      '-Wno-error=switch',
-      '-Wno-invalid-offsetof',
-    ]
-    binary.compiler.cxxflags += ['-fno-rtti']
-  if binary.compiler.like('clang'):
-    binary.compiler.cxxflags += [
-      '-Wno-implicit-exception-spec-mismatch',
-      '-Wno-error=unused-private-field',
-      '-Wno-unused-const-variable',
-    ]
+binary.sources += [
+  'compile-context.cpp',
+  'constant-evaluator.cpp',
+  'dll_exports.cpp',
+  'float-value.cpp',
+  'int-value.cpp',
+  'pool-allocator.cpp',
+  'scopes.cpp',
+  'smx-builder.cpp',
+  'source-manager.cpp',
+  'symbols.cpp',
+  'reporting.cpp',
+  'type-manager.cpp',
+  'types.cpp',
+  'parser/ast-printer.cpp',
+  'parser/json-tools.cpp',
+  'parser/keyword-table.cpp',
+  'parser/lexer.cpp',
+  'parser/macro-lexer.cpp',
+  'parser/parser.cpp',
+  'parser/preprocessor.cpp',
+  'parser/tk-evaluator.cpp',
+  'sema/name-resolver.cpp',
+  'sema/semantic-analysis.cpp',
+  'sema/type-resolver.cpp',
+]
+libspcomp2 = builder.Add(binary)
 
-  binary.sources += [
-    'compile-context.cpp',
-    'constant-evaluator.cpp',
-    'dll_exports.cpp',
-    'float-value.cpp',
-    'int-value.cpp',
-    'pool-allocator.cpp',
-    'scopes.cpp',
-    'smx-builder.cpp',
-    'source-manager.cpp',
-    'symbols.cpp',
-    'reporting.cpp',
-    'type-manager.cpp',
-    'types.cpp',
-    'parser/ast-printer.cpp',
-    'parser/json-tools.cpp',
-    'parser/keyword-table.cpp',
-    'parser/lexer.cpp',
-    'parser/macro-lexer.cpp',
-    'parser/parser.cpp',
-    'parser/preprocessor.cpp',
-    'parser/tk-evaluator.cpp',
-    'sema/name-resolver.cpp',
-    'sema/semantic-analysis.cpp',
-    'sema/type-resolver.cpp',
-  ]
-  SP.libspcomp[arch] = builder.Add(binary)
+binary = Root.Program(builder, 'spcomp', arch)
+binary.compiler.cxxincludes += [
+  os.path.join(builder.sourcePath),
+  os.path.join(builder.sourcePath, 'include'),
+  os.path.join(builder.sourcePath, builder.sourceFolder),
+]
+if binary.compiler.like('msvc'):
+  binary.compiler.postlink += ['/SUBSYSTEM:CONSOLE']
 
-  binary = Root.Program(builder, 'spcomp', arch)
-  binary.compiler.cxxincludes += [
-    os.path.join(builder.sourcePath),
-    os.path.join(builder.sourcePath, 'include'),
-    os.path.join(builder.sourcePath, builder.sourceFolder),
-  ]
-  if binary.compiler.like('msvc'):
-    binary.compiler.postlink += ['/SUBSYSTEM:CONSOLE']
+binary.sources += [
+  'main.cpp',
+]
+binary.compiler.linkflags += [
+  libspcomp2.binary
+]
+builder.Add(binary)
 
-  binary.sources += [
-    'main.cpp',
-  ]
-  binary.compiler.linkflags += [
-    SP.libspcomp[arch].binary
-  ]
-  builder.Add(binary)
-
-
+rvalue = libspcomp2

--- a/exp/tools/docparse/AMBuilder
+++ b/exp/tools/docparse/AMBuilder
@@ -17,21 +17,19 @@
 # SourcePawn. If not, see http://www.gnu.org/licenses/.
 import os
 
-for arch in Root.archs:
-  binary = Root.Program(builder, 'docparse', arch)
-  binary.compiler.cxxincludes += [
-    os.path.join(builder.sourcePath, 'exp'),
-    os.path.join(builder.sourcePath, 'exp/compiler'),
-  ]
+binary = Root.Program(builder, 'docparse', arch)
+binary.compiler.cxxincludes += [
+  os.path.join(builder.sourcePath, 'exp'),
+  os.path.join(builder.sourcePath, 'exp/compiler'),
+]
 
-  if binary.compiler.like('msvc'):
-    binary.compiler.postlink += ['/SUBSYSTEM:CONSOLE']
+if binary.compiler.like('msvc'):
+  binary.compiler.postlink += ['/SUBSYSTEM:CONSOLE']
 
-  binary.sources += [
-    'docparse.cpp',
-  ]
-  binary.compiler.linkflags += [
-    SP.libspcomp[arch].binary
-  ]
-  builder.Add(binary)
-
+binary.sources += [
+  'docparse.cpp',
+]
+binary.compiler.linkflags += [
+  SP.libspcomp2[arch].binary
+]
+builder.Add(binary)

--- a/vm/AMBuilder
+++ b/vm/AMBuilder
@@ -1,15 +1,13 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os
 
-libsourcepawn = {}
-SP.libsourcepawn = {}
-SP.spshell = {}
+libsourcepawn_a = None
 
 def configure_like_shell(name, arch):
   prog = Root.Program(builder, name, arch)
   prog.compiler.includes += Includes
   prog.compiler.linkflags[0:0] = [
-    libsourcepawn[arch].binary,
+    libsourcepawn_a.binary,
     SP.zlib[arch],
   ]
   if prog.compiler.like('gcc'):
@@ -18,116 +16,117 @@ def configure_like_shell(name, arch):
     prog.compiler.postlink += ['-lpthread', '-lrt']
   return prog
 
-for arch in Root.archs:
-  Includes = [
-    os.path.join(SP.amtl, 'amtl'),
-    os.path.join(SP.amtl),
-    os.path.join(builder.currentSourcePath),
-    os.path.join(builder.currentSourcePath, '..', 'third_party'),
+Includes = [
+  os.path.join(SP.amtl, 'amtl'),
+  os.path.join(SP.amtl),
+  os.path.join(builder.currentSourcePath),
+  os.path.join(builder.currentSourcePath, '..', 'third_party'),
 
-    # The include path for SP v2 stuff.
-    os.path.join(builder.sourcePath, 'sourcepawn', 'include'),
+  # The include path for SP v2 stuff.
+  os.path.join(builder.sourcePath, 'sourcepawn', 'include'),
+]
+
+if builder.cxx.like('gcc'):
+  builder.cxx.cflags += [
+    '-Wno-invalid-offsetof',
+  ]
+  builder.cxx.cxxflags += ['-fno-rtti']
+if builder.cxx.like('clang'):
+  builder.cxx.cxxflags += [
+    '-Wno-implicit-exception-spec-mismatch',
+  ]
+if builder.cxx.family == 'gcc':
+  # ABI restrictions...
+  builder.cxx.cxxflags += [
+    '-Wno-delete-non-virtual-dtor',
   ]
 
-  if builder.cxx.like('gcc'):
-    builder.cxx.cflags += [
-      '-Wno-invalid-offsetof',
-    ]
-    builder.cxx.cxxflags += ['-fno-rtti']
-  if builder.cxx.like('clang'):
-    builder.cxx.cxxflags += [
-      '-Wno-implicit-exception-spec-mismatch',
-    ]
-  if builder.cxx.family == 'gcc':
-    # ABI restrictions...
-    builder.cxx.cxxflags += [
-      '-Wno-delete-non-virtual-dtor',
-    ]
+# Build the static library.
+library = Root.StaticLibrary(builder, 'sourcepawn', arch)
+library.compiler.includes += Includes
 
-  # Build the static library.
-  library = Root.StaticLibrary(builder, 'sourcepawn', arch)
-  library.compiler.includes += Includes
+library.sources += [
+  'api.cpp',
+  'base-context.cpp',
+  'builtins.cpp',
+  'code-allocator.cpp',
+  'code-stubs.cpp',
+  'compiled-function.cpp',
+  'environment.cpp',
+  'file-utils.cpp',
+  'interpreter.cpp',
+  'md5/md5.cpp',
+  'method-info.cpp',
+  'method-verifier.cpp',
+  'opcodes.cpp',
+  'plugin-context.cpp',
+  'plugin-runtime.cpp',
+  'pool-allocator.cpp',
+  'runtime-helpers.cpp',
+  'scripted-invoker.cpp',
+  'smx-v1-image.cpp',
+  'stack-frames.cpp',
+  'watchdog_timer.cpp',
+]
 
+is_emscripten = builder.cxx.family == 'emscripten'
+has_jit = arch in ['x86'] and not is_emscripten
+
+if has_jit:
   library.sources += [
-    'api.cpp',
-    'base-context.cpp',
-    'builtins.cpp',
-    'code-allocator.cpp',
-    'code-stubs.cpp',
-    'compiled-function.cpp',
-    'environment.cpp',
-    'file-utils.cpp',
-    'interpreter.cpp',
-    'md5/md5.cpp',
-    'method-info.cpp',
-    'method-verifier.cpp',
-    'opcodes.cpp',
-    'plugin-context.cpp',
-    'plugin-runtime.cpp',
-    'pool-allocator.cpp',
-    'runtime-helpers.cpp',
-    'scripted-invoker.cpp',
-    'smx-v1-image.cpp',
-    'stack-frames.cpp',
-    'watchdog_timer.cpp',
+    'jit.cpp',
+  ]
+  library.compiler.defines += ['SP_HAS_JIT']
+
+if is_emscripten:
+  library.sources += [
+    'code-stubs-null.cpp',
+  ]
+elif arch == 'x86':
+  library.sources += [
+    'linking.cpp',
+    'x86/assembler-x86.cpp',
+    'x86/code-stubs-x86.cpp',
+    'x86/jit_x86.cpp',
+  ]
+elif arch == 'x64':
+  library.sources += [
+    'linking.cpp',
+    'x64/assembler-x64.cpp',
+    'x64/code-stubs-x64.cpp',
+    'x64/macro-assembler-x64.cpp',
   ]
 
-  is_emscripten = builder.cxx.family == 'emscripten'
-  has_jit = arch in ['x86'] and not is_emscripten
+libsourcepawn_a = builder.Add(library)
 
-  if has_jit:
-    library.sources += [
-      'jit.cpp',
-    ]
-    library.compiler.defines += ['SP_HAS_JIT']
+# Build the dynamically-linked library.
+dll = Root.Library(builder, 'sourcepawn.jit.x86', arch)
+dll.compiler.includes += Includes
+dll.compiler.linkflags[0:0] = [
+  libsourcepawn_a.binary,
+  SP.zlib[arch],
+]
+dll.sources += [
+  'dll_exports.cpp'
+]
 
-  if is_emscripten:
-    library.sources += [
-      'code-stubs-null.cpp',
-    ]
-  elif arch == 'x86':
-    library.sources += [
-      'linking.cpp',
-      'x86/assembler-x86.cpp',
-      'x86/code-stubs-x86.cpp',
-      'x86/jit_x86.cpp',
-    ]
-  elif arch == 'x64':
-    library.sources += [
-      'linking.cpp',
-      'x64/assembler-x64.cpp',
-      'x64/code-stubs-x64.cpp',
-      'x64/macro-assembler-x64.cpp',
-    ]
+if builder.target.platform == 'linux':
+  dll.compiler.postlink += ['-lpthread', '-lrt']
 
-  libsourcepawn[arch] = builder.Add(library)
+libsourcepawn = builder.Add(dll)
 
-  # Build the dynamically-linked library.
-  dll = Root.Library(builder, 'sourcepawn.jit.x86', arch)
-  dll.compiler.includes += Includes
-  dll.compiler.linkflags[0:0] = [
-    libsourcepawn[arch].binary,
-    SP.zlib[arch],
-  ]
-  dll.sources += [
-    'dll_exports.cpp'
-  ]
+# Build the debug shell.
+shell = configure_like_shell('spshell', arch)
+shell.sources += [
+  'shell.cpp'
+]
+spshell = builder.Add(shell)
 
-  if builder.target.platform == 'linux':
-    dll.compiler.postlink += ['-lpthread', '-lrt']
+# Build the verifier.
+verifier = configure_like_shell('verifier', arch)
+verifier.sources += [
+  '../tools/verifier/verifier.cpp',
+]
+builder.Add(verifier)
 
-  SP.libsourcepawn[arch] = builder.Add(dll)
-
-  # Build the debug shell.
-  shell = configure_like_shell('spshell', arch)
-  shell.sources += [
-    'shell.cpp'
-  ]
-  SP.spshell[arch] = builder.Add(shell)
-
-  # Build the verifier.
-  verifier = configure_like_shell('verifier', arch)
-  verifier.sources += [
-    '../tools/verifier/verifier.cpp',
-  ]
-  builder.Add(verifier)
+rvalue = spshell

--- a/vm/plugin-context.cpp
+++ b/vm/plugin-context.cpp
@@ -502,7 +502,7 @@ PluginContext::popTrackerAndSetHeap()
   assert(sp_ >= hp_);
   assert(hp_ >= cell_t(data_size_));
 
-  if (hp_ - cell_t(data_size_) < sizeof(cell_t))
+  if (hp_ - cell_t(data_size_) < (cell_t)sizeof(cell_t))
     return SP_ERROR_TRACKER_BOUNDS;
 
   hp_ -= sizeof(cell_t);


### PR DESCRIPTION
Small simplification to some AMBuild files (most of the code changes are dedents). Instead of iterating the archs in each script, iterate them in the root script instead.