### PR TITLE
Make semicolons after methodmap declarations optional, even with #pragma semicolon.

### DIFF
--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -3715,7 +3715,7 @@ static void domethodmap(LayoutSpec spec)
     map->methods.append(ke::Move(method));
   }
 
-  require_newline(TerminatorPolicy::Semicolon);
+  require_newline(TerminatorPolicy::NewlineOrSemicolon);
 }
 
 class AutoStage

--- a/tests/compile-only/ok-methodmap-decl-no-semi.sp
+++ b/tests/compile-only/ok-methodmap-decl-no-semi.sp
@@ -1,0 +1,6 @@
+#pragma semicolon 1
+
+methodmap Quack {
+}
+
+public void main() {}


### PR DESCRIPTION
This was probably what was intended in https://github.com/alliedmodders/sourcepawn/pull/319.