### PR TITLE
Reenable Emscripten CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ env:
   matrix:
     - AM_CC=clang-3.8 AM_CXX=clang++-3.8 AM_ARCH=x86 AM_TYPE=optimize
     - AM_CC=clang-3.8 AM_CXX=clang++-3.8 AM_ARCH=x64 AM_TYPE=optimize
+    - AM_CC=emcc AM_CXX=em++ AM_ARCH=x86 AM_TYPE=optimize
+    - AM_CC=emcc AM_CXX=em++ AM_ARCH=x86 AM_TYPE=debug
     - AM_CC=clang-3.8 AM_CXX=clang++-3.8 AM_ARCH=x86 AM_TYPE=debug
     - AM_CC=clang-3.8 AM_CXX=clang++-3.8 AM_ARCH=x64 AM_TYPE=debug
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
       - linux-libc-dev:i386
 env:
   global:
-    - EMSCRIPTEN_SDK_BRANCH=incoming
+    - EMSCRIPTEN_SDK_BRANCH=master
     - EMSCRIPTEN_SDK_URI=https://github.com/urho3d/emscripten-sdk.git
   matrix:
     - AM_CC=clang-3.8 AM_CXX=clang++-3.8 AM_ARCH=x86 AM_TYPE=optimize


### PR DESCRIPTION
Reverts alliedmodders/sourcepawn#225

The `incoming` branch of urho3d/emscripten-sdk was changed to be building a load of extra tools, and possibly lacking optimizations? First run of emcc was taking 6+ minutes and running out of memory. Switching to `master` which has now been updated to the EMSDK version we require has resolved this and everything seems to be working again.