### PR TITLE
Use atoms for symbol names.

### DIFF
--- a/compiler/expression-parsing.cpp
+++ b/compiler/expression-parsing.cpp
@@ -191,14 +191,14 @@ BaseExpressionParser::parse_sizeof()
         subsym=finddepend(subsym);
     } /* for */
     if (level>sym->dim.array.level+1) {
-      error(28,sym->name);  /* invalid subscript */
+      error(28,sym->name());  /* invalid subscript */
     } else if (level==sym->dim.array.level+1) {
       result = (idxsym!=NULL && idxsym->dim.array.length>0) ? idxsym->dim.array.length : 1;
     } else {
       result = array_levelsize(sym,level);
     }
     if (result==0 && strchr((char *)lptr,PREPROC_TERM)==NULL)
-      error(163,sym->name);          /* indeterminate array size in "sizeof" expression */
+      error(163,sym->name());          /* indeterminate array size in "sizeof" expression */
   } /* if */
   while (paranthese--)
     needtoken(')');
@@ -257,14 +257,14 @@ BaseExpressionParser::parse_cellsof()
         subsym=finddepend(subsym);
     } /* for */
     if (level>sym->dim.array.level+1) {
-      error(28,sym->name);  /* invalid subscript */
+      error(28,sym->name());  /* invalid subscript */
     } else if (level==sym->dim.array.level+1) {
       result = (idxsym!=NULL && idxsym->dim.array.length>0) ? idxsym->dim.array.length : 1;
     } else {
       result = array_levelsize(sym,level);
     }
     if (result==0 && strchr((char *)lptr,PREPROC_TERM)==NULL)
-      error(163,sym->name);          /* indeterminate array size in "sizeof" expression */
+      error(163,sym->name());          /* indeterminate array size in "sizeof" expression */
   } /* if */
 
   while (paranthese--)
@@ -326,7 +326,7 @@ BaseExpressionParser::parse_tagof()
         subsym=finddepend(subsym);
     } /* for */
     if (level>sym->dim.array.level+1)
-      error(28,sym->name);  /* invalid subscript */
+      error(28,sym->name());  /* invalid subscript */
     else if (level==sym->dim.array.level+1 && idxsym!=NULL)
       tag= idxsym->x.tags.index;
   } /* if */

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -44,6 +44,7 @@
 #endif
 #include <sp_vm_types.h>
 #include <amtl/am-vector.h>
+#include "shared/string-pool.h"
 #include "osdefs.h"
 #include "amx.h"
 
