### PR TITLE
Fix memory leak in ControlFlowGraph.

### DIFF
--- a/vm/control-flow.cpp
+++ b/vm/control-flow.cpp
@@ -33,6 +33,7 @@ ControlFlowGraph::~ControlFlowGraph()
   while (iter != blocks_.end()) {
     Block* block = *iter;
     iter = blocks_.erase(iter);
+    block->unlink();
     block->Release();
   }
 }


### PR DESCRIPTION
Block::unlink() was never called, leading to cycles.