### PR TITLE
Fix exp libsmx dependency not being automatically satisfied

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -329,6 +329,7 @@ else:
   if 'vm' in build:
     sp.BuildVM()
   if 'exp' in build:
+    sp.EnsureLibSmx()
     sp.BuildExperimental()
 
 if builder.parent is not None:


### PR DESCRIPTION
Fix #323 

* Add `EnsureLibSmx` in the project-wide `AMBuildScript`'s option parser for the `exp` branch