### PR TITLE
SmxViewer: Collect unknown functions while disassembling

### DIFF
--- a/tools/smxtools/smxdasm/File.cs
+++ b/tools/smxtools/smxdasm/File.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Collections.Generic;
+using System;
 
 namespace smxdasm
 {
@@ -16,6 +17,7 @@ namespace smxdasm
         public SmxTagTable Tags;
         public SmxDataSection Data;
         public SmxCodeV1Section CodeV1;
+        public SmxCalledFunctionsTable CalledFunctions;
         public SmxDebugInfoSection DebugInfo;
         public SmxDebugFilesTable DebugFiles;
         public SmxDebugLinesTable DebugLines;
@@ -47,6 +49,8 @@ namespace smxdasm
                 else if (section.Name == ".dbg.info")
                     DebugInfo = new SmxDebugInfoSection(Header, section);
             }
+
+            CalledFunctions = new SmxCalledFunctionsTable();
 
             // .dbg.names was removed when RTTI was added.
             if (DebugNames == null)
@@ -131,6 +135,52 @@ namespace smxdasm
                 }
             }
             UnknownSections = unknown.ToArray();
+
+            // Disassemble all functions right away to find all called functions.
+            if (DebugSymbols != null)
+            {
+                foreach (var entry in DebugSymbols.Entries)
+                {
+                    if (entry.Ident != SymKind.Function)
+                        continue;
+                    try
+                    {
+                        V1Disassembler.Disassemble(this, CodeV1, entry.Address);
+                    }
+                    catch (Exception)
+                    {
+                        continue;
+                    }
+                }
+            }
+            if (Publics != null)
+            {
+                foreach (var pubfun in Publics.Entries)
+                {
+                    try
+                    {
+                        V1Disassembler.Disassemble(this, CodeV1, (int)pubfun.Address);
+                    }
+                    catch (Exception)
+                    {
+                        continue;
+                    }
+                }
+            }
+            if (CalledFunctions != null)
+            {
+                foreach (var fun in CalledFunctions.Entries)
+                {
+                    try
+                    {
+                        V1Disassembler.Disassemble(this, CodeV1, (int)fun.Address);
+                    }
+                    catch (Exception)
+                    {
+                        continue;
+                    }
+                }
+            }
         }
 
         public string FindGlobalName(int address)
@@ -183,7 +233,41 @@ namespace smxdasm
                         return pubfun.Name;
                 }
             }
+            if (CalledFunctions != null)
+            {
+                foreach (var fun in CalledFunctions.Entries)
+                {
+                    if (fun.Address == address)
+                        return fun.Name;
+                }
+            }
             return "(unknown)";
+        }
+
+        public bool IsFunctionAtAddress(int address)
+        {
+            if (DebugSymbols != null)
+            {
+                if (DebugSymbols.FindFunction(address) != null)
+                    return true;
+            }
+            if (Publics != null)
+            {
+                foreach (var pubfun in Publics.Entries)
+                {
+                    if (pubfun.Address == address)
+                        return true;
+                }
+            }
+            if (CalledFunctions != null)
+            {
+                foreach (var fun in CalledFunctions.Entries)
+                {
+                    if (fun.Address == address)
+                        return true;
+                }
+            }
+            return false;
         }
     }
 }

--- a/tools/smxtools/smxdasm/File.cs
+++ b/tools/smxtools/smxdasm/File.cs
@@ -143,42 +143,21 @@ namespace smxdasm
                 {
                     if (entry.Ident != SymKind.Function)
                         continue;
-                    try
-                    {
-                        V1Disassembler.Disassemble(this, CodeV1, entry.Address);
-                    }
-                    catch (Exception)
-                    {
-                        continue;
-                    }
+                    V1Disassembler.TryDisassemble(this, CodeV1, entry.Address);
                 }
             }
             if (Publics != null)
             {
                 foreach (var pubfun in Publics.Entries)
                 {
-                    try
-                    {
-                        V1Disassembler.Disassemble(this, CodeV1, (int)pubfun.Address);
-                    }
-                    catch (Exception)
-                    {
-                        continue;
-                    }
+                    V1Disassembler.TryDisassemble(this, CodeV1, (int)pubfun.Address);
                 }
             }
             if (CalledFunctions != null)
             {
                 foreach (var fun in CalledFunctions.Entries)
                 {
-                    try
-                    {
-                        V1Disassembler.Disassemble(this, CodeV1, (int)fun.Address);
-                    }
-                    catch (Exception)
-                    {
-                        continue;
-                    }
+                    V1Disassembler.TryDisassemble(this, CodeV1, (int)fun.Address);
                 }
             }
         }

