### PR TITLE
Factor out function-specific fields from symbol.

### DIFF
--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -134,9 +134,12 @@ class FunctionData : public SymbolData {
   ~FunctionData();
   virtual FunctionData* asFunction() { return this; }
 
+  void resizeArgs(size_t nargs);
+
   long stacksize;       /* label: how many local variables are declared */
   int funcid;           /* set for functions during codegen */
   stringlist *dbgstrs;  /* debug strings - functions only */
+  ke::Vector<arginfo> args;
 };
 
 /*  Symbol table format
@@ -171,7 +174,6 @@ struct symbol {
     } tags;             /* extra tags */
   } x;                  /* 'x' for 'extra' */
   union {
-    arginfo *arglist;   /* types of all parameters for functions */
     constvalue *enumlist;/* list of names for the "root" of an enumeration */
     struct {
       cell length;      /* arrays: length (size) */

--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -1756,8 +1756,8 @@ static void declloc(int tokid)
       markstack(MEMUSE_STATIC, type->size);
       assert(curfunc!=NULL);
       assert((curfunc->usage & uNATIVE)==0);
-      if (curfunc->x.stacksize<declared+1)
-        curfunc->x.stacksize=declared+1;  /* +1 for PROC opcode */
+      if (curfunc->function()->stacksize<declared+1)
+        curfunc->function()->stacksize=declared+1;  /* +1 for PROC opcode */
     } else if (type->ident == iREFARRAY) {
       // Generate the symbol so we can access its stack address during initialization.
       declared+=1; /* one cell for address */
@@ -1846,8 +1846,8 @@ static void declloc(int tokid)
       markheap(MEMUSE_DYNAMIC, 0);
       markstack(MEMUSE_STATIC, 1);
       assert(curfunc != NULL && ((curfunc->usage & uNATIVE) == 0));
-      if (curfunc->x.stacksize<declared+1)
-        curfunc->x.stacksize=declared+1;  /* +1 for PROC opcode */
+      if (curfunc->function()->stacksize<declared+1)
+        curfunc->function()->stacksize=declared+1;  /* +1 for PROC opcode */
     } /* if */
     /* now that we have reserved memory for the variable, we can proceed
      * to initialize it */
@@ -4081,7 +4081,7 @@ symbol *fetchfunc(char *name)
     /* assume no arguments */
     sym->dim.arglist=(arginfo*)calloc(1, sizeof(arginfo));
     /* set the required stack size to zero (only for non-native functions) */
-    sym->x.stacksize=1;         /* 1 for PROC opcode */
+    sym->function()->stacksize=1;         /* 1 for PROC opcode */
   } /* if */
   if (pc_deprecate!=NULL) {
     assert(sym!=NULL);

--- a/compiler/sc2.cpp
+++ b/compiler/sc2.cpp
@@ -2957,6 +2957,21 @@ symbol *finddepend(const symbol *parent)
   return sym;
 }
 
+FunctionData::FunctionData()
+ : stacksize(0),
+   funcid(0),
+   dbgstrs(nullptr)
+{
+}
+
+FunctionData::~FunctionData()
+{
+  if (dbgstrs) {
+    delete_stringtable(dbgstrs);
+    free(dbgstrs);
+  }
+}
+
 symbol::symbol()
  : symbol("", 0, 0, 0, 0, 0)
 {
@@ -2976,13 +2991,13 @@ symbol::symbol(const char* symname, cell symaddr, int symident, int symvclass, i
    lnumber(fline),
    documentation(nullptr),
    methodmap(nullptr),
-   funcid(0),
-   dbgstrs(nullptr),
    addr_(symaddr),
    name_(nullptr)
 {
   if (symname)
     name_ = gAtoms.add(symname);
+  if (symident == iFUNCTN)
+    data_.assign(new FunctionData);
   memset(&x, 0, sizeof(x));
   memset(&dim, 0, sizeof(dim));
 }
@@ -3012,10 +3027,6 @@ symbol::~symbol()
   } /* if */
   if (documentation!=NULL)
     free(documentation);
-  if (dbgstrs) {
-    delete_stringtable(dbgstrs);
-    free(dbgstrs);
-  }
 }
 
 /*  addsym

--- a/compiler/sc2.cpp
+++ b/compiler/sc2.cpp
@@ -2962,6 +2962,7 @@ FunctionData::FunctionData()
    funcid(0),
    dbgstrs(nullptr)
 {
+  resizeArgs(0);
 }
 
 FunctionData::~FunctionData()
@@ -2970,6 +2971,16 @@ FunctionData::~FunctionData()
     delete_stringtable(dbgstrs);
     free(dbgstrs);
   }
+}
+
+void
+FunctionData::resizeArgs(size_t nargs)
+{
+  arginfo null_arg;
+  memset(&null_arg, 0, sizeof(null_arg));
+
+  args.resize(nargs);
+  args.append(null_arg);
 }
 
 symbol::symbol()
@@ -3013,12 +3024,10 @@ symbol::~symbol()
   if (ident==iFUNCTN) {
     /* run through the argument list; "default array" arguments
      * must be freed explicitly; the tag list must also be freed */
