### PR TITLE
SmxTools: Fix line and locals lookup of rtti symbols

### DIFF
--- a/tools/smxtools/smxdasm/Rtti.cs
+++ b/tools/smxtools/smxdasm/Rtti.cs
@@ -313,7 +313,6 @@ namespace smxdasm
     public struct RttiNative
     {
         public string name;
-        public int pcode_offset;
         public int signature;
     }
 

--- a/tools/smxtools/smxdasm/Sections.cs
+++ b/tools/smxtools/smxdasm/Sections.cs
@@ -566,7 +566,7 @@ namespace smxdasm
         public DebugVarEntry FindLocal(int codeaddr, int address)
         {
             int start_at = 0;
-            int stop_at = smx_file_.DebugMethods.Entries.Length;
+            int stop_at = Entries.Length;
             if (smx_file_.DebugMethods != null && smx_file_.RttiMethods != null)
             {
                 int? index = null;
@@ -599,7 +599,7 @@ namespace smxdasm
                     return sym;
                 if (i == stop_at - 1)
                     break;
-                var next_sym = Entries[stop_at + 1];
+                var next_sym = Entries[i + 1];
                 if (address > sym.address && address < next_sym.address)
                     return sym;
             }

--- a/tools/smxtools/smxviewer/MainWindow.cs
+++ b/tools/smxtools/smxviewer/MainWindow.cs
@@ -364,6 +364,7 @@ namespace smxviewer
                 {
                     addDetailLine("0x{0:x6}: {1}", i, current.ToString());
                     current.Clear();
+                    continue;
                 }
 
                 if (b < 0x20 || b > 0x7f)
@@ -732,7 +733,7 @@ namespace smxviewer
 
             uint? line = null;
             if (file_.DebugLines != null)
-                line = file_.DebugLines.FindLine((uint)sym.code_end);
+                line = file_.DebugLines.FindLine((uint)sym.code_start);
             if (line != null)
                 addDetailLine("line: \"{0}\"", (uint)line);
 


### PR DESCRIPTION
The displayed line was looked up from the address of the end of the scope of the variable instead of where it's first declared.

`SmxDebugLocals::FindLocal` used the `.dbg.methods` before checking for null and didn't look for array variables correctly.