### PR TITLE
KE_CONSTEXPR define was removed

### DIFF
--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -2684,7 +2684,7 @@ static int consume_line()
   return TRUE;
 }
 
-KE_CONSTEXPR cell char_array_cells(cell size)
+constexpr cell char_array_cells(cell size)
 {
   return (size + sizeof(cell) - 1) / sizeof(cell);
 }


### PR DESCRIPTION
KE_CONSTEXPR define was removed in this commit: https://github.com/alliedmodders/amtl/commit/7586906494fd1df46c468309798b5d3f49c95b39