-    assert(dim.arglist!=NULL);
-    for (arginfo* arg=dim.arglist; arg->ident!=0; arg++) {
+    for (arginfo* arg=&function()->args[0]; arg->ident!=0; arg++) {
       if (arg->ident==iREFARRAY && arg->hasdefault)
         free(arg->defvalue.array.data);
     } /* for */
-    free(dim.arglist);
   } else if (ident==iCONSTEXPR && (usage & uENUMROOT)==uENUMROOT) {
     /* free the constant list of an enum root */
     assert(dim.enumlist!=NULL);

--- a/compiler/sc3.cpp
+++ b/compiler/sc3.cpp
@@ -2959,8 +2959,8 @@ SC3ExpressionParser::callfunction(symbol *sym, const svalue *aImplicitThis, valu
       totalsize++;                    /* add "call" opcode */
     totalsize+=sCallStackUsage;
     if (curfunc != NULL) {
-      if (curfunc->x.stacksize<totalsize)
-        curfunc->x.stacksize=totalsize;
+      if (curfunc->function()->stacksize<totalsize)
+        curfunc->function()->stacksize=totalsize;
     } else {
       error(10);
     }

--- a/compiler/sc3.cpp
+++ b/compiler/sc3.cpp
@@ -2588,7 +2588,7 @@ SC3ExpressionParser::callfunction(symbol *sym, const svalue *aImplicitThis, valu
   args.prepare();
 
   /* run through the arguments */
-  arg=sym->dim.arglist;
+  arg=&sym->function()->args[0];
   assert(arg!=NULL);
   stgmark(sSTARTREORDER);
   memset(arglist,ARG_UNHANDLED,sizeof arglist);

--- a/compiler/sc6.cpp
+++ b/compiler/sc6.cpp
@@ -990,7 +990,7 @@ RttiBuilder::encode_signature(symbol* sym)
 
   uint32_t argc = 0;
   bool is_variadic = false;
-  for (arginfo* arg = sym->dim.arglist; arg->ident; arg++) {
+  for (arginfo* arg = &sym->function()->args[0]; arg->ident; arg++) {
     if (arg->ident == iVARARGS)
       is_variadic = true;
     argc++;
@@ -1011,7 +1011,7 @@ RttiBuilder::encode_signature(symbol* sym)
     encode_tag_into(bytes, sym->tag);
   }
 
-  for (arginfo* arg = sym->dim.arglist; arg->ident; arg++) {
+  for (arginfo* arg = &sym->function()->args[0]; arg->ident; arg++) {
     if (arg->ident == iREFERENCE)
       bytes.append(cb::kByRef);
     variable_type_t info = {

--- a/compiler/sc6.cpp
+++ b/compiler/sc6.cpp
@@ -273,12 +273,12 @@ static void do_ldgfen(CellWriter* writer, char *params, cell opcode)
   symbol *sym = extract_call_target(params);
   assert(sym->ident == iFUNCTN);
   assert(!(sym->usage & uNATIVE));
-  assert((sym->funcid & 1) == 1);
+  assert((sym->function()->funcid & 1) == 1);
 
   // Note: we emit const.pri for backward compatibility.
   assert(opcode == sp::OP_UNGEN_LDGFN_PRI);
   writer->append(sp::OP_CONST_PRI);
-  writer->append(sym->funcid);
+  writer->append(sym->function()->funcid);
 }
 
 static void do_call(CellWriter* writer, char *params, cell opcode)
@@ -895,14 +895,14 @@ RttiBuilder::add_method(symbol* sym)
   method.pcode_end = sym->codeaddr;
   method.signature = encode_signature(sym);
 
-  if (!sym->dbgstrs)
+  if (!sym->function()->dbgstrs)
     return;
 
   smx_rtti_debug_method debug;
   debug.method_index = index;
   debug.first_local = dbg_locals_->count();
 
-  for (stringlist* iter = sym->dbgstrs; iter; iter = iter->next) {
+  for (stringlist* iter = sym->function()->dbgstrs; iter; iter = iter->next) {
     if (iter->line[0] == '\0')
       continue;
 
@@ -1301,7 +1301,7 @@ static void assemble_to_buffer(SmxByteBuffer *buffer, void *fin)
     pubfunc.address = sym->addr();
     pubfunc.name = names->add(gAtoms, f.name.chars());
 
-    sym->funcid = (uint32_t(i) << 1) | 1;
+    sym->function()->funcid = (uint32_t(i) << 1) | 1;
 
     rtti.add_method(sym);
   }

--- a/compiler/sclist.cpp
+++ b/compiler/sclist.cpp
@@ -515,9 +515,9 @@ stringlist *insert_dbgsymbol(symbol *sym)
     } /* if */
 
     if (curfunc) {
-      if (!curfunc->dbgstrs)
-        curfunc->dbgstrs = (stringlist*)calloc(1, sizeof(stringlist));
-      return insert_string(curfunc->dbgstrs, string);
+      if (!curfunc->function()->dbgstrs)
+        curfunc->function()->dbgstrs = (stringlist*)calloc(1, sizeof(stringlist));
+      return insert_string(curfunc->function()->dbgstrs, string);
     }
     return insert_string(&dbgstrings, string);
   } /* if */

--- a/compiler/sctracker.cpp
+++ b/compiler/sctracker.cpp
@@ -158,17 +158,20 @@ funcenum_t *funcenum_for_symbol(symbol *sym)
   ft.usage = uPUBLIC & (sym->usage & uRETVALUE);
   ft.argcount = 0;
   ft.ommittable = FALSE;
-  for (arginfo *arg = sym->dim.arglist; arg->ident; arg++) {
+  for (arginfo& arg : sym->function()->args) {
+    if (!arg.ident)
+      break;
+
     funcarg_t *dest = &ft.args[ft.argcount++];
 
     dest->tagcount = 1;
-    dest->tags[0] = arg->tag;
+    dest->tags[0] = arg.tag;
 
-    dest->dimcount = arg->numdim;
-    memcpy(dest->dims, arg->dim, arg->numdim * sizeof(int));
+    dest->dimcount = arg.numdim;
+    memcpy(dest->dims, arg.dim, arg.numdim * sizeof(int));
 
-    dest->ident = arg->ident;
-    dest->fconst = !!(arg->usage & uCONST);
+    dest->ident = arg.ident;
+    dest->fconst = !!(arg.usage & uCONST);
     dest->ommittable = FALSE;
   }
 

--- a/compiler/sctracker.h
+++ b/compiler/sctracker.h
@@ -92,10 +92,10 @@ typedef struct methodmap_method_s
     assert(getter || setter);
     if (getter)
       return getter->tag;
-    arginfo *thisp = &setter->dim.arglist[0];
+    arginfo *thisp = &setter->function()->args[0];
     if (thisp->ident == 0)
       return pc_tag_void;
-    arginfo *valp = &setter->dim.arglist[1];
+    arginfo *valp = &setter->function()->args[1];
     if (valp->ident != iVARIABLE)
       return pc_tag_void;
     return valp->tag;


### PR DESCRIPTION
It's pretty gross to have this stuff in unions.