### PR TITLE
Remove value::arrayidx.

### DIFF
--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -331,7 +331,6 @@ struct value {
   char ident;           /* iCONSTEXPR, iVARIABLE, iARRAY, iARRAYCELL,
                          * iEXPRESSION or iREFERENCE */
   char boolresult;      /* boolean result for relational operators */
-  cell *arrayidx;       /* last used array indices, for checking self assignment */
 
   // Returns whether the value can be rematerialized based on static
   // information, or whether it is the result of an expression.


### PR DESCRIPTION
This is parsing state and has nothing to do with values. It was also
ridiculously complicated for the sole purpose of an obscure warning around
a specific type of self-assignment, a[y] = a[y]. Note that |a = a| does
have a warning, but only if |a| is scalar.