### PR TITLE
Fix issues related to line terminators on global declarations.

### DIFF
--- a/compiler/errors.cpp
+++ b/compiler/errors.cpp
@@ -86,7 +86,7 @@ int error(const token_pos_t& where, int number, ...)
 {
   va_list ap;
   va_start(ap, number);
-  ErrorReport report = ErrorReport::create_va(number, -1, where.line, ap);
+  ErrorReport report = ErrorReport::create_va(number, where.file, where.line, ap);
   va_end(ap);
 
   report.lineno = where.line;

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -2063,11 +2063,13 @@ int lex(cell *lexvalue,char **lexsym)
 
   tok->start.line = fline;
   tok->start.col = (int)(lptr - pline);
+  tok->start.file = fnumber;
 
   lex_once(tok, lexvalue);
 
   tok->end.line = fline;
   tok->end.col = (int)(lptr - pline);
+  tok->end.file = tok->start.file;
   return tok->id;
 }
 
@@ -2639,15 +2641,15 @@ int peek_same_line()
   return tEOL;
 }
 
-int require_newline(int allow_semi)
+int require_newline(TerminatorPolicy policy)
 {
-  if (allow_semi) {
+  if (policy != TerminatorPolicy::Newline) {
     // Semicolon must be on the same line.
     auto pos = current_token()->start;
     int next_tok_id = peek_same_line();
     if (next_tok_id == ';') {
       lexpop();
-    } else if (sc_needsemicolon) {
+    } else if (policy == TerminatorPolicy::Semicolon && sc_needsemicolon) {
       error(pos, 1, ";", get_token_string(next_tok_id).chars());
     }
   }

--- a/compiler/lexer.h
+++ b/compiler/lexer.h
@@ -27,6 +27,7 @@
 class Type;
 
 struct token_pos_t {
+  int file;
   int line;
   int col;
 };
@@ -252,7 +253,6 @@ int expecttoken(int id, token_t *tok);
 int matchsymbol(token_ident_t *ident);
 int needsymbol(token_ident_t *ident);
 int peek_same_line();
-int require_newline(int allow_semi);
 void litadd(cell value);
 void litinsert(cell value,int pos);
 int alphanum(char c);
@@ -273,3 +273,11 @@ symbol *addvariable2(const char *name,cell addr,int ident,int vclass,int tag,
 symbol *addvariable3(declinfo_t *decl,cell addr,int vclass,int slength);
 int getlabel(void);
 char *itoh(ucell val);
+
+enum class TerminatorPolicy {
+  Newline,
+  NewlineOrSemicolon,
+  Semicolon
+};
+
+int require_newline(TerminatorPolicy policy);

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -2652,7 +2652,7 @@ static void declstruct(void)
     if (pstructs_addarg(pstruct, &arg) == NULL)
       error(103, arg.name, layout_spec_name(Layout_PawnStruct));
 
-    require_newline(TRUE);
+    require_newline(TerminatorPolicy::NewlineOrSemicolon);
   } while (!lexpeek('}'));
   needtoken('}');
   matchtoken(';');  /* eat up optional semicolon */
@@ -3390,7 +3390,10 @@ int parse_property_accessor(const typeinfo_t *type, methodmap_t *map, methodmap_
     }
   }
 
-  require_newline(target->usage & uNATIVE);
+  if (target->usage & uNATIVE)
+    require_newline(TerminatorPolicy::Semicolon);
+  else
+    require_newline(TerminatorPolicy::Newline);
   return TRUE;
 }
 
@@ -3421,7 +3424,7 @@ parse_property(methodmap_t *map)
         lexclr(TRUE);
     }
 
-    require_newline(FALSE);
+    require_newline(TerminatorPolicy::Newline);
   }
 
   return method;
@@ -3518,7 +3521,10 @@ parse_method(methodmap_t *map)
     map->ctor = method.get();
   }
 
