### PR TITLE
Eliminate the native counter hack.

### DIFF
--- a/compiler/codegen.h
+++ b/compiler/codegen.h
@@ -70,7 +70,7 @@ void genarray(int dims, int _autozero);
 void swap1(void);
 void ffswitch(int label);
 void ffcase(cell value, char* labelname, int newtable);
-void ffcall(symbol* sym, const char* label, int numargs);
+void ffcall(symbol* sym, int numargs);
 void ffret();
 void ffabort(int reason);
 void ffbounds(cell size);

--- a/compiler/expressions.cpp
+++ b/compiler/expressions.cpp
@@ -227,7 +227,7 @@ check_userop(void (*oper)(void), int tag1, int tag2, int numparam, value* lval, 
     }
     markexpr(sPARM, NULL, 0); /* mark the end of a sub-expression */
     assert(sym->ident == iFUNCTN);
-    ffcall(sym, NULL, paramspassed);
+    ffcall(sym, paramspassed);
     if (sc_status != statSKIP)
         markusage(sym, uREAD); /* do not mark as "used" when this call itself is skipped */
     sideeffect = TRUE;         /* assume functions carry out a side-effect */
@@ -3024,7 +3024,7 @@ SC3ExpressionParser::callfunction(symbol* sym, const svalue* aImplicitThis, valu
     stgmark(sENDREORDER); /* mark end of reversed evaluation */
 
     sCallStackUsage++;
-    ffcall(sym, NULL, nargs);
+    ffcall(sym, nargs);
     if (sc_status != statSKIP)
         markusage(sym, uREAD); /* do not mark as "used" when this call itself is skipped */
     if (symret != NULL)

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -630,7 +630,6 @@ resetglobals(void) {
     declared = 0;          /* number of local cells declared */
     glb_declared = 0;      /* number of global cells declared */
     code_idx = 0;          /* number of bytes with generated code */
-    ntv_funcid = 0;        /* incremental number of native function */
     curseg = 0;            /* 1 if currently parsing CODE, 2 if parsing DATA */
     freading = FALSE;      /* no input file ready yet */
     fline = 0;             /* the line number in the current file */
@@ -3792,7 +3791,7 @@ dodelete() {
     // stack 8
     pushreg(sPRI);
     {
-        ffcall(map->dtor->target, NULL, 1);
+        ffcall(map->dtor->target, 1);
 
         // Only mark usage if we're not skipping codegen.
         if (sc_status != statSKIP)
@@ -5328,7 +5327,7 @@ destructsymbols(symbol* root, int level) {
                 addconst(offset); /* add offset to array data to the address */
                 pushreg(sPRI);
                 assert(opsym->ident == iFUNCTN);
-                ffcall(opsym, NULL, 2);
+                ffcall(opsym, 2);
                 if (sc_status != statSKIP)
                     markusage(opsym,
                               uREAD); /* do not mark as "used" when this call itself is skipped */

--- a/compiler/scvars.cpp
+++ b/compiler/scvars.cpp
@@ -58,7 +58,6 @@ int staging = 0;                           /* true if staging output */
 cell declared = 0;                         /* number of local cells declared */
 cell glb_declared = 0;                     /* number of global cells declared */
 cell code_idx = 0;                         /* number of bytes with generated code */
-int ntv_funcid = 0;                        /* incremental number of native function */
 int errnum = 0;                            /* number of errors */
 int warnnum = 0;                           /* number of warnings */
 int sc_debug = sCHKBOUNDS;                 /* by default: bounds checking+assertions */

--- a/compiler/scvars.h
+++ b/compiler/scvars.h
@@ -50,7 +50,6 @@ extern int staging;               /* true if staging output */
 extern cell declared;             /* number of local cells declared */
 extern cell glb_declared;         /* number of global cells declared */
 extern cell code_idx;             /* number of bytes with generated code */
-extern int ntv_funcid;            /* incremental number of native function */
 extern int errnum;                /* number of errors */
 extern int warnnum;               /* number of warnings */
 extern int sc_debug;              /* debug/optimization options (bit field) */


### PR DESCRIPTION
For some reason, natives had a weird relationship with the assembler.
The code generator assigned an address based on a global counter, and
then the assembler was responsible for building the table in the same
order. (Similar nonsense exists with the staging counter, but we'll save
that for another day.)

Instead, emit sysreq instructions by name as we do for the call
instruction. This allows us to build the table during code generation,
simplifying another piece of the assembler pipeline.

Bug: N/A
Test: manual test