### PR TITLE
Fix building GCC 8

### DIFF
--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -3797,7 +3797,7 @@ static void dodelete()
  *                 | function-type-inner
  * function-type-inner ::= "function" type-expr "(" new-style-args ")"
  */
-static void parse_function_type(ke::UniquePtr<functag_t> &type)
+static void parse_function_type(const ke::UniquePtr<functag_t> &type)
 {
   int lparen = matchtoken('(');
   needtoken(tFUNCTION);

--- a/compiler/sc1.cpp
+++ b/compiler/sc1.cpp
@@ -2645,7 +2645,6 @@ static void declstruct(void)
     }
 
     structarg_t arg;
-    memset(&arg, 0, sizeof(arg));
 
     arg.tag = decl.type.tag;
     arg.dimcount = decl.type.numdim;
@@ -3798,10 +3797,8 @@ static void dodelete()
  *                 | function-type-inner
  * function-type-inner ::= "function" type-expr "(" new-style-args ")"
  */
-static void parse_function_type(functag_t *type)
+static void parse_function_type(ke::UniquePtr<functag_t> &type)
 {
-  memset(type, 0, sizeof(*type));
-
   int lparen = matchtoken('(');
   needtoken(tFUNCTION);
 
@@ -3873,9 +3870,9 @@ static void dotypedef()
 
   funcenum_t *def = funcenums_add(ident.name);
 
-  functag_t type;
-  parse_function_type(&type);
-  functags_add(def, &type);
+  auto type = ke::MakeUnique<functag_t>();
+  parse_function_type(type);
+  functags_add(def, ke::Move(type));
 }
 
 // Unsafe typeset - only supports function types. This is a transition hack for SP2.
@@ -3896,9 +3893,9 @@ static void dotypeset()
   funcenum_t *def = funcenums_add(ident.name);
   needtoken('{');
   while (!matchtoken('}')) {
-    functag_t type;
-    parse_function_type(&type);
-    functags_add(def, &type);
+    auto type = ke::MakeUnique<functag_t>();
+    parse_function_type(type);
+    functags_add(def, ke::Move(type));
   }
 
   require_newline(TRUE);

--- a/compiler/sctracker.cpp
+++ b/compiler/sctracker.cpp
@@ -102,18 +102,17 @@ funcenum_t *funcenums_add(const char *name)
 
 funcenum_t *funcenum_for_symbol(symbol *sym)
 {
-  functag_t ft;
-  memset(&ft, 0, sizeof(ft));
+  auto ft = ke::MakeUnique<functag_t>();
 
-  ft.ret_tag = sym->tag;
-  ft.usage = uPUBLIC & (sym->usage & uRETVALUE);
-  ft.argcount = 0;
-  ft.ommittable = FALSE;
+  ft->ret_tag = sym->tag;
+  ft->usage = uPUBLIC & (sym->usage & uRETVALUE);
+  ft->argcount = 0;
+  ft->ommittable = FALSE;
   for (arginfo& arg : sym->function()->args) {
     if (!arg.ident)
       break;
 
-    funcarg_t *dest = &ft.args[ft.argcount++];
+    funcarg_t *dest = &ft->args[ft->argcount++];
 
     dest->tagcount = 1;
     dest->tags[0] = arg.tag;
@@ -130,7 +129,7 @@ funcenum_t *funcenum_for_symbol(symbol *sym)
   ke::SafeSprintf(name, sizeof(name), "::ft:%s:%d:%d", sym->name(), sym->addr(), sym->codeaddr);
 
   funcenum_t *fe = funcenums_add(name);
-  functags_add(fe, &ft);
+  functags_add(fe, ke::Move(ft));
 
   return fe;
 }
@@ -149,10 +148,9 @@ functag_t *functag_find_intrinsic(int tag)
   return fe->entries.back().get();
 }
 
-functag_t *functags_add(funcenum_t *en, functag_t *src)
+functag_t *functags_add(funcenum_t *en, ke::UniquePtr<functag_t> &&src)
 {
-  auto t = ke::MakeUnique<functag_t>(*src);
-  en->entries.append(ke::Move(t));
+  en->entries.append(ke::Move(src));
   return en->entries.back().get();
 }
 

--- a/compiler/sctracker.h
+++ b/compiler/sctracker.h
@@ -153,7 +153,7 @@ structarg_t *pstructs_getarg(pstruct_t *pstruct, const char *member);
  */
 void funcenums_free();
 funcenum_t *funcenums_add(const char *name);
-functag_t *functags_add(funcenum_t *en, functag_t *src);
+functag_t *functags_add(funcenum_t *en, ke::UniquePtr<functag_t> &&src);
 funcenum_t *funcenum_for_symbol(symbol *sym);
 functag_t *functag_find_intrinsic(int tag);
 


### PR DESCRIPTION
Fixes building using gcc 8. Currently it fails due ```-Werror=class-memaccess```


> -Wclass-memaccess warns when objects of non-trivial class types are manipulated in potentially unsafe ways by raw memory functions such as ```memcpy```, or ```realloc```.
> The warning helps detect calls that bypass user-defined constructors or copy-assignment operators, corrupt virtual table pointers, data members of const-qualified types or references, or member pointers.
> The warning also detects calls that would bypass access controls to data members.

[Source](https://gcc.gnu.org/gcc-8/changes.html)