### PR TITLE
Fix wrong debug codestart of struct variables

### DIFF
--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -1389,6 +1389,8 @@ static void declstructvar(char *firstname,int fpublic, pstruct_t *pstruct)
   }
   if (!mysym)
     mysym=addsym(name->chars(), 0, iVARIABLE, sGLOBAL, pc_addtag(pstruct->name), usage);
+  else
+    mysym->codeaddr = code_idx;
 
   if (!matchtoken('=')) {
     matchtoken(';');


### PR DESCRIPTION
The compiler rewrites the definition address of all variables in the write phase. That second phase uses previous usage knowledge to exclude unused functions, making the binary smaller.

Struct variables are handled in a seperate `declstructvar` function which missed that write pass fixup.

Set the definition address of struct variables in the write pass es well.

Fixes #308