--- a/tools/smxtools/smxdasm/Sections.cs
+++ b/tools/smxtools/smxdasm/Sections.cs
@@ -142,6 +142,37 @@ namespace smxdasm
         }
     }
 
+    public class SmxCalledFunctionsTable
+    {
+        private List<CalledFunctionEntry> functions_;
+        
+        public SmxCalledFunctionsTable()
+        {
+            functions_ = new List<CalledFunctionEntry>();
+        }
+
+        public CalledFunctionEntry[] Entries
+        {
+            get { return functions_.ToArray(); }
+        }
+
+        public int Length
+        {
+            get { return functions_.Count; }
+        }
+        public CalledFunctionEntry this[int index]
+        {
+            get { return functions_[index]; }
+        }
+        public void AddFunction(uint addr)
+        {
+            var entry = new CalledFunctionEntry();
+            entry.Address = addr;
+            entry.Name = String.Format("sub_{0:x}", addr);
+            functions_.Add(entry);
+        }
+    }
+
     // The .pubvars table.
     public class SmxPubvarTable : SmxSection
     {

--- a/tools/smxtools/smxdasm/V1Disassembler.cs
+++ b/tools/smxtools/smxdasm/V1Disassembler.cs
@@ -181,6 +181,7 @@ namespace smxdasm
             Prep(V1Opcode.REBASE, V1Param.Address, V1Param.Constant, V1Param.Constant);
         }
 
+        private SmxFile file_;
         private byte[] data_;
         private int code_start_;
         private int proc_offset_;
@@ -206,6 +207,7 @@ namespace smxdasm
 
         private V1Disassembler(SmxFile file, SmxCodeV1Section code, int proc_offset)
         {
+            file_ = file;
             data_ = file.Header.Data;
             code_start_ = code.CodeStart;
             proc_offset_ = proc_offset;
@@ -248,6 +250,14 @@ namespace smxdasm
                 insn.Params = new int[insn.Info.Params.Length];
                 for (var i = 0; i < insn.Info.Params.Length; i++)
                     insn.Params[i] = readNext();
+
+                // Catch calls to unknown functions so they can be disassembled easily too.
+                if (op == (int)V1Opcode.CALL)
+                {
+                    var addr = insn.Params[0];
+                    if (!file_.IsFunctionAtAddress(addr))
+                        file_.CalledFunctions.AddFunction((uint)addr);
+                }
             }
             return insns.ToArray();
         }

--- a/tools/smxtools/smxdasm/V1Disassembler.cs
+++ b/tools/smxtools/smxdasm/V1Disassembler.cs
@@ -267,5 +267,17 @@ namespace smxdasm
             var disassembler = new V1Disassembler(file, code, proc_offset);
             return disassembler.disassemble();
         }
+
+        public static V1Instruction[] TryDisassemble(SmxFile file, SmxCodeV1Section code, int proc_offset)
+        {
+            try
+            {
+                return Disassemble(file, code, proc_offset);
+            }
+            catch
+            {
+                return null;
+            }
+        }
     }
 }

--- a/tools/smxtools/smxdasm/V1Types.cs
+++ b/tools/smxtools/smxdasm/V1Types.cs
@@ -108,6 +108,13 @@ namespace smxdasm
         }
     }
 
+    // Called functions that weren't in the .publics or .dbg.symbols sections.
+    public class CalledFunctionEntry
+    {
+        public uint Address;
+        public string Name;
+    }
+
     // The ".natives" section.
     public class NativeEntry
     {

--- a/tools/smxtools/smxviewer/MainWindow.cs
+++ b/tools/smxtools/smxviewer/MainWindow.cs
@@ -519,6 +519,13 @@ namespace smxviewer
                     functionMap[sym.Name] = sym.CodeStart;
                 }
             }
+            if (file_.CalledFunctions != null)
+            {
+                foreach (var fun in file_.CalledFunctions.Entries)
+                {
+                    functionMap[fun.Name] = fun.Address;
+                }
+            }
 
             foreach (var pair in functionMap)
             {


### PR DESCRIPTION
When encountering a `call` while disassembling check if there is an entry for the called address in the ".publics" or ".dbg.symbols" sections. If the function is missing add it to a seperate list to be able to disassemble functions even while debug info is stripped.

The functions are added with a name like `sub_<addr>` to be unqiue.