### PR TITLE
Fix a HEA leak when using break in nested scopes.

### DIFF
--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -6244,6 +6244,7 @@ static void dobreak(void)
     return;
   destructsymbols(&loctab,nestlevel);
   genstackfree(ptr[wqBRK]);
+  genheapfree(ptr[wqBRK]);
   jumplabel(ptr[wqEXIT]);
 }
 


### PR DESCRIPTION
Ancient bug - looks like it's a carryover from AMX Mod X.

The following script will misalign the HEA stack:

```
native void printnum(int n);

public main() {
  while (true) {
    for (int i = 1; i < 10; i++) {
      char[] egg = new char[i];
      if (i % 2 == 0) {
         char[] yam = new char[i + 3];
         break;
      } else {
         char[] yam = new char[i + 3];
         continue;
      }
    }
  }
}
```