### PR TITLE
Fix uninitialized variable guarding profiling scopes

### DIFF
--- a/vm/environment.h
+++ b/vm/environment.h
@@ -222,7 +222,7 @@ class EnterProfileScope
   }
 
  private:
-  bool scope_entered_;
+  bool scope_entered_ = false;
 };
 
 class ErrorReport : public SourcePawn::IErrorReport


### PR DESCRIPTION
The crash fix in #316 didn't initialize the member variable, so it doesn't really fix the issue. It seems I just got tricked during testing with debug builds.

https://crash.limetech.org/R4777WANZDTG