### PR TITLE
Compute static memory requirements of methods.

### DIFF
--- a/tools/verifier/verifier.cpp
+++ b/tools/verifier/verifier.cpp
@@ -78,8 +78,10 @@ Analyze(const char* file)
 {
   char error[255];
   AutoPtr<IPluginRuntime> rt(sEnv->APIv2()->LoadBinaryFromFile(file, error, sizeof(error)));
-  if (!rt)
+  if (!rt) {
+    fprintf(stdout, "Could not load .smx file: %s\n", error);
     return false;
+  }
 
   if (sVerbose) {
     uint32_t index;

--- a/vm/graph-builder.cpp
+++ b/vm/graph-builder.cpp
@@ -337,7 +337,12 @@ GraphBuilder::prescan()
         return error(SP_ERROR_INVALID_INSTRUCTION);
       opcode_params = (ncases * 2) + 1;
     } else {
-      opcode_params = kOpcodeSizes[op] - 1;
+      int opcode_size = kOpcodeSizes[op];
+      if (opcode_size == 0) {
+        // This opcode is not generated, and is therefore illegal.
+        return error(SP_ERROR_INVALID_INSTRUCTION);
+      }
+      opcode_params = opcode_size - 1;
     }
     assert(opcode_params >= 0);
 

--- a/vm/method-verifier.h
+++ b/vm/method-verifier.h
@@ -55,18 +55,35 @@ class MethodVerifier final
   void reportError(int err);
   cell_t readCell();
 
+  struct VerifyData : public IBlockData {
+    VerifyData()
+     : stack_balance(0)
+    {}
+    uint32_t stack_balance;
+  };
+
+  bool handleJoins();
+  bool verifyJoin(VerifyData* a, VerifyData* b);
+  bool verifyJoins(Block* block);
+  bool pushStack(uint32_t num_cells);
+  bool popStack(uint32_t num_cells);
+
  private:
   PluginRuntime* rt_;
   ke::RefPtr<ControlFlowGraph> graph_;
+  Block* block_;
+  ke::Vector<Block*> verify_joins_;
   uint32_t code_features_;
   uint32_t startOffset_;
   size_t memSize_;
   size_t datSize_;
   size_t heapSize_;
+  uint32_t max_stack_;
   const cell_t* code_;
   const cell_t* method_;
   const cell_t* insn_;
   const cell_t* cip_;
+  const cell_t* prev_cip_;
   const cell_t* stop_at_;
   ExternalFuncRefCallback collect_func_refs_;
   int error_;

--- a/vm/opcodes.cpp
+++ b/vm/opcodes.cpp
@@ -90,6 +90,10 @@ SpewOpcode(FILE* fp, PluginRuntime* runtime, const cell_t* start, const cell_t* 
     case OP_GENARRAY_Z:
     case OP_CONST_PRI:
     case OP_CONST_ALT:
+    case OP_LOAD_S_PRI:
+    case OP_LOAD_S_ALT:
+    case OP_STOR_S_PRI:
+    case OP_STOR_S_ALT:
       fprintf(fp, "%d", cip[1]);
       break;
 


### PR DESCRIPTION
This series of patches adds a few new verification steps. The first is that the stack must be _balanced_. The amount of stack space used must be equal across all incoming edges to a block. This has a few important implications:
1. The compiler is not allowed to leak stack space, which in a loop could easily yield a run-time error.
2. The amount of stack space used by a method must be _static_. 
3. The operand of any stack-affecting instruction can be assigned a constant offset from the base of the stack frame. (This will lead to big wins in the JIT).

The algorithm is simple: for each opcode, the stack balance is adjusted based on how much it adds or removes from the stack. When parsing each block, its initial stack balance is inherited from any predecessor, and it must be equal across all predecessors. Loop edges must be checked again later since they are cyclic.

In addition, a second verification step is that stack offsets must now be within each block's stack balance. Even if the stack offset is valid for some other block, it must also be valid locally.

These changes did cause a few new failures in my .smx corpus. Four copies of "THC RPG" [1], three dated 02/15/2014 and one dated 07/14/2013 (both using SourceMod 1.5.x) have an odd bug. One block references a local variable that does not exist, and it is quite clear from the bytecode that something is wrong. Lysis manages to assign a name to this stack offset, but the name isn't anywhere in the debug symbols. I don't know what happened, but this plugin is unsupported so I'm not too worried.

A plugin that used to fail verification, but now passes, is from the Lysis test suite. "anlol.smx" (dated 02/24/2016, SM 1.7.3) has a wildly huge stack offset, -1000000004, which we used to statically determine was impossible to satisfy. I removed this check because now it can be encapsulated in the runtime's stack space check, which I'll do as a separate patch when I go to optimize the JIT. This plugin has been heavily obfuscated so it is certainly not generated by a supported compiler.

Finally, a plugin called "PUNISHER old v34" [2] fails the new requirements. It is again heavily obfuscated by some third-party compiler. Unfortunately this compiler inserted an extra `pop.alt` instruction on an empty stack, which is nonsensical and not allowed.

[1] Attachments 114946, 130624, 130633, 122854
[2] Attachment 164723 (08/04/2017, SM 1.7)