### PR TITLE
Always parse as UTF-8.

### DIFF
--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -198,7 +198,6 @@ int plungequalifiedfile(char *name)
   PUSHSTK_I(iflevel);
   assert(!SKIPPING);
   assert(skiplevel==iflevel);   /* these two are always the same when "parsing" */
-  PUSHSTK_I(sc_is_utf8);
   PUSHSTK_I(icomment);
   PUSHSTK_I(fcurrent);
   PUSHSTK_I(fline);
@@ -215,7 +214,7 @@ int plungequalifiedfile(char *name)
   assert(sc_status==statFIRST || strcmp(get_inputfile(fcurrent), inpfname)==0);
   setfiledirect(inpfname);      /* (optionally) set in the list file */
   listline=-1;                  /* force a #line directive when changing the file */
-  sc_is_utf8=(short)scan_utf8(inpf,name);
+  skip_utf8_bom(inpf);
   return TRUE;
 }
 
@@ -356,7 +355,6 @@ static void readline(unsigned char *line)
       fline=i;
       fcurrent=(short)POPSTK_I();
       icomment=(short)POPSTK_I();
-      sc_is_utf8=(short)POPSTK_I();
       iflevel=(short)POPSTK_I();
       skiplevel=iflevel;        /* this condition held before including the file */
       assert(!SKIPPING);        /* idem ditto */
@@ -1650,7 +1648,7 @@ static int scanellipsis(const unsigned char *lptr)
     return 0;           /* quick exit: cannot read after EOF */
   if ((localbuf=(unsigned char*)malloc((sLINEMAX+1)*sizeof(unsigned char)))==NULL)
     return 0;
-  inpfmark=pc_getpossrc(inpf,inpfmark);
+  inpfmark=pc_getpossrc(inpf);
   localcomment=icomment;
 
   found=0;