-  require_newline(target->usage & uNATIVE);
+  if (target->usage & uNATIVE)
+    require_newline(TerminatorPolicy::Semicolon);
+  else
+    require_newline(TerminatorPolicy::Newline);
   return method;
 }
 
@@ -3619,7 +3625,7 @@ static bool dousing()
   }
 
   declare_handle_intrinsics();
-  require_newline(TRUE);
+  require_newline(TerminatorPolicy::Semicolon);
   return true;
 }
 
@@ -3703,7 +3709,7 @@ static void domethodmap(LayoutSpec spec)
     map->methods.append(ke::Move(method));
   }
 
-  require_newline(TRUE);
+  require_newline(TerminatorPolicy::Semicolon);
 }
 
 class AutoStage
@@ -3900,7 +3906,7 @@ static void parse_function_type(const ke::UniquePtr<functag_t> &type)
   if (lparen)
     needtoken(')');
 
-  require_newline(TRUE);
+  require_newline(TerminatorPolicy::Semicolon);
   errorset(sRESET, 0);
 }
 
@@ -3950,7 +3956,7 @@ static void dotypeset()
     functags_add(def, ke::Move(type));
   }
 
-  require_newline(TRUE);
+  require_newline(TerminatorPolicy::NewlineOrSemicolon);
 }
 
 /*  decl_enum   - declare enumerated constants
@@ -4216,13 +4222,13 @@ static void decl_enumstruct()
       append_constval(values, decl.name, position, root_tag);
     }
     position += decl.type.numdim ? decl.type.dim[0] : 1;
-    require_newline(TRUE);
+    require_newline(TerminatorPolicy::Semicolon);
   }
 
   if (!position)
     error(119, struct_name.name);
 
-  require_newline(TRUE);
+  require_newline(TerminatorPolicy::Newline);
 
   if (root) {
     assert(root->usage & uENUMROOT);

--- a/tests/compile-only/fail-missing-semi-on-enum-struct.txt
+++ b/tests/compile-only/fail-missing-semi-on-enum-struct.txt
@@ -1,2 +1,1 @@
 (5) : error 001: expected token: ";", but found "<newline>"
-(6) : error 001: expected token: ";", but found "<newline>"

--- a/tests/compile-only/ok-enum-struct-to-any-array.sp
+++ b/tests/compile-only/ok-enum-struct-to-any-array.sp
@@ -7,7 +7,7 @@ dostuff(any[] array) {
 
 enum struct X {
   int inner[5];
-};
+}
 
 public main()
 {

--- a/tests/enum-structs/array-of-structs.sp
+++ b/tests/enum-structs/array-of-structs.sp
@@ -4,7 +4,7 @@ enum struct Sample {
   int x;
   int y;
   int data[5];
-};
+}
 
 public main() {
   Sample s[5];

--- a/tests/enum-structs/chained-method-call.sp
+++ b/tests/enum-structs/chained-method-call.sp
@@ -4,7 +4,7 @@ methodmap X {
   public void dump() {
     printnum(view_as<int>(this));
   }
-};
+}
 
 enum struct Point {
   int x;
@@ -15,7 +15,7 @@ enum struct Point {
     this.y = y;
     return view_as<X>(this.y);
   }
-};
+}
 
 public main()
 {

--- a/tests/enum-structs/dynamic-arrays.sp
+++ b/tests/enum-structs/dynamic-arrays.sp
@@ -4,7 +4,7 @@ enum struct Sample {
   int x;
   int y;
   int data[5];
-};
+}
 
 public main() {
   Sample[] s = new Sample[10];

--- a/tests/enum-structs/inline-arrays.sp
+++ b/tests/enum-structs/inline-arrays.sp
@@ -4,7 +4,7 @@ enum struct Sample {
   int x;
   int y;
   int data[5];
-};
+}
 
 public main() {
   Sample s;

--- a/tests/enum-structs/method-call.sp
+++ b/tests/enum-structs/method-call.sp
@@ -8,7 +8,7 @@ enum struct Point {
     this.x = x;
     this.y = y;
   }
-};
+}
 
 void Set(Point p, int x, int y) {
   p.x = x;

--- a/tests/enum-structs/methodmap-in-struct.sp
+++ b/tests/enum-structs/methodmap-in-struct.sp
@@ -4,11 +4,11 @@ methodmap T {
   public void print() {
     printnum(view_as<int>(this));
   }
-};
+}
 
 enum struct X {
   T t;
-};
+}
 
 public main()
 {

--- a/tests/enum-structs/nested.sp
+++ b/tests/enum-structs/nested.sp
@@ -3,17 +3,17 @@
 enum struct Inner {
   int x;
   char message[32];
-};
+}
 
 enum struct Middle {
   Inner inner;
-};
+}
 
 enum struct Sample {
   float a;
   Middle m;
   int y;
-};
+}
 
 public main() {
   Sample s;

--- a/tests/enum-structs/resolve-field-offsets.sp
+++ b/tests/enum-structs/resolve-field-offsets.sp
@@ -5,7 +5,7 @@ enum struct X {
   char message[20];
   float x;
   float y;
-};
+}
 
 public main() {
   printnum(X::a);

--- a/tests/enum-structs/simple.sp
+++ b/tests/enum-structs/simple.sp
@@ -5,7 +5,7 @@ enum struct Sample {
   int x;
   int y;
   char message[32];
-};
+}
 
 public main() {
   Sample s;

--- a/tests/enum-structs/sizeof-enum.sp
+++ b/tests/enum-structs/sizeof-enum.sp
@@ -5,7 +5,7 @@ enum struct X {
   char message[20];
   float x;
   float y;
-};
+}
 
 public main() {
   X x;

--- a/tests/enum-structs/sizeof-type.sp
+++ b/tests/enum-structs/sizeof-type.sp
@@ -5,7 +5,7 @@ enum struct X {
   char message[20];
   float x;
   float y;
-};
+}
 
 public main() {
   printnum(sizeof(X::a));

--- a/tests/enum-structs/sizeof-var.sp
+++ b/tests/enum-structs/sizeof-var.sp
@@ -5,7 +5,7 @@ enum struct X {
   char message[20];
   float x;
   float y;
-};
+}
 
 public main() {
   X x;

--- a/tests/enum-structs/string-fields.sp
+++ b/tests/enum-structs/string-fields.sp
@@ -4,7 +4,7 @@
 enum struct X {
   char message[20];
   int a;
-};
+}
 
 public main() {
   X x;

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -555,7 +555,8 @@ class TestRunner(object):
     self.out("Failures were detected in the following tests:")
     failures = sorted([test.unique_name for test in self.failures_])
     for test in failures:
-      self.out("  {0}".format(test))
+      test_path = os.path.join(os.path.split(__file__)[0], test)
+      self.out("  {0}".format(os.path.relpath(test_path)))
 
   def out(self, text):
     when = (datetime.datetime.now() - self.start_time_).total_seconds()


### PR DESCRIPTION
This patch tweaks the require_newline algorithm to allow for three
scenarios:

(1) A declaration where ONLY newlines are allowed to terminate a
statement. Enum structs now fall into this category.

(2) A declaration where semicolons OR newlines are allowed to terminate
a statement. Methodmaps, typesets fall into category. If a semicolon is
missing, requiring semicolons with a pragma will not error. This mode is
for compatibility, since the original semantics were a mistake
(methodmaps should be "newline", typesets should be "semicolon").

(3) A declaration where semicolons are required to terminate a
statement. If semicolons are not required with a #pragma, then the
missing semicolon is ignored and a newline is accepted.

Finally, this patch fixes a bug where token_pos_t did not track the file
number of the token, leading to incorrect error positions if the lexer
jumped past an #include directive.

Bug: issue #314.