@@ -118,8 +119,6 @@ struct symbol {
 
   symbol *next;
   symbol *parent;  /* hierarchical types */
-  char name[sNAMEMAX+1];
-  uint32_t hash;        /* value derived from name, for quicker searching */
   cell codeaddr;        /* address (in the code segment) where the symbol declaration starts */
   char vclass;          /* sLOCAL if "addr" refers to a local symbol */
   char ident;           /* see below for possible values */
@@ -159,9 +158,19 @@ struct symbol {
   void setAddr(int addr) {
     addr_ = addr;
   }
+  sp::Atom* nameAtom() const {
+    return name_;
+  }
+  const char* name() const {
+    return name_ ? name_->chars() : "";
+  }
+  void setName(sp::Atom* name) {
+    name_ = name;
+  }
 
  private:
   cell addr_;            /* address or offset (or value for constant, index for native function) */
+  sp::Atom* name_;
 };
 
 /*  Possible entries for "ident". These are used in the "symbol", "value"
@@ -993,5 +1002,7 @@ struct AutoDisableLiteralQueue
  private:
   bool prev_value_;
 };
+
+extern sp::StringPool gAtoms;
 
 #endif /* SC_H_INCLUDED */

--- a/compiler/sc3.cpp
+++ b/compiler/sc3.cpp
@@ -150,7 +150,7 @@ int check_userop(void (*oper)(void),int tag1,int tag2,int numparam,
   /* check existance and the proper declaration of this function */
   if ((sym->usage & uMISSING)!=0 || (sym->usage & uPROTOTYPED)==0) {
     char symname[2*sNAMEMAX+16];  /* allow space for user defined operators */
-    funcdisplayname(symname,sym->name);
+    funcdisplayname(symname,sym->name());
     if ((sym->usage & uMISSING)!=0)
       error(4,symname);           /* function not defined */
     if ((sym->usage & uPROTOTYPED)==0)
@@ -610,7 +610,7 @@ SC3ExpressionParser::skim(int *opstr,void (*testfunc)(int),int dropval,int endva
 
     foundop=nextop(&opidx,opstr);
     if ((foundop || hits) && (lval->ident==iARRAY || lval->ident==iREFARRAY))
-      error(33, lval->sym ? lval->sym->name : "-unknown-");  /* array was not indexed in an expression */
+      error(33, lval->sym ? lval->sym->name() : "-unknown-");  /* array was not indexed in an expression */
     if (foundop) {
       if (!hits) {
         /* this is the first operator in the list */
@@ -676,7 +676,7 @@ static void checkfunction(value *lval)
      */
     if (sym!=curfunc && (sym->usage & uRETVALUE)==0) {
       char symname[2*sNAMEMAX+16];  /* allow space for user defined operators */
-      funcdisplayname(symname,sym->name);
+      funcdisplayname(symname,sym->name());
       error(209,symname);       /* function should return a value */
     } /* if */
   } else {
@@ -838,10 +838,10 @@ SC3ExpressionParser::plnge2(void (*oper)(void),
     checkfunction(lval1);
     checkfunction(lval2);
     if (lval1->ident==iARRAY || lval1->ident==iREFARRAY) {
-      const char *ptr=(lval1->sym!=NULL) ? lval1->sym->name : "-unknown-";
+      const char *ptr=(lval1->sym!=NULL) ? lval1->sym->name() : "-unknown-";
       error(33,ptr);                    /* array must be indexed */
     } else if (lval2->ident==iARRAY || lval2->ident==iREFARRAY) {
-      const char *ptr=(lval2->sym!=NULL) ? lval2->sym->name : "-unknown-";
+      const char *ptr=(lval2->sym!=NULL) ? lval2->sym->name() : "-unknown-";
       error(33,ptr);                    /* array must be indexed */
     } /* if */
     /* ??? ^^^ should do same kind of error checking with functions */
@@ -1063,7 +1063,7 @@ SC3ExpressionParser::hier14(value *lval1)
       return error(23); /* array assignment must be simple assigment */
     assert(lval1->sym!=NULL);
     if (array_totalsize(lval1->sym)==0)
-      return error(46,lval1->sym->name);        /* unknown array size */
+      return error(46,lval1->sym->name());        /* unknown array size */
     lvalue=TRUE;
   } /* if */
 
@@ -1099,7 +1099,7 @@ SC3ExpressionParser::hier14(value *lval1)
       for (i=0; i<sDIMEN_MAX; i++)
         same=same && (lval3.arrayidx[i]==lval2.arrayidx[i]);
       if (same)
-        error(226,lval3.sym->name);   /* self-assignment */
+        error(226,lval3.sym->name());   /* self-assignment */
     } /* if */
   } else if (lval1->ident == iACCESSOR) {
     pushreg(sPRI);
@@ -1129,7 +1129,7 @@ SC3ExpressionParser::hier14(value *lval1)
       /* check whether lval2 and lval3 (old lval1) refer to the same variable */
       if (lval2.ident==iVARIABLE && lval3.ident==lval2.ident && lval3.sym==lval2.sym) {
         assert(lval3.sym!=NULL);
-        error(226,lval3.sym->name);     /* self-assignment */
+        error(226,lval3.sym->name());     /* self-assignment */
       } /* if */
     } /* if */
   } /* if */
@@ -1160,14 +1160,14 @@ SC3ExpressionParser::hier14(value *lval1)
     } /* if */
     if (lval2.ident!=iARRAY && lval2.ident!=iREFARRAY
         && (lval2.sym==NULL || lval2.constval<=0))
-      error(33,lval3.sym->name);        /* array must be indexed */
+      error(33,lval3.sym->name());        /* array must be indexed */
     if (lval2.sym!=NULL) {
       if (lval2.constval==0) {
         val=lval2.sym->dim.array.length;/* array variable */
       } else {
         val=lval2.constval;
         if (lval2.sym->dim.array.level!=0)
-          error(28,lval2.sym->name);
+          error(28,lval2.sym->name());
       } /* if */
       level=lval2.sym->dim.array.level;
       idxtag=lval2.sym->x.tags.index;
@@ -1192,7 +1192,7 @@ SC3ExpressionParser::hier14(value *lval1)
     else if (ltlength<val || (exactmatch && ltlength>val) || val==0)
       return error(47); /* array sizes must match */
     else if (lval3.ident!=iARRAYCELL && !matchtag(lval3.sym->x.tags.index,idxtag,MATCHTAG_COERCE|MATCHTAG_SILENT))
-      error(229,(lval2.sym!=NULL) ? lval2.sym->name : lval3.sym->name); /* index tag mismatch */
+      error(229,(lval2.sym!=NULL) ? lval2.sym->name() : lval3.sym->name()); /* index tag mismatch */
     if (level>0) {
       /* check the sizes of all sublevels too */
       symbol *sym1 = lval3.sym;
@@ -1215,7 +1215,7 @@ SC3ExpressionParser::hier14(value *lval1)
         if (sym1->dim.array.length!=sym2->dim.array.length)
           error(47);    /* array sizes must match */
         else if (!matchtag(sym1->x.tags.index,sym2->x.tags.index,MATCHTAG_COERCE|MATCHTAG_SILENT))
-          error(229,sym2->name);  /* index tag mismatch */
+          error(229,sym2->name());  /* index tag mismatch */
       } /* for */
       /* get the total size in cells of the multi-dimensional array */
       val=array_totalsize(lval3.sym);
@@ -1319,12 +1319,12 @@ SC3ExpressionParser::hier13(value *lval)
     if (!array1 && array2) {
       const char *ptr = "-unknown-";
       if (lval->sym != NULL)
-        ptr = lval->sym->name;
+        ptr = lval->sym->name();
       error(33,ptr);            /* array must be indexed */
     } else if (array1 && !array2) {
       const char *ptr = "-unknown-";
       if (lval2.sym != NULL)
-        ptr = lval2.sym->name;
+        ptr = lval2.sym->name();
       error(33,ptr);            /* array must be indexed */
     } /* if */
     /* ??? if both are arrays, should check dimensions */
@@ -1880,7 +1880,7 @@ restart:
       !(lexpeek('.') || lexpeek('(')))
   {
     // Cannot use methodmap as an rvalue/lvalue.
-    error(174, sym ? sym->name : "(unknown)");
+    error(174, sym ? sym->name() : "(unknown)");
 
     lval1->ident = iCONSTEXPR;
     lval1->tag = 0;
@@ -1909,7 +1909,7 @@ restart:
         needtoken(close);
         return FALSE;
       } else if (sym->ident!=iARRAY && sym->ident!=iREFARRAY){
-        error(28,sym->name);    /* cannot subscript, variable is not an array */
+        error(28,sym->name());    /* cannot subscript, variable is not an array */
         needtoken(close);
         return FALSE;
       } /* if */
@@ -1920,7 +1920,7 @@ restart:
       if (hier14(&lval2))       /* create expression for the array index */
         rvalue(&lval2);
       if (lval2.ident==iARRAY || lval2.ident==iREFARRAY)
-        error(33,lval2.sym->name);      /* array must be indexed */
+        error(33,lval2.sym->name());      /* array must be indexed */
       needtoken(close);
       if ((sym->usage & uENUMROOT))
         matchtag(sym->x.tags.index,lval2.tag,TRUE);
@@ -1933,7 +1933,7 @@ restart:
         if (!(sym->tag == pc_tag_string && sym->dim.array.level == 0)) {
           /* normal array index */
           if (lval2.constval<0 || (sym->dim.array.length!=0 && sym->dim.array.length<=lval2.constval))
-            error(32,sym->name);        /* array index out of bounds */
+            error(32,sym->name());        /* array index out of bounds */
           if (lval2.constval!=0) {
             /* don't add offsets for zero subscripts */
             #if PAWN_CELL_SIZE==16
@@ -1951,7 +1951,7 @@ restart:
           /* character index */
           if (lval2.constval<0 || (sym->dim.array.length!=0
               && sym->dim.array.length*((8*sizeof(cell))/sCHARBITS)<=(ucell)lval2.constval))
-            error(32,sym->name);        /* array index out of bounds */
+            error(32,sym->name());        /* array index out of bounds */
           if (lval2.constval!=0) {
             /* don't add offsets for zero subscripts */
             #if sCHARBITS==16
@@ -2108,7 +2108,7 @@ restart:
         if (sym && sym->ident == iMETHODMAP && sym->methodmap) {
           if (!sym->methodmap->ctor) {
             // Immediately fatal - no function to call.
-            return error(172, sym->name);
+            return error(172, sym->name());
           }
           if (sym->methodmap->must_construct_with_new()) {
             // Keep going, this is basically a style thing.
@@ -2129,7 +2129,7 @@ restart:
         }
       } else if ((sym->usage & uMISSING)!=0) {
         char symname[2*sNAMEMAX+16];  /* allow space for user defined operators */
-        funcdisplayname(symname,sym->name);
+        funcdisplayname(symname,sym->name());
         error(4,symname);             /* function not defined */
       } /* if */
 
@@ -2576,12 +2576,12 @@ SC3ExpressionParser::callfunction(symbol *sym, const svalue *aImplicitThis, valu
       !(sym->usage & uREAD) &&
       sc_status == statWRITE)
   {
-    error(195, sym->name);
+    error(195, sym->name());
   }
 
   if ((sym->flags & flgDEPRECATED)!=0) {
     const char *ptr= (sym->documentation!=NULL) ? sym->documentation : "";
-    error(234,sym->name,ptr);   /* deprecated (probably a native function) */
+    error(234,sym->name(),ptr);   /* deprecated (probably a native function) */
   } /* if */
 
   CallArgPusher args(aImplicitThis);
@@ -2833,7 +2833,7 @@ SC3ExpressionParser::callfunction(symbol *sym, const svalue *aImplicitThis, valu
               if (arg[argidx].dim[level]!=0 && sym->dim.array.length!=arg[argidx].dim[level])
                 error(47);        /* array sizes must match */
               else if (!matchtag(arg[argidx].idxtag[level],sym->x.tags.index,TRUE))
-                error(229,sym->name);   /* index tag mismatch */
+                error(229,sym->name());   /* index tag mismatch */
               append_constval(&arrayszlst,arg[argidx].name,sym->dim.array.length,level);
               sym=finddepend(sym);
               assert(sym!=NULL);
@@ -2845,7 +2845,7 @@ SC3ExpressionParser::callfunction(symbol *sym, const svalue *aImplicitThis, valu
             if (arg[argidx].dim[level]!=0 && sym->dim.array.length!=arg[argidx].dim[level])
               error(47);          /* array sizes must match */
             else if (!matchtag(arg[argidx].idxtag[level],sym->x.tags.index,TRUE))
-              error(229,sym->name);   /* index tag mismatch */
+              error(229,sym->name());   /* index tag mismatch */
             append_constval(&arrayszlst,arg[argidx].name,sym->dim.array.length,level);
           } /* if */
           /* address already in PRI */
@@ -3043,7 +3043,7 @@ static int constant(value *lval)
   tok=lex(&val,&st);
   if (tok==tSYMBOL && (sym=findconst(st,&cmptag))!=0) {
     if (cmptag>1)
-      error(91,sym->name);  /* ambiguity: multiple matching constants (different tags) */
+      error(91,sym->name());  /* ambiguity: multiple matching constants (different tags) */
     lval->constval=sym->addr();
     ldconst(lval->constval,sPRI);
     lval->ident=iCONSTEXPR;

--- a/compiler/sc4.cpp
+++ b/compiler/sc4.cpp
@@ -682,7 +682,7 @@ void ffcall(symbol *sym,const char *label,int numargs)
   assert(sym!=NULL);
   assert(sym->ident==iFUNCTN);
   if (sc_asmfile)
-    funcdisplayname(symname,sym->name);
+    funcdisplayname(symname,sym->name());
   if ((sym->usage & uNATIVE)!=0) {
     /* reserve a SYSREQ id if called for the first time */
     assert(label==NULL);
@@ -690,7 +690,7 @@ void ffcall(symbol *sym,const char *label,int numargs)
     if (sc_status==statWRITE && (sym->usage & uREAD)==0 && sym->addr()>=0)
       sym->setAddr(ntv_funcid++);
     /* Look for an alias */
-    if (lookup_alias(aliasname, sym->name)) {
+    if (lookup_alias(aliasname, sym->name())) {
       symbol *asym = findglb(aliasname);
       if (asym && asym->ident==iFUNCTN && ((sym->usage & uNATIVE) != 0)) {
         sym = asym;
@@ -710,6 +710,7 @@ void ffcall(symbol *sym,const char *label,int numargs)
     stgwrite("\n"); /* write on a separate line, to mark a sequence point for the peephole optimizer */
     code_idx+=opcodes(1)+opargs(2);
   } else {
+    const char* symname = sym->name();
     pushval(numargs);
     /* normal function */
     stgwrite("\tcall ");
@@ -717,10 +718,9 @@ void ffcall(symbol *sym,const char *label,int numargs)
       stgwrite("l.");
       stgwrite(label);
     } else {
-      stgwrite(sym->name);
+      stgwrite(symname);
     } /* if */
-    if (sc_asmfile
-        && (label!=NULL || (!isalpha(sym->name[0]) && sym->name[0]!='_'  && sym->name[0]!=sc_ctrlchar)))
+    if (sc_asmfile && (label!=NULL || (!isalpha(symname[0]) && symname[0]!='_'  && symname[0]!=sc_ctrlchar)))
     {
       stgwrite("\t; ");
       stgwrite(symname);
@@ -1313,7 +1313,7 @@ void load_glbfn(symbol *sym)
   assert(sym->ident == iFUNCTN);
   assert(!(sym->usage & uNATIVE));
   stgwrite("\tldgfn.pri ");
-  stgwrite(sym->name);
+  stgwrite(sym->name());
   stgwrite("\n");
   code_idx += opcodes(1) + opargs(1);
 

--- a/compiler/sclist.cpp
+++ b/compiler/sclist.cpp
@@ -30,6 +30,7 @@
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>
+#include <inttypes.h>
 #include "sc.h"
 #include "lstring.h"
 
@@ -459,20 +460,6 @@ void delete_autolisttable(void)
 
 /* ----- debug information --------------------------------------- */
 
-/* These macros are adapted from LibDGG libdgg-int64.h, see
- * http://www.dennougedougakkai-ndd.org/pub/libdgg/
- */
-#if defined(__STDC_VERSION__) && __STDC_VERSION__>=199901L
-  #define __STDC_FORMAT_MACROS
-  #define __STDC_CONSTANT_MACROS
-  #include <inttypes.h>         /* automatically includes stdint.h */
-#elif (defined _MSC_VER || defined __BORLANDC__) && (defined _I64_MAX || defined HAVE_I64)
-  #define PRId64 "I64d"
-  #define PRIx64 "I64x"
-#else
-  #define PRId64 "lld"
-  #define PRIx64 "llx"
-#endif
 #define PRIdC  "d"
 #define PRIxC  "x"
 
@@ -509,7 +496,7 @@ stringlist *insert_dbgsymbol(symbol *sym)
     char string[2*sNAMEMAX+128];
     char symname[2*sNAMEMAX+16];
 
-    funcdisplayname(symname,sym->name);
+    funcdisplayname(symname,sym->name());
     /* address tag:name codestart codeend ident vclass [tag:dim ...] */
     assert(sym->ident != iFUNCTN);
     sprintf(string,"S:%" PRIxC " %x:%s %" PRIxC " %" PRIxC " %x %x %x",

--- a/compiler/sctracker.cpp
+++ b/compiler/sctracker.cpp
@@ -173,7 +173,7 @@ funcenum_t *funcenum_for_symbol(symbol *sym)
   }
 
   char name[METHOD_NAMEMAX+1];
-  UTIL_Format(name, sizeof(name), "::ft:%s:%d:%d", sym->name, sym->addr(), sym->codeaddr);
+  UTIL_Format(name, sizeof(name), "::ft:%s:%d:%d", sym->name(), sym->addr(), sym->codeaddr);
 
   funcenum_t *fe = funcenums_add(name);
   functags_add(fe, &ft);

--- a/compiler/sp_symhash.cpp
+++ b/compiler/sp_symhash.cpp
@@ -8,14 +8,14 @@
 
 struct NameAndScope
 {
-  const char *name;
+  sp::Atom* name;
   int fnumber;
   int *cmptag;
   mutable symbol *matched;
   mutable int count;
 
   NameAndScope(const char *name, int fnumber, int *cmptag)
-   : name(name),
+   : name(gAtoms.add(name)),
      fnumber(fnumber),
      cmptag(cmptag),
      matched(nullptr),
@@ -33,10 +33,10 @@ struct SymbolHashPolicy
   // so, we can't be that accurate, since we might match the right symbol
   // very early.
   static uint32_t hash(const NameAndScope &key) {
-    return ke::HashCharSequence(key.name, strlen(key.name));
+    return ke::HashPointer(key.name);
   }
   static uint32_t hash(const symbol *s) {
-    return ke::HashCharSequence(s->name, strlen(s->name));
+    return ke::HashPointer(s->nameAtom());
   }
 
   static bool matches(const NameAndScope &key, symbol *sym) {
@@ -44,7 +44,7 @@ struct SymbolHashPolicy
       return false;
     if (sym->fnumber >= 0 && sym->fnumber != key.fnumber)
       return false;
-    if (strcmp(key.name, sym->name) != 0)
+    if (key.name != sym->nameAtom())
       return false;
     if (key.cmptag) {
       key.count++;


### PR DESCRIPTION
Currently symbol names are stored as an inline buffer and a cached hash value. This is unnecessary
given we have a string pool, so let's use that instead. This also helps toward relaxing the restriction
on name lengths.