### PR TITLE
Add look-ahead for oldstyle decl

### DIFF
--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -5391,10 +5391,10 @@ static void statement(int *lastindent,int allow_decl)
   case tDECL:
   case tSTATIC:
   case tNEW:
-    if (matchtoken(tSYMBOL)) {
+    if (tok == tNEW && matchtoken(tSYMBOL)) {
         if (lexpeek('(')) {
           lexpush();
-          goto doxpr_jmp;
+          goto doexpr_jump;
         }
       lexpush(); // we matchtoken'ed, give it back to lex for declloc
     }
@@ -5474,7 +5474,7 @@ static void statement(int *lastindent,int allow_decl)
     decl_enum(sLOCAL);
     break;
   default:          /* non-empty expression */
-doxpr_jmp:
+doexpr_jump:
     lexpush();      /* analyze token later */
     doexpr(TRUE,TRUE,TRUE,TRUE,NULL,NULL,FALSE);
     needtoken(tTERM);

--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -5391,11 +5391,13 @@ static void statement(int *lastindent,int allow_decl)
   case tDECL:
   case tSTATIC:
   case tNEW:
-    if (matchtoken(tSYMBOL) && lexpeek('(')) {
-      lexpush();
-      goto doxpr_jmp;
+    if (matchtoken(tSYMBOL)) {
+        if (lexpeek('(')) {
+          lexpush();
+          goto doxpr_jmp;
+        }
+      lexpush(); // we matchtoken'ed, give it back to lex for declloc
     }
-
     if (!allow_decl) {
       error(3);
       break;

--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -5391,6 +5391,11 @@ static void statement(int *lastindent,int allow_decl)
   case tDECL:
   case tSTATIC:
   case tNEW:
+    if (matchtoken(tSYMBOL) && lexpeek('(')) {
+      lexpush();
+      goto doxpr_jmp;
+    }
+
     if (!allow_decl) {
       error(3);
       break;
@@ -5467,6 +5472,7 @@ static void statement(int *lastindent,int allow_decl)
     decl_enum(sLOCAL);
     break;
   default:          /* non-empty expression */
+doxpr_jmp:
     lexpush();      /* analyze token later */
     doexpr(TRUE,TRUE,TRUE,TRUE,NULL,NULL,FALSE);
     needtoken(tTERM);

--- a/tests/compile-only/ok-anon-instansiation.sp
+++ b/tests/compile-only/ok-anon-instansiation.sp
@@ -1,0 +1,8 @@
+methodmap MyMethodMap < Handle {
+	public native MyMethodMap();
+}
+
+public OnPluginStart()
+{
+	new MyMethodMap();
+}

--- a/tests/compile-only/ok-anon-instantiation.sp
+++ b/tests/compile-only/ok-anon-instantiation.sp
@@ -1,4 +1,4 @@
-methodmap MyMethodMap < Handle {
+methodmap MyMethodMap __nullable__ {
 	public native MyMethodMap();
 }
 


### PR DESCRIPTION
This commit prevents anonymous instantiations in the form of `new Class()` from falling into declloc.


Fixes #162