@@ -2758,17 +2756,13 @@ static cell litchar(const unsigned char **lptr,int flags)
 
   cptr=*lptr;
   if ((flags & RAWMODE)!=0 || *cptr!=sc_ctrlchar) {  /* no escape character */
-    #if !defined NO_UTF8
-      if (sc_is_utf8 && (flags & UTF8MODE)!=0) {
+      if ((flags & UTF8MODE)!=0) {
         c=get_utf8_char(cptr,&cptr);
         assert(c>=0);   /* file was already scanned for conformance to UTF-8 */
       } else {
-    #endif
         c=*cptr;
         cptr+=1;
-    #if !defined NO_UTF8
       } /* if */
-    #endif
   } else {
     cptr+=1;
     if (*cptr==sc_ctrlchar) {

--- a/compiler/libpawnc.cpp
+++ b/compiler/libpawnc.cpp
@@ -247,7 +247,7 @@ int pc_writesrc(void *handle,unsigned char *source)
   return 0;
 }
 
-void *pc_getpossrc(void *handle,void *position)
+void *pc_getpossrc(void *handle)
 {
   src_file_t *src = (src_file_t *)handle;
 

--- a/compiler/libpawnc.h
+++ b/compiler/libpawnc.h
@@ -24,7 +24,7 @@ void *pc_createsrc(char *filename);
 void pc_closesrc(void *handle);   /* never delete */
 char *pc_readsrc(void *handle,unsigned char *target,int maxchars);
 int pc_writesrc(void *handle,unsigned char *source);
-void *pc_getpossrc(void *handle,void *position); /* mark the current position */
+void *pc_getpossrc(void *handle);
 void pc_resetsrc(void *handle,void *position);  /* reset to a position marked earlier */
 int  pc_eofsrc(void *handle);
 

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -90,6 +90,7 @@
 #include "assembler.h"
 #include "expressions.h"
 #include "libpawnc.h"
+#include "sci18n.h"
 #define VERSION_STR "3.2.3636"
 #define VERSION_INT 0x0302
 
@@ -308,6 +309,7 @@ int pc_compile(int argc, char *argv[])
       pc_writesrc(ftmp,(unsigned char*)"#file \"");
       pc_writesrc(ftmp,(unsigned char*)sname);
       pc_writesrc(ftmp,(unsigned char*)"\"\n");
+      skip_utf8_bom(fsrc);
       while (!pc_eofsrc(fsrc) && pc_readsrc(fsrc,tstring,sizeof tstring)) {
         pc_writesrc(ftmp,tstring);
       } /* while */
@@ -323,6 +325,7 @@ int pc_compile(int argc, char *argv[])
   inpf_org=pc_opensrc(inpfname);
   if (inpf_org==NULL)
     error(FATAL_ERROR_READ,inpfname);
+  skip_utf8_bom(inpf_org);
   freading=TRUE;
   outf=(FILE*)pc_openasm(outfname); /* first write to assembler file (may be temporary) */
   if (outf==NULL)
@@ -349,7 +352,7 @@ int pc_compile(int argc, char *argv[])
   } /* if */
   /* do the first pass through the file (or possibly two or more "first passes") */
   sc_parsenum=0;
-  inpfmark=pc_getpossrc(inpf_org,NULL);
+  inpfmark=pc_getpossrc(inpf_org);
   do {
     /* reset "defined" flag of all functions and global variables */
     reduce_referrers(&glbtab);

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -188,7 +188,6 @@ static int lastst     = 0;      /* last executed statement type */
 static int nestlevel  = 0;      /* number of active (open) compound statements */
 static int endlessloop= 0;      /* nesting level of endless loop */
 static int rettype    = 0;      /* the type that a "return" expression should have */
-static int skipinput  = 0;      /* number of lines to skip from the first input file */
 static int verbosity  = 1;      /* verbosity level, 0=quiet, 1=normal, 2=verbose */
 static int sc_reparse = 0;      /* needs 3th parse because of changed prototypes? */
 static int sc_parsenum = 0;     /* number of the extra parses */
@@ -218,7 +217,7 @@ int pc_compile(int argc, char *argv[])
   );
 #endif
 
-  int entry,i,jmpcode;
+  int entry,jmpcode;
   int retcode;
   char incfname[_MAX_PATH];
   void *inpfmark;
@@ -331,10 +330,6 @@ int pc_compile(int argc, char *argv[])
   if (outf==NULL)
     error(FATAL_ERROR_WRITE,outfname);
   setconstants();               /* set predefined constants and tagnames */
-  for (i=0; i<skipinput; i++)   /* skip lines in the input file */
-    if (pc_readsrc(inpf_org,pline,sLINEMAX)!=NULL)
-      fline++;                  /* keep line number up to date */
-  skipinput=fline;
   sc_status=statFIRST;
   /* write starting options (from the command line or the configuration file) */
   if (sc_listing) {
@@ -377,7 +372,6 @@ int pc_compile(int argc, char *argv[])
     inpf=inpf_org;
     freading=TRUE;
     pc_resetsrc(inpf,inpfmark); /* reset file position */
-    fline=skipinput;            /* reset line number */
     sc_reparse=FALSE;           /* assume no extra passes */
     sc_status=statFIRST;        /* resetglobals() resets it to IDLE */
 
@@ -431,7 +425,6 @@ int pc_compile(int argc, char *argv[])
   inpf=inpf_org;
   freading=TRUE;
   pc_resetsrc(inpf,inpfmark);   /* reset file position */
-  fline=skipinput;              /* reset line number */
   lexinit();                    /* clear internal flags of lex() */
   sc_status=statWRITE;          /* allow to write --this variable was reset by resetglobals() */
   writeleader(&glbtab);
@@ -677,7 +670,6 @@ static void initglobals(void)
 
   sc_asmfile=FALSE;     /* do not create .ASM file */
   sc_listing=FALSE;     /* do not create .LST file */
-  skipinput=0;          /* number of lines to skip from the first input file */
   sc_ctrlchar=CTRL_CHAR;/* the escape character */
   litmax=sDEF_LITMAX;   /* current size of the literal table */
   errnum=0;             /* number of errors */
@@ -858,9 +850,6 @@ static void parseoptions(int argc,char **argv,char *oname,char *ename,char *pnam
         break;
       case 'p':
         strlcpy(pname,option_value(ptr,argv,argc,&arg),_MAX_PATH); /* set name of implicit include file */
-        break;
-      case 's':
-        skipinput=atoi(option_value(ptr,argv,argc,&arg));
         break;
       case 't':
         sc_tabsize=atoi(option_value(ptr,argv,argc,&arg));
@@ -1119,7 +1108,6 @@ static void about(void)
 #endif
     pc_printf("             2    full optimizations\n");
     pc_printf("         -p<name> set name of \"prefix\" file\n");
-    pc_printf("         -s<num>  skip lines from the input file\n");
     pc_printf("         -t<num>  TAB indent size (in character positions, default=%d)\n",sc_tabsize);
     pc_printf("         -v<num>  verbosity level; 0=quiet, 1=normal, 2=verbose (default=%d)\n",verbosity);
     pc_printf("         -w<num>  disable a specific warning by its number\n");

--- a/compiler/sci18n.h
+++ b/compiler/sci18n.h
@@ -20,4 +20,4 @@
 #pragma once
 
 cell get_utf8_char(const unsigned char *string,const unsigned char **endptr);
-int scan_utf8(void *fp,const char *filename);
+void skip_utf8_bom(void *fp);

--- a/compiler/scvars.h
+++ b/compiler/scvars.h
@@ -72,7 +72,6 @@ extern int sc_status;       /* read/write status */
 extern int sc_err_status;   /* TRUE if errors should be generated even if sc_status = SKIP */
 extern int sc_rationaltag;  /* tag for rational numbers */
 extern int rational_digits; /* number of fractional digits */
-extern short sc_is_utf8;    /* is this source file in UTF-8 encoding */
 extern char *pc_deprecate;  /* if non-NULL, mark next declaration as deprecated */
 extern int pc_optimize;     /* (peephole) optimization level */
 extern int pc_memflags;     /* special flags for the stack/heap usage */

--- a/tests/compile-only/ok-byte-order-mark.sp
+++ b/tests/compile-only/ok-byte-order-mark.sp
@@ -1,0 +1,2 @@
+﻿public main() {
+}


### PR DESCRIPTION
This is a ~13% compile time improvement on SourceMod plugins.

Mysteriously, it wasn't enough to parse three times: the compiler
also pre-scans the entire text of source/include files to determine
if each uses UTF-8. This is particularly mysterious as the result
of pre-scanning for UTF-8 is that it will allow parsing more UTF-8
characters. Why bother scanning in the first place?

One reason is to remove the byte order mark (BOM), which this patch
retains by scanning the first three bytes. Otherwise, it seems this code
can be removed. It's possible upstream had more dependent logic and we
removed it long ago.