### PR TITLE
Improve type pretty-printing. Slightly.

### DIFF
--- a/compiler/expressions.cpp
+++ b/compiler/expressions.cpp
@@ -288,14 +288,10 @@ type_to_name(int tag)
     if (tag == pc_anytag)
         return "any";
 
-    const char* name = pc_tagname(tag);
-    if (name)
-        return name;
-
     Type* type = gTypes.find(tag);
-    if (type && type->isFunction())
-        return "function";
-    return "unknown";
+    if (!type)
+        return "unknown";
+    return type->prettyName();
 }
 
 int
@@ -1833,7 +1829,7 @@ field_expression(svalue& thisval, value* lval, symbol** target, methodmap_method
 
     methodmap_t* map = gTypes.find(thisval.val.tag)->asMethodmap();
     if (!map) {
-        error(104, pc_typename(thisval.val.tag));
+        error(104, type_to_name(thisval.val.tag));
         return FER_Fail;
     }
 

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -584,17 +584,6 @@ inst_datetime_defines(void) {
 }
 
 const char*
-pc_typename(int tag) {
-    if (tag == 0)
-        return "int";
-    if (tag == sc_rationaltag)
-        return "float";
-    if (tag == pc_tag_string)
-        return "char";
-    return pc_tagname(tag);
-}
-
-const char*
 pc_tagname(int tag) {
     if (Type* type = gTypes.find(tag))
         return type->name();
@@ -1790,7 +1779,7 @@ declloc(int tokid) {
                     int explicit_dims = type->numdim;
                     if (parse_new_typename(NULL, &tag)) {
                         if (tag != type->semantic_tag())
-                            error(164, pc_typename(tag), pc_typename(type->tag));
+                            error(164, type_to_name(tag), type_to_name(type->tag));
                         if (gTypes.find(tag)->isEnumStruct()) {
                             assert(explicit_dims > 0);
                             explicit_dims--;
@@ -2887,7 +2876,7 @@ parse_old_array_dims(declinfo_t* decl, int flags) {
                 // Fixed array with dynamic size. Note that this protects this code
                 // from not supporting new-style enum structs (it is called before
                 // rewriting happens).
-                error(161, pc_typename(type->tag));
+                error(161, type_to_name(type->tag));
             }
         }
 
@@ -3744,7 +3733,7 @@ dodelete() {
 
     methodmap_t* map = gTypes.find(sval.val.tag)->asMethodmap();
     if (!map) {
-        error(115, "type", pc_tagname(sval.val.tag));
+        error(115, "type", type_to_name(sval.val.tag));
         return;
     }
 

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -468,7 +468,6 @@ int pc_compile(int argc, char** argv);
 int pc_addconstant(const char* name, cell value, int tag);
 int pc_addtag(const char* name);
 int pc_findtag(const char* name);
-const char* pc_typename(int tag);
 const char* pc_tagname(int tag);
 int parse_decl(declinfo_t* decl, int flags);
 const char* type_to_name(int tag);

--- a/compiler/sctracker.cpp
+++ b/compiler/sctracker.cpp
@@ -391,9 +391,10 @@ deduce_layout_spec_by_tag(int tag)
     if (type && type->isStruct())
         return Layout_PawnStruct;
 
-    const char* name = pc_tagname(tag);
-    if (findglb(name))
-        return Layout_Enum;
+    if (Type* type = gTypes.find(tag)) {
+      if (findglb(type->name()))
+          return Layout_Enum;
+    }
 
     return Layout_None;
 }

--- a/compiler/types.cpp
+++ b/compiler/types.cpp
@@ -72,6 +72,14 @@ Type::isDeclaredButNotDefined() const
 }
 
 const char*
+Type::prettyName() const
+{
+  if (kind_ == TypeKind::Function)
+    return kindName();
+  return name();
+}
+
+const char*
 Type::kindName() const
 {
   switch (kind_) {
@@ -89,6 +97,8 @@ Type::kindName() const
       if (funcenum_ptr_) {
         if (funcenum_ptr_->entries.length() > 1)
           return "typeset";
+        if (name_.startsWith("::"))
+          return "function";
         return "typedef";
       }
       return "function";

--- a/compiler/types.h
+++ b/compiler/types.h
@@ -92,6 +92,7 @@ class Type
         return kind_;
     }
     const char* kindName() const;
+    const char* prettyName() const;
     cell smx_export_value() const {
         return value_ | int(kind_) | fixed_;
     }


### PR DESCRIPTION
The two-pass parser treats any unknown variable as a function, and if
those leak into expressions, it can lead to weird error messages.

Bug: issue #354
Test: manual test