### PR TITLE
Fix a bug where returning an indeterminate array would assert.

### DIFF
--- a/compiler/expressions.cpp
+++ b/compiler/expressions.cpp
@@ -2500,7 +2500,7 @@ SC3ExpressionParser::callfunction(symbol *sym, const svalue *aImplicitThis, valu
      * reserved memory block as a hidden parameter
      */
     retsize=(int)array_totalsize(symret);
-    assert(retsize>0);
+    assert(retsize>0 || !cc_ok());
     modheap(retsize*sizeof(cell));/* address is in ALT */
     pushreg(sALT);                /* pass ALT as the last (hidden) parameter */
     markheap(MEMUSE_STATIC, retsize);

--- a/compiler/messages.h
+++ b/compiler/messages.h
@@ -152,7 +152,7 @@ static const char *errmsg[] = {
 /*125*/  "expected \"native\", \"get\", or \"set\"\n",
 /*126*/  "%s for %s already exists\n",
 /*127*/  "property getters cannot accept extra arguments\n",
-/*128*/  "unused128\n",
+/*128*/  "cannot return an array of indeterminate length\n",
 /*129*/  "cannot mix methodmaps and classes with inheritance\n",
 /*130*/  "cannot coerce functions to values\n",
 /*131*/  "cannot coerce object type %s to non-object type %s\n",

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -6088,6 +6088,8 @@ static void doreturn(void)
                */
             } /* if */
           } /* for */
+          if (!sub->dim.array.length)
+            error(128);
         } /* if */
       } else {
         int idxtag[sDIMEN_MAX];
@@ -6109,6 +6111,8 @@ static void doreturn(void)
           if (dim[numdim]<=0)
             error(46,sym->name());
         } /* for */
+        if (!sub->dim.array.length)
+          error(128);
         if (sym->tag==pc_tag_string && numdim!=0)
           slength=dim[numdim-1];
         /* the address of the array is stored in a hidden parameter; the address

--- a/tests/compile-only/fail-return-indeterminate-array.sp
+++ b/tests/compile-only/fail-return-indeterminate-array.sp
@@ -1,0 +1,12 @@
+native void PrintToServer(const char[] fmt, any:...);
+
+stock String:Workaround(val)
+{
+  char sNames[][] = {"Humans", "Zombies", "Egg"};
+  return sNames[val];
+}
+
+public OnPluginStart()
+{
+  PrintToServer("Good: %s", Workaround(1));
+}

--- a/tests/compile-only/fail-return-indeterminate-array.txt
+++ b/tests/compile-only/fail-return-indeterminate-array.txt
@@ -1,0 +1,1 @@
+(6) : error 128: cannot return an array of indeterminate length


### PR DESCRIPTION
This bug was reported by KyleS.