### PR TITLE
Disqualifiy const from enum struct fields

### DIFF
--- a/compiler/messages.h
+++ b/compiler/messages.h
@@ -118,7 +118,7 @@ static const char* errmsg[] = {
     /*091*/ "ambiguous constant; tag override is required (symbol \"%s\")\n",
     /*092*/ "number of arguments does not match definition\n",
     /*093*/ "expected tag name identifier\n",
-    /*094*/ "cannot assign const qualifier to enum struct field \"%s\"\n",
+    /*094*/ "cannot apply const qualifier to enum struct field \"%s\"\n",
     /*095*/ "type \"%s\" cannot be applied as a tag\n",
     /*096*/ "could not find member \"%s\" in struct \"%s\"\n",
     /*097*/ "symbol \"%s\" does not have a matching type\n",

--- a/compiler/messages.h
+++ b/compiler/messages.h
@@ -118,7 +118,7 @@ static const char* errmsg[] = {
     /*091*/ "ambiguous constant; tag override is required (symbol \"%s\")\n",
     /*092*/ "number of arguments does not match definition\n",
     /*093*/ "expected tag name identifier\n",
-    /*094*/ "unused94\n",
+    /*094*/ "cannot assign const qualifier to enum struct field \"%s\"\n",
     /*095*/ "type \"%s\" cannot be applied as a tag\n",
     /*096*/ "could not find member \"%s\" in struct \"%s\"\n",
     /*097*/ "symbol \"%s\" does not have a matching type\n",

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -4124,6 +4124,9 @@ decl_enumstruct() {
         if (!parse_new_decl(&decl, nullptr, DECLFLAG_FIELD))
             continue;
 
+        if (decl.type.usage & uCONST)
+            error(94, decl.name);
+
         // It's not possible to have circular references other than this, because
         // Pawn is inherently forward-pass only.
         if (decl.type.semantic_tag() == root_tag) {

--- a/tests/compile-only/fail-enum-struct-const-field.sp
+++ b/tests/compile-only/fail-enum-struct-const-field.sp
@@ -1,0 +1,8 @@
+enum struct A {
+	const int x;
+}
+
+int main() {
+	A t;
+	t.x = 3;
+}

--- a/tests/compile-only/fail-enum-struct-const-field.txt
+++ b/tests/compile-only/fail-enum-struct-const-field.txt
@@ -1,1 +1,1 @@
-(2) : error 094: cannot assign const qualifier to enum struct field "x"
+(2) : error 094: cannot apply const qualifier to enum struct field "x"

--- a/tests/compile-only/fail-enum-struct-const-field.txt
+++ b/tests/compile-only/fail-enum-struct-const-field.txt
@@ -1,0 +1,1 @@
+(2) : error 094: cannot assign const qualifier to enum struct field "x"


### PR DESCRIPTION
Fixes #363 

Prevents enum struct fields from being `const`. I'm not sure we want to support const enum struct members, so if that is something we want I can refactor this, but I went straight for removal & error.


Added test