### PR TITLE
Forbid passing character slices to references.

### DIFF
--- a/compiler/expressions.cpp
+++ b/compiler/expressions.cpp
@@ -2769,7 +2769,7 @@ SC3ExpressionParser::callfunction(symbol* sym, const svalue* aImplicitThis, valu
                         // always an iVARIABLE.
                         assert(!args.handling_this());
 
-                        if (!lvalue)
+                        if (!lvalue || lval.ident == iARRAYCHAR)
                             error(35, argidx + 1 - firstArgOffset); /* argument type mismatch */
                         if (lval.sym != NULL && (lval.sym->usage & uCONST) != 0 &&
                             (arg[argidx].usage & uCONST) == 0)

--- a/tests/compile-only/fail-array-char-to-int-ref.sp
+++ b/tests/compile-only/fail-array-char-to-int-ref.sp
@@ -1,0 +1,10 @@
+#include <shell>
+
+void blah(int& a) {
+  printnum(a);
+}
+
+public main() {
+  char s[] = "Hello!";
+  blah(s[1]);
+}

--- a/tests/compile-only/fail-array-char-to-int-ref.txt
+++ b/tests/compile-only/fail-array-char-to-int-ref.txt
@@ -1,0 +1,1 @@
+(9) : error 035: argument type mismatch (argument 1)


### PR DESCRIPTION
This can't be properly supported because there is no 8-bit char type. As
is, it performs an improper memory access.

Bug: N/A
Test: compile-only/fail-array-char-to-int-ref