### PR TITLE
Require a balanced heap state at join points.

### DIFF
--- a/vm/control-flow.h
+++ b/vm/control-flow.h
@@ -110,6 +110,9 @@ class Block :
   bool isLoopHeader() const {
     return is_loop_header_;
   }
+  ControlFlowGraph* graph() const {
+    return &graph_;
+  }
 
   template <typename T>
   T* data() const {

--- a/vm/method-verifier.h
+++ b/vm/method-verifier.h
@@ -60,13 +60,16 @@ class MethodVerifier final
      : stack_balance(0)
     {}
     uint32_t stack_balance;
+    ke::Vector<int32_t> heap_balance;
   };
 
   bool handleJoins();
-  bool verifyJoin(VerifyData* a, VerifyData* b);
+  bool verifyJoin(Block* block, VerifyData* a, VerifyData* b);
   bool verifyJoins(Block* block);
   bool pushStack(uint32_t num_cells);
   bool popStack(uint32_t num_cells);
+  bool pushHeap(uint32_t num_cells);
+  bool popHeap(uint32_t num_cells);
 
  private:
   PluginRuntime* rt_;


### PR DESCRIPTION
We can require a balanced HEA state in addition to STK. Heap allocations can be dynamic, which makes this a bit more complicated. We need to correctly interleave static and dynamic allocations, which requires a stack.

The really annoying problem, though, is that the compiler had a bug for 12 years where dynamic arrays were not freed on "break" statements inside loops. This messes up our analysis because the join point will see an empty heap state on one predecessor, and lingering dynamic variables in the other.

Two plugins in my corpus were affected by this bug. One of them still had the source code available, and I was able to work around it by detecting break statements and ignoring the balancing error. (I think it is okay, in this case, to pick a random predecessor's state to inherit, because the only entries should be extra dynamic entries.)

I could not find the source to the other plugin, and I can't tell what's going on from its control flow. It's found in attachments 138975, 146934, 150386, and 150800. It appears to be a discontinued deathmatch plugin by H3bus, and the thread for it has been scrubbed. Given that these binaries were made between 10/2014 and 12/2015, for SourceMod 1.6.2, I think I'm okay making it fail validation. But I'll keep an eye out for cases where the bug detection does not work.