### PR TITLE
Remove POPSTK_I/P.

### DIFF
--- a/compiler/lexer.h
+++ b/compiler/lexer.h
@@ -224,18 +224,6 @@ enum TokenKind {
   tLAST_TOKEN_ID
 };
 
-typedef union {
-  void *pv;                 /* e.g. a name */
-  int i;
-} stkitem;                  /* type of items stored on the compiler stack */
-
-#define PUSHSTK_P(v)  { stkitem s_; s_.pv=(v); pushstk(s_); }
-#define PUSHSTK_I(v)  { stkitem s_; s_.i=(v); pushstk(s_); }
-#define POPSTK_P()    (popstk().pv)
-#define POPSTK_I()    (popstk().i)
-void pushstk(stkitem val);
-stkitem popstk(void);
-void clearstk(void);
 int plungequalifiedfile(char *name);  /* explicit path included */
 int plungefile(char *name,int try_currentpath,int try_includepaths);   /* search through "include" paths */
 void preprocess(void);

--- a/compiler/scvars.cpp
+++ b/compiler/scvars.cpp
@@ -72,13 +72,10 @@ cell pc_stksize=sDEF_AMXSTACK;/* default stack size */
 int freading  = FALSE;  /* Is there an input file ready for reading? */
 int fline     = 0;      /* the line number in the current file */
 short fnumber = 0;      /* the file number in the file table (debugging) */
-short fcurrent= 0;      /* current file being processed (debugging) */
-short sc_intest=FALSE;  /* true if inside a test */
 int sideeffect= 0;      /* true if an expression causes a side-effect */
 int stmtindent= 0;      /* current indent of the statement */
 int indent_nowarn=FALSE;/* skip warning "217 loose indentation" */
 int sc_tabsize=8;       /* number of spaces that a TAB represents */
-short sc_allowtags=TRUE;  /* allow/detect tagnames in lex() */
 int sc_status;          /* read/write status */
 int sc_err_status;
 int sc_rationaltag=0;   /* tag for rational numbers */
@@ -96,6 +93,15 @@ int sc_compression_level=9;
 void *inpf    = NULL;   /* file read from (source or include) */
 void *inpf_org= NULL;   /* main source file */
 memfile_t* outf = NULL; /* (intermediate) text file written to */
+
+bool sc_intest;
+bool sc_allowtags;
+short fcurrent;         /* current file being processed */
+
+ke::Vector<short> gCurrentFileStack;
+ke::Vector<int> gCurrentLineStack;
+ke::Vector<void*> gInputFileStack;
+ke::Vector<char*> gInputFilenameStack;
 
 jmp_buf errbuf;
 

--- a/compiler/scvars.h
+++ b/compiler/scvars.h
@@ -21,6 +21,7 @@
 
 #include <setjmp.h>
 #include <amtl/am-string.h>
+#include <amtl/am-vector.h>
 
 struct memfile_t;
 
@@ -63,14 +64,10 @@ extern cell pc_stksize;     /* stack size */
 extern int freading;        /* is there an input file ready for reading? */
 extern int fline;           /* the line number in the current file */
 extern short fnumber;       /* number of files in the input file table */
-extern short fcurrent;      /* current file being processed */
-extern short sc_intest;     /* true if inside a test */
-extern short sc_intest;     /* true if inside a test */
 extern int sideeffect;      /* true if an expression causes a side-effect */
 extern int stmtindent;      /* current indent of the statement */
 extern int indent_nowarn;   /* skip warning "217 loose indentation" */
 extern int sc_tabsize;      /* number of spaces that a TAB represents */
-extern short sc_allowtags;  /* allow/detect tagnames in lex() */
 extern int sc_status;       /* read/write status */
 extern int sc_err_status;   /* TRUE if errors should be generated even if sc_status = SKIP */
 extern int sc_rationaltag;  /* tag for rational numbers */
@@ -99,6 +96,15 @@ extern memfile_t* outf;          /* file written to */
 extern jmp_buf errbuf;      /* target of longjmp() on a fatal error */
 
 extern ke::AString pc_deprecate;
+
+extern bool sc_intest;
+extern bool sc_allowtags;
+extern short fcurrent;      /* current file being processed */
+
+extern ke::Vector<short> gCurrentFileStack;
+extern ke::Vector<int> gCurrentLineStack;
+extern ke::Vector<void*> gInputFileStack;
+extern ke::Vector<char*> gInputFilenameStack;
 
 // Returns true if compilation is in its second phase (writing phase) and has
 // so far proceeded without error.

--- a/tests/compile-only/fail-empty-parenthetical.sp
+++ b/tests/compile-only/fail-empty-parenthetical.sp
@@ -1,0 +1,4 @@
+public void OnPluginStart()
+{
+	v = () + ()
+}

--- a/tests/compile-only/fail-empty-parenthetical.txt
+++ b/tests/compile-only/fail-empty-parenthetical.txt
@@ -1,0 +1,2 @@
+(3) : error 029: invalid expression, assumed zero
+(4) : error 001: expected token: ")", but found "-end of file-"


### PR DESCRIPTION
This mechanism was an untyped stack for squirreling away data while the
compiler processed nested structures. This was gross even for a C
codebase: each individual item should have had its own stack, since then
if the stack is unbalanced, it is much clearer where the fault lies.

Even then the stack was used unnecessarily in many places. For example
sc_intest and sc_allowtags were trivially scoped.

Bug: issue #312