### PR TITLE
Move stack checks to the function prologue.

### DIFF
--- a/vm/method-info.cpp
+++ b/vm/method-info.cpp
@@ -22,7 +22,8 @@ MethodInfo::MethodInfo(PluginRuntime* rt, uint32_t codeOffset)
  : rt_(rt),
    pcode_offset_(codeOffset),
    checked_(false),
-   validation_error_(SP_ERROR_NONE)
+   validation_error_(SP_ERROR_NONE),
+   max_stack_(0)
 {
 }
 
@@ -46,8 +47,11 @@ MethodInfo::InternalValidate()
 {
   MethodVerifier verifier(rt_, pcode_offset_);
   graph_ = verifier.verify();
-  if (!graph_)
+  if (graph_) {
+    max_stack_ = verifier.max_stack();
+  } else {
     validation_error_ = verifier.error();
+  }
 
   checked_ = true;
 }

--- a/vm/method-info.h
+++ b/vm/method-info.h
@@ -44,9 +44,11 @@ class MethodInfo final : public ke::Refcounted<MethodInfo>
   int validationError() const {
     return validation_error_;
   }
-
   uint32_t pcode_offset() const {
     return pcode_offset_;
+  }
+  int32_t max_stack() const {
+    return max_stack_;
   }
 
   void setCompiledFunction(CompiledFunction* fun);
@@ -65,6 +67,7 @@ class MethodInfo final : public ke::Refcounted<MethodInfo>
 
   bool checked_;
   int validation_error_;
+  int32_t max_stack_;
 };
 
 } // namespace sp

--- a/vm/method-verifier.cpp
+++ b/vm/method-verifier.cpp
@@ -88,6 +88,12 @@ MethodVerifier::verify()
       return nullptr;
   }
 
+  if (max_stack_ > INT_MAX / 4) {
+    reportError(SP_ERROR_STACKLOW);
+    return nullptr;
+  }
+  max_stack_ *= sizeof(cell_t);
+
   return graph_;
 }
 

--- a/vm/method-verifier.h
+++ b/vm/method-verifier.h
@@ -32,6 +32,9 @@ class MethodVerifier final
 
   ke::RefPtr<ControlFlowGraph> verify();
 
+  int32_t max_stack() const {
+    return max_stack_;
+  }
   int error() const {
     return error_;
   }


### PR DESCRIPTION
Now that methods are required to have a statically sized stack frame, we can check stack bounds in the method prologue. OP_STACK no longer needs any checks.