### PR TITLE
Add a -z compression level argument.

### DIFF
--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -874,6 +874,9 @@ static void parseoptions(int argc,char **argv,char *oname,char *ename,char *pnam
             exit(1);
         }
         break;
+      case 'z':
+        sc_compression_level=atoi(option_value(ptr,argv,argc,&arg));
+        break;
       case '\\':                /* use \ instead for escape characters */
         sc_ctrlchar='\\';
         break;
@@ -1091,6 +1094,7 @@ static void about(void)
     pc_printf("         -t<num>  TAB indent size (in character positions, default=%d)\n",sc_tabsize);
     pc_printf("         -v<num>  verbosity level; 0=quiet, 1=normal, 2=verbose (default=%d)\n",verbosity);
     pc_printf("         -w<num>  disable a specific warning by its number\n");
+    pc_printf("         -z<num>  compression level, default=9 (0=none, 1=worst, 9=best)\n");
     pc_printf("         -E       treat warnings as errors\n");
     pc_printf("         -\\       use '\\' for escape characters\n");
     pc_printf("         -^       use '^' for escape characters\n");

--- a/compiler/scvars.cpp
+++ b/compiler/scvars.cpp
@@ -90,6 +90,7 @@ int pc_memflags=0;      /* special flags for the stack/heap usage */
 int sc_showincludes=0;  /* show include files */
 int sc_require_newdecls=0; /* Require new-style declarations */
 bool sc_warnings_are_errors=false;
+int sc_compression_level=9;
 
 void *inpf    = NULL;   /* file read from (source or include) */
 void *inpf_org= NULL;   /* main source file */

--- a/compiler/scvars.h
+++ b/compiler/scvars.h
@@ -88,6 +88,7 @@ extern int sc_require_newdecls; /* only newdecls are allowed */
 extern bool sc_warnings_are_errors;
 extern unsigned sc_total_errors;
 extern int pc_code_version; /* override the code version */
+extern int sc_compression_level;
 
 extern void *inpf;          /* file read from (source or include) */
 extern void *inpf_org;      /* main source file */

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -415,6 +415,7 @@ class TestRunner(object):
 
     argv += mode['spcomp']['args']
     argv += mode['args']
+    argv += ['-z', '1'] # Fast compilation for tests.
     if test.warnings_are_errors:
       argv += ['-E']
     if mode['spcomp']['name'] == 'spcomp2':


### PR DESCRIPTION
Compression slows compilation down a lot when running tests. Compression
is very, very good on SourceMod plugins even at zlib's lowest
compression level, probably since the code and data sections are mostly
zeroes. But we keep the default at 9, and specify -z 1 for tests.