### PR TITLE
Rewrite symbol pruning.

### DIFF
--- a/compiler/assembler.h
+++ b/compiler/assembler.h
@@ -1,8 +1,5 @@
 // vim: set ts=8 sts=2 sw=2 tw=99 et:
 //
-//  Pawn compiler - Error message system
-//  In fact a very simple system, using only 'panic mode'.
-//
 //  Copyright (c) ITB CompuPhase, 1997-2006
 //
 //  This software is provided "as-is", without any express or implied warranty.

--- a/compiler/codegen.h
+++ b/compiler/codegen.h
@@ -1,8 +1,5 @@
 // vim: set ts=8 sts=2 sw=2 tw=99 et:
 //
-//  Pawn compiler - Error message system
-//  In fact a very simple system, using only 'panic mode'.
-//
 //  Copyright (c) ITB CompuPhase, 1997-2006
 //
 //  This software is provided "as-is", without any express or implied warranty.

--- a/compiler/lexer.h
+++ b/compiler/lexer.h
@@ -1,8 +1,5 @@
 // vim: set ts=8 sts=2 sw=2 tw=99 et:
 //
-//  Pawn compiler - Error message system
-//  In fact a very simple system, using only 'panic mode'.
-//
 //  Copyright (c) ITB CompuPhase, 1997-2006
 //
 //  This software is provided "as-is", without any express or implied warranty.
@@ -261,7 +258,6 @@ int ishex(char c);
 int isoctal(char c);
 void delete_symbol(symbol *root,symbol *sym);
 void delete_symbols(symbol *root,int level,int del_labels,int delete_functions);
-int refer_symbol(symbol *entry,symbol *bywhom);
 void markusage(symbol *sym,int usage);
 symbol *findglb(const char *name);
 symbol *findloc(const char *name);

--- a/compiler/libpawnc.h
+++ b/compiler/libpawnc.h
@@ -1,8 +1,5 @@
 // vim: set ts=8 sts=2 sw=2 tw=99 et:
 //
-//  Pawn compiler - Error message system
-//  In fact a very simple system, using only 'panic mode'.
-//
 //  Copyright (c) ITB CompuPhase, 1997-2006
 //
 //  This software is provided "as-is", without any express or implied warranty.

--- a/compiler/optimizer.h
+++ b/compiler/optimizer.h
@@ -1,8 +1,5 @@
 // vim: set ts=8 sts=2 sw=2 tw=99 et:
 //
-//  Pawn compiler - Error message system
-//  In fact a very simple system, using only 'panic mode'.
-//
 //  Copyright (c) ITB CompuPhase, 1997-2006
 //
 //  This software is provided "as-is", without any express or implied warranty.

--- a/compiler/sci18n.h
+++ b/compiler/sci18n.h
@@ -1,8 +1,5 @@
 // vim: set ts=8 sts=2 sw=2 tw=99 et:
 //
-//  Pawn compiler - Error message system
-//  In fact a very simple system, using only 'panic mode'.
-//
 //  Copyright (c) ITB CompuPhase, 1997-2006
 //
 //  This software is provided "as-is", without any express or implied warranty.

--- a/compiler/sclist.h
+++ b/compiler/sclist.h
@@ -1,8 +1,5 @@
 // vim: set ts=8 sts=2 sw=2 tw=99 et:
 //
-//  Pawn compiler - Error message system
-//  In fact a very simple system, using only 'panic mode'.
-//
 //  Copyright (c) ITB CompuPhase, 1997-2006
 //
 //  This software is provided "as-is", without any express or implied warranty.

--- a/compiler/scvars.h
+++ b/compiler/scvars.h
@@ -1,8 +1,5 @@
 // vim: set ts=8 sts=2 sw=2 tw=99 et:
 //
-//  Pawn compiler - Error message system
-//  In fact a very simple system, using only 'panic mode'.
-//
 //  Copyright (c) ITB CompuPhase, 1997-2006
 //
 //  This software is provided "as-is", without any express or implied warranty.


### PR DESCRIPTION
reduce_referrers tries to find unused symbols. During parsing, a simple
dependency tree is built, and this leads to a fixpoint algorithm
determining which symbols are transitively unused. Unfortunately, this
algorithm is ridiculously inefficient: it scans all global symbols
during each "sweep", and while processing each symbol, scans all global
symbols again if unused. Due to other considerations the algorithm is
essentially O(n*n*m).

This patch replaces it with a more efficient solution. This extends the
dependency graph to include backward and forward links, which means
reduce_referrers can use a simple topological sort. The new runtime is
closer to O(n). This is about a 10% improvement in compilation time.

The tricky aspect to this patch is that "symbol" is not pool-allocated
as it would be in normal compilers. And because of Pawn's weird
multi-pass parsing process, symbols are deleted, and we need to make
sure graph links are updated. The previous code took great care to do
this, and additionally to ensure that no duplicate links were added.
However, it is simpler (and faster) to just always add duplicate links,
and to clear all links in between passes (they will be rebuilt anyway).