### PR TITLE
Fix Travis Emscripten build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: cpp
-sudo: false
-dist: trusty
+dist: xenial
 addons:
   apt:
     packages:
-      - g++-4.8
-      - g++-4.8-multilib
-      - clang-3.8
+      - gcc-multilib
+      - g++-multilib
       - libstdc++6
       - lib32stdc++6
       - libc6-dev
@@ -14,16 +12,13 @@ addons:
       - linux-libc-dev
       - linux-libc-dev:i386
 env:
-  global:
-    - EMSCRIPTEN_SDK_BRANCH=master
-    - EMSCRIPTEN_SDK_URI=https://github.com/urho3d/emscripten-sdk.git
   matrix:
-    - AM_CC=clang-3.8 AM_CXX=clang++-3.8 AM_ARCH=x86 AM_TYPE=optimize
-    - AM_CC=clang-3.8 AM_CXX=clang++-3.8 AM_ARCH=x64 AM_TYPE=optimize
+    - AM_CC=clang AM_CXX=clang++ AM_ARCH=x86 AM_TYPE=optimize
+    - AM_CC=clang AM_CXX=clang++ AM_ARCH=x64 AM_TYPE=optimize
     - AM_CC=emcc AM_CXX=em++ AM_ARCH=x86 AM_TYPE=optimize
     - AM_CC=emcc AM_CXX=em++ AM_ARCH=x86 AM_TYPE=debug
-    - AM_CC=clang-3.8 AM_CXX=clang++-3.8 AM_ARCH=x86 AM_TYPE=debug
-    - AM_CC=clang-3.8 AM_CXX=clang++-3.8 AM_ARCH=x64 AM_TYPE=debug
+    - AM_CC=clang AM_CXX=clang++ AM_ARCH=x86 AM_TYPE=debug
+    - AM_CC=clang AM_CXX=clang++ AM_ARCH=x64 AM_TYPE=debug
 install:
   - source ./tools/travis-download-compiler.sh
   - CHECKOUT_DIR=$PWD && cd .. && $CHECKOUT_DIR/tools/checkout-deps.sh && cd $CHECKOUT_DIR

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -26,25 +26,26 @@ def Normalize(path):
 def SetArchFlags(compiler, arch, platform):
   if compiler.like('gcc'):
     if arch == 'x86':
-      compiler.cflags += ['-msse']
+      if not compiler.like('emscripten'):
+        compiler.cflags += ['-msse']
     else:
       compiler.cflags += ['-fPIC']
 
-    if arch == 'x64':
-      gccarch = '-m64'
-      msvcarch = '/MACHINE:X64'
-    else:
-      gccarch = '-m32'
-      msvcarch = '/MACHINE:X86'
+  if arch == 'x64':
+    gccarch = '-m64'
+    msvcarch = '/MACHINE:X64'
+  else:
+    gccarch = '-m32'
+    msvcarch = '/MACHINE:X86'
 
-    if compiler.like('msvc'):
-      if msvcarch not in compiler.linkflags:
-        compiler.linkflags += [msvcarch]
-    else:
-      if gccarch not in compiler.cflags:
-        compiler.cflags += [gccarch]
-      if gccarch not in compiler.linkflags:
-        compiler.linkflags += [gccarch]
+  if compiler.like('msvc'):
+    if msvcarch not in compiler.linkflags:
+      compiler.linkflags += [msvcarch]
+  else:
+    if gccarch not in compiler.cflags:
+      compiler.cflags += [gccarch]
+    if gccarch not in compiler.linkflags:
+      compiler.linkflags += [gccarch]
 
 def AppendArchSuffix(binary, name, arch):
   if arch == 'x64':

--- a/compiler/AMBuilder
+++ b/compiler/AMBuilder
@@ -18,8 +18,6 @@ if compiler.like('gcc'):
     '-Wno-format',
   ]
   compiler.c_only_flags += ['-std=c99']
-  if builder.target.platform == 'linux':
-    compiler.postlink += ['-lm']
   compiler.postlink += ['-lstdc++']
 if compiler.family == 'clang':
   compiler.cxxflags += [

--- a/tools/travis-download-compiler.sh
+++ b/tools/travis-download-compiler.sh
@@ -3,10 +3,15 @@
 set -e
 
 if [ "$AM_CC" == "emcc" ]; then
-  git clone --depth 1 --branch $EMSCRIPTEN_SDK_BRANCH $EMSCRIPTEN_SDK_URI $HOME/emscripten-sdk
-  $HOME/emscripten-sdk/emsdk activate --build=Release sdk-$EMSCRIPTEN_SDK_BRANCH-64bit
+  git clone --depth 1 https://github.com/emscripten-core/emsdk.git $HOME/emsdk
 
-  source $HOME/emscripten-sdk/emsdk_env.sh
+  $HOME/emsdk/emsdk install latest
+  $HOME/emsdk/emsdk activate latest
+
+  source $HOME/emsdk/emsdk_env.sh
+
+  # The SDK no longer sets this envvar, but ambuild expects it.
+  export EMSCRIPTEN=$HOME/emsdk/fastcomp/emscripten
 
   for compiler in $EMSCRIPTEN/{emcc,em++}; do
     touch -d "2017-01-01 00:00:00 +0800" $compiler

--- a/vm/AMBuilder
+++ b/vm/AMBuilder
@@ -12,8 +12,6 @@ def configure_like_shell(name, arch):
   ]
   if prog.compiler.like('gcc'):
     prog.compiler.linkflags += ['-lstdc++']
-  if builder.target.platform == 'linux':
-    prog.compiler.postlink += ['-lpthread', '-lrt']
   return prog
 
 Includes = [
@@ -112,9 +110,6 @@ dll.compiler.linkflags[0:0] = [
 dll.sources += [
   'dll_exports.cpp'
 ]
-
-if builder.target.platform == 'linux':
-  dll.compiler.postlink += ['-lpthread', '-lrt']
 
 libsourcepawn = builder.Add(dll)
 

--- a/vm/watchdog_timer.cpp
+++ b/vm/watchdog_timer.cpp
@@ -20,6 +20,15 @@
 
 using namespace sp;
 
+#ifdef __EMSCRIPTEN__
+// When using emscripten's pthread stubs, prctl is missing and causes a link error.
+extern "C" int __attribute__((weak)) prctl(int, ...)
+{
+  errno = EINVAL;
+  return -1;
+}
+#endif
+
 WatchdogTimer::WatchdogTimer(Environment* env)
  : env_(env),
    terminate_(false),


### PR DESCRIPTION
This ended up needing quite a lot of mangling:

* Moved us to the latest travis build image and using distro Clang 7.x
* Switched to the upstream emscripten SDK, now it has pre-build linux bins
* Bit of compiler flag cleanup that were getting duplicated after prior refactoring work
* Fixed an unrelated issue with setting arch flags on Windows
* Added a stub for prctl to fix linking issues