### PR TITLE
Fix warning when non-stock functions are used by stock functions.

### DIFF
--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -5132,6 +5132,13 @@ reduce_referrers(symbol* root) {
         for (symbol* sym : dead->refers_to()) {
             sym->drop_reference_from(dead);
             if (is_symbol_unused(sym) && !(sym->flags & flgQUEUED)) {
+                // During compilation, anything marked as stock will be omitted from
+                // the final binary *without warning*. If a stock calls a non-stock
+                // function, we want to avoid warnings on that function as well, so
+                // we propagate the stock bit.
+                if (dead->usage & uSTOCK)
+                    sym->usage |= uSTOCK;
+
                 sym->flags |= flgQUEUED;
                 work.append(sym);
             }

--- a/tests/warnings/unused-from-member-function.sp
+++ b/tests/warnings/unused-from-member-function.sp
@@ -1,0 +1,15 @@
+// warnings_are_errors: true
+enum struct My_Struct {
+  int size;
+
+  void File() {
+    this.size = fun(this.size);
+  }
+}
+
+int fun(int value) {
+  return value;
+}
+
+public main() {
+}


### PR DESCRIPTION
Bug: issue #349
Test: warnings/unused-from-member-function.sp