### PR TITLE
Fix crash when enabling profiler

### DIFF
--- a/vm/environment.h
+++ b/vm/environment.h
@@ -209,15 +209,20 @@ class EnterProfileScope
  public:
   EnterProfileScope(const char* group, const char* name)
   {
-    if (Environment::get()->IsProfilingEnabled())
+    if (Environment::get()->IsProfilingEnabled()) {
       Environment::get()->profiler()->EnterScope(group, name);
+      scope_entered_ = true;
+    }
   }
 
   ~EnterProfileScope()
   {
-    if (Environment::get()->IsProfilingEnabled())
+    if (scope_entered_ && Environment::get()->IsProfilingEnabled())
       Environment::get()->profiler()->LeaveScope();
   }
+
+ private:
+  bool scope_entered_;
 };
 
 class ErrorReport : public SourcePawn::IErrorReport


### PR DESCRIPTION
When a plugin is currently executing code while the profiler is being activated, the VM tried to leave a profiling scope it never entered.

`sm_rcon sm prof start vprof` would crash the server.

https://crash.limetech.org/lgolraffyt46