### PR TITLE
Disallow reference tokens on enum struct parameters.

### DIFF
--- a/compiler/messages.h
+++ b/compiler/messages.h
@@ -160,7 +160,7 @@ static const char *errmsg[] = {
 /*133*/  "cannot coerce unrelated object types %s and %s\n",
 /*134*/  "type mismatch (%s and %s)\n",
 /*135*/  "cannot use enum struct type \"%s\" in natives\n",
-/*136*/  "unused136\n",
+/*136*/  "reference is redundant, enum struct types are array-like\n",
 /*137*/  "cannot mix reference and array types\n",
 /*138*/  "const was specified twice\n",
 /*139*/  "could not find type \"%s\"\n",

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -2786,7 +2786,10 @@ static int parse_new_typeexpr(typeinfo_t *type, const token_t *first, int flags)
         error(137);
         return FALSE;
       }
-      type->ident = iREFERENCE;
+      if (gTypes.find(type->semantic_tag())->isEnumStruct())
+        error(136);
+      else
+        type->ident = iREFERENCE;
     }
   }
 

--- a/tests/compile-only/fail-duplicate-enum-struct-field.sp
+++ b/tests/compile-only/fail-duplicate-enum-struct-field.sp
@@ -1,0 +1,11 @@
+#include <shell>
+
+enum struct Point {
+  int x;
+  int y;
+  int y;
+};
+
+public main()
+{
+}

--- a/tests/compile-only/fail-duplicate-enum-struct-field.txt
+++ b/tests/compile-only/fail-duplicate-enum-struct-field.txt
@@ -1,0 +1,1 @@
+(6) : error 103: y was already defined on this enum struct

--- a/tests/compile-only/fail-enum-struct-reference.sp
+++ b/tests/compile-only/fail-enum-struct-reference.sp
@@ -1,0 +1,15 @@
+#include <shell>
+
+enum struct Point {
+  int x;
+};
+
+void Crab(Point& p) {
+  p.x = 10;
+}
+
+public main()
+{
+  Point p;
+  Crab(p);
+}

--- a/tests/compile-only/fail-enum-struct-reference.txt
+++ b/tests/compile-only/fail-enum-struct-reference.txt
@@ -1,0 +1,1 @@
+(7) : error 136: reference is redundant, enum struct types are array-like


### PR DESCRIPTION
This essentially guarantees that future struct implementations will have
pass-by-reference semantics. The alternative would be requiring a
reference token for enum structs, and then leaving the door open for
pass-by-value semantics later. However, there do not seem to be many use
cases for pass-by-value that could not be solved in other ways. And this
implementation matches how arrays and methodmaps are already used.