### PR TITLE
Disallow references on indeterminate array arguments.

### DIFF
--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -2785,11 +2785,9 @@ static int parse_new_typeexpr(typeinfo_t *type, const token_t *first, int flags)
 
   if (flags & DECLFLAG_ARGUMENT) {
     if (matchtoken('&')) {
-      if (type->ident == iARRAY) {
+      if (type->ident == iARRAY || type->ident == iREFARRAY)
         error(137);
-        return FALSE;
-      }
-      if (gTypes.find(type->semantic_tag())->isEnumStruct())
+      else if (gTypes.find(type->semantic_tag())->isEnumStruct())
         error(136);
       else
         type->ident = iREFERENCE;

--- a/tests/compile-only/fail-ref-arg-with-array-type.sp
+++ b/tests/compile-only/fail-ref-arg-with-array-type.sp
@@ -1,0 +1,3 @@
+public void foo(int[]& ...)
+{
+}

--- a/tests/compile-only/fail-ref-arg-with-array-type.txt
+++ b/tests/compile-only/fail-ref-arg-with-array-type.txt
@@ -1,0 +1,1 @@
+(1) : error 137: cannot mix reference and array types


### PR DESCRIPTION
This fixes issue #313.