### PR TITLE
Remove some stuff from symbol.

### DIFF
--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -132,7 +132,6 @@ struct symbol {
       int index;        /* array & enum: tag of array indices or the enum item */
       int field;        /* enumeration fields, where a size is attached to the field */
     } tags;             /* extra tags */
-    constvalue *lib;    /* native function: library it is part of */
     long stacksize;     /* normal/public function: stack requirements */
   } x;                  /* 'x' for 'extra' */
   union {
@@ -877,7 +876,6 @@ extern cell *litq;          /* the literal queue */
 extern unsigned char pline[]; /* the line read from the input file */
 extern const unsigned char *lptr;/* points to the current position in "pline" */
 extern constvalue libname_tab;/* library table (#pragma library "..." syntax) */
-extern constvalue *curlibrary;/* current library */
 extern int pc_addlibtable;  /* is the library table added to the AMX file? */
 extern symbol *curfunc;     /* pointer to current function */
 extern char *inpfname;      /* name of the file currently read from */

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -127,7 +127,6 @@ struct symbol {
   int compound;         /* compound level (braces nesting level) */
   int tag;              /* tagname id */
   union {
-    int declared;       /* label: how many local variables are declared */
     struct {
       int index;        /* array & enum: tag of array indices or the enum item */
       int field;        /* enumeration fields, where a size is attached to the field */

--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -695,7 +695,6 @@ static void initglobals(void)
 
   pline[0]='\0';        /* the line read from the input file */
   lptr=NULL;            /* points to the current position in "pline" */
-  curlibrary=NULL;      /* current library */
   inpf_org=NULL;        /* main source file */
 
   wqptr=wq;             /* initialize while queue pointer */
@@ -4081,8 +4080,6 @@ symbol *fetchfunc(char *name)
     assert(sym!=NULL);          /* fatal error 103 must be given on error */
     /* assume no arguments */
     sym->dim.arglist=(arginfo*)calloc(1, sizeof(arginfo));
-    /* set library ID to NULL (only for native functions) */
-    sym->x.lib=NULL;
     /* set the required stack size to zero (only for non-native functions) */
     sym->x.stacksize=1;         /* 1 for PROC opcode */
   } /* if */
@@ -4406,7 +4403,6 @@ static symbol *funcstub(int tokid, declinfo_t *decl, const int *thistag)
 
   if (fnative) {
     sym->usage=(char)(uNATIVE | uRETVALUE | uDEFINE | (sym->usage & uPROTOTYPED));
-    sym->x.lib=curlibrary;
   } else if (fpublic) {
     sym->usage|=uPUBLIC;
   } /* if */
@@ -5169,8 +5165,6 @@ static void destructsymbols(symbol *root,int level)
         ffcall(opsym,NULL,2);
         if (sc_status!=statSKIP)
           markusage(opsym,uREAD);   /* do not mark as "used" when this call itself is skipped */
-        if ((opsym->usage & uNATIVE)!=0 && opsym->x.lib!=NULL)
-          opsym->x.lib->value += 1; /* increment "usage count" of the library */
       } /* if */
     } /* if */
     sym=sym->next;

--- a/compiler/sc2.cpp
+++ b/compiler/sc2.cpp
@@ -171,7 +171,6 @@ int plungequalifiedfile(char *name)
   }
   PUSHSTK_P(inpf);
   PUSHSTK_P(inpfname);          /* pointer to current file name */
-  PUSHSTK_P(curlibrary);
   PUSHSTK_I(iflevel);
   assert(!SKIPPING);
   assert(skiplevel==iflevel);   /* these two are always the same when "parsing" */
@@ -337,7 +336,6 @@ static void readline(unsigned char *line)
       iflevel=(short)POPSTK_I();
       skiplevel=iflevel;        /* this condition held before including the file */
       assert(!SKIPPING);        /* idem ditto */
-      curlibrary=(constvalue *)POPSTK_P();
       free(inpfname);           /* return memory allocated for the include file name */
       inpfname=(char *)POPSTK_P();
       inpf=POPSTK_P();

--- a/compiler/sc3.cpp
+++ b/compiler/sc3.cpp
@@ -221,8 +221,6 @@ int check_userop(void (*oper)(void),int tag1,int tag2,int numparam,
   ffcall(sym,NULL,paramspassed);
   if (sc_status!=statSKIP)
     markusage(sym,uREAD);       /* do not mark as "used" when this call itself is skipped */
-  if ((sym->usage & uNATIVE)!=0 && sym->x.lib!=NULL)
-    sym->x.lib->value += 1;     /* increment "usage count" of the library */
   sideeffect=TRUE;              /* assume functions carry out a side-effect */
   assert(resulttag!=NULL);
   *resulttag=sym->tag;          /* save tag of the called function */
@@ -2944,8 +2942,6 @@ SC3ExpressionParser::callfunction(symbol *sym, const svalue *aImplicitThis, valu
   ffcall(sym,NULL,nargs);
   if (sc_status!=statSKIP)
     markusage(sym,uREAD);       /* do not mark as "used" when this call itself is skipped */
-  if ((sym->usage & uNATIVE)!=0 &&sym->x.lib!=NULL)
-    sym->x.lib->value += 1;     /* increment "usage count" of the library */
   if (symret!=NULL)
     popreg(sPRI);               /* pop hidden parameter as function result */
   sideeffect=TRUE;              /* assume functions carry out a side-effect */


### PR DESCRIPTION
This is not used in SourceMod, and SMX does not have a library table.