### PR TITLE
Simplify inline exit frames.

### DIFF
--- a/vm/jit.h
+++ b/vm/jit.h
@@ -130,6 +130,7 @@ class CompilerBase : public PcodeVisitor
   Label throw_error_code_[SP_MAX_ERROR_CODES];
   Label report_error_;
   Label return_reported_error_;
+  Label unbound_native_error_;
 
   // Debugging.
   Label debug_break_;

--- a/vm/runtime-helpers.cpp
+++ b/vm/runtime-helpers.cpp
@@ -40,4 +40,10 @@ ReportOutOfBoundsError(cell_t index, cell_t bounds)
   }
 }
 
+void
+ReportUnboundNative()
+{
+  Environment::get()->ReportError(SP_ERROR_INVALID_NATIVE);
+}
+
 } // namespace sp

--- a/vm/runtime-helpers.h
+++ b/vm/runtime-helpers.h
@@ -22,6 +22,7 @@
 namespace sp {
 
 void ReportOutOfBoundsError(cell_t index, cell_t bounds);
+void ReportUnboundNative();
 
 } // namespace sp
 

--- a/vm/x64/macro-assembler-x64.cpp
+++ b/vm/x64/macro-assembler-x64.cpp
@@ -36,17 +36,6 @@ MacroAssembler::leaveFrame()
 }
 
 void
-MacroAssembler::enterInlineExitFrame(ExitFrameType type, uintptr_t payload, CodeLabel* return_address)
-{
-  {
-    ReserveScratch scratch(this);
-    movq(scratch.reg(), return_address);
-    push(scratch.reg());
-  }
-  enterExitFrame(type, payload);
-}
-
-void
 MacroAssembler::enterExitFrame(ExitFrameType type, uintptr_t payload)
 {
   enterFrame(JitFrameType::Exit, EncodeExitFrameId(type, payload));

--- a/vm/x64/macro-assembler-x64.h
+++ b/vm/x64/macro-assembler-x64.h
@@ -35,10 +35,6 @@ class MacroAssembler : public Assembler
   void enterFrame(JitFrameType type, uint32_t function_id);
   void leaveFrame();
 
-  // Inline exit frames are not entered via a call; instead they simulate a
-  // call by pushing a return address.
-  void enterInlineExitFrame(ExitFrameType type, uintptr_t payload, CodeLabel* return_address);
-
   void enterExitFrame(ExitFrameType type, uintptr_t payload);
   void leaveExitFrame();
 

--- a/vm/x86/macro-assembler-x86.h
+++ b/vm/x86/macro-assembler-x86.h
@@ -60,16 +60,16 @@ class MacroAssembler : public Assembler
     leaveFrame();
   }
 
-  // Inline exit frames are not entered via a call; instead they simulate a
-  // call by pushing a return address.
-  void enterInlineExitFrame(ExitFrameType type, uintptr_t payload, CodeLabel* return_address) {
+  void pushInlineExitFrame(ExitFrameType type, uintptr_t payload, CodeLabel* return_address) {
     push(return_address);
-    enterExitFrame(type, payload);
+    push(ebp);
+    movl(Operand(ExternalAddress(Environment::get()->addressOfExit())), esp);
+    push(uint32_t(JitFrameType::Exit));
+    push(EncodeExitFrameId(type, payload));
   }
-  void leaveInlineExitFrame() {
-    // Note: no ret, the frame is inline. We add 4 to esp isntead.
-    leaveExitFrame();
-    addl(esp, 4);
+
+  void popInlineExitFrame(uint32_t extra_argc) {
+    addl(esp, (4 + extra_argc) * sizeof(uintptr_t));
   }
 
   void alignStack() {


### PR DESCRIPTION
When invoking C++ from JIT code, we need to construct an "exit frame"
so that FrameIterator can recover a stack trace. The normal way of
creating an exit frame is implicitly, via a call. The call pushes a
return address, and the new prologue configures the frame pointer and
stores it in the Environment.

Notably, this means there is a small inline helper function every time
we transition to C++. For performance-sensitive code, like native calls,
this is not ideal. Instead we create an "inline" exit frame. Instead of
calling, we derive the return address at compile-time, push it, and thus
avoid the call instructions.

This patch makes additional improves to the inline-exit path by also
eliding "leave" instructions. It also preserves ebp, which should
improve stack walking by Breakpad.