### PR TITLE
Warn when legacy enum structs are used.

### DIFF
--- a/compiler/messages.h
+++ b/compiler/messages.h
@@ -288,4 +288,6 @@ static const char* warnmsg[] = {
     /*238*/ "'%s:' is an illegal cast; use view_as<%s>(expression)\n",
     /*239*/ "'%s' is an illegal tag; use %s as a type\n",
     /*240*/ "'%s:' is an old-style tag operation; use view_as<%s>(expression) instead\n",
+    /*241*/
+    "Array-based enum structs will be removed in 1.11. See https://wiki.alliedmods.net/SourcePawn_Transitional_Syntax#Enum_Structs\n",
 };

--- a/compiler/types.h
+++ b/compiler/types.h
@@ -160,6 +160,10 @@ class Type
         return enumstruct_ptr_;
     }
 
+    bool isEnum() const {
+      return kind_ == TypeKind::Enum;
+    }
+
   private:
     void setFunction(funcenum_t* func) {
         setFixed();

--- a/tests/compile-only/fail-legacy-enum-structs.sp
+++ b/tests/compile-only/fail-legacy-enum-structs.sp
@@ -1,0 +1,12 @@
+// warnings_are_errors: true
+
+enum A {
+  B, C, D
+};
+
+new lame[A];
+
+public what(crab[A])
+{
+  new blah[A];
+}

--- a/tests/compile-only/fail-legacy-enum-structs.txt
+++ b/tests/compile-only/fail-legacy-enum-structs.txt
@@ -1,0 +1,3 @@
+(7) : error 241: Array-based enum structs will be removed in 1.11. See https://wiki.alliedmods.net/SourcePawn_Transitional_Syntax#Enum_Structs
+(9) : error 241: Array-based enum structs will be removed in 1.11. See https://wiki.alliedmods.net/SourcePawn_Transitional_Syntax#Enum_Structs
+(11) : error 241: Array-based enum structs will be removed in 1.11. See https://wiki.alliedmods.net/SourcePawn_Transitional_Syntax#Enum_Structs


### PR DESCRIPTION
Bug: N/A
Test: compile-only/fail-legacy-enum-structs