### PR TITLE
Switch to the AMTL argument parser.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   matrix:
     - AM_CC=clang AM_CXX=clang++ AM_ARCH=x86 AM_TYPE=optimize
     - AM_CC=clang AM_CXX=clang++ AM_ARCH=x64 AM_TYPE=optimize
-    - AM_CC=emcc AM_CXX=em++ AM_ARCH=x86 AM_TYPE=optimize
+#   - AM_CC=emcc AM_CXX=em++ AM_ARCH=x86 AM_TYPE=optimize
 #   - AM_CC=emcc AM_CXX=em++ AM_ARCH=x86 AM_TYPE=debug
     - AM_CC=clang AM_CXX=clang++ AM_ARCH=x86 AM_TYPE=debug
     - AM_CC=clang AM_CXX=clang++ AM_ARCH=x64 AM_TYPE=debug

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -284,22 +284,26 @@ class SourcePawn(object):
     self.libsourcepawn = {}
     self.zlib = None
     self.libsmx = None
+    self.libamtl = None
 
   def BuildSpcomp(self):
     self.EnsureZlib()
     self.EnsureLibSmx()
+    self.EnsureAmtl()
     for arch in self.root.archs:
       spcomp = self.BuildForArch('compiler/AMBuilder', arch)
       self.spcomp[arch] = spcomp
 
   def BuildVM(self):
     self.EnsureZlib()
+    self.EnsureAmtl()
     for arch in self.root.archs:
       spshell, libsourcepawn = self.BuildForArch('vm/AMBuilder', arch)
       self.spshell[arch] = spshell
       self.libsourcepawn[arch] = libsourcepawn
 
   def BuildExperimental(self):
+    self.EnsureAmtl()
     for arch in self.root.archs:
       libspcomp2 = self.BuildForArch('exp/compiler/AMBuilder', arch)
       self.libspcomp2[arch] = libspcomp2
@@ -310,6 +314,17 @@ class SourcePawn(object):
     self.BuildSpcomp()
     self.BuildVM()
     self.BuildExperimental()
+
+  def EnsureAmtl(self):
+    if self.libamtl is not None:
+      return
+    self.libamtl = {}
+    for arch in self.root.archs:
+      def do_config(builder, name):
+          return self.root.StaticLibrary(builder, name, arch)
+      extra_vars = {'Configure': do_config}
+      libamtl = self.BuildForArch("third_party/amtl/amtl/AMBuilder", arch, extra_vars)
+      self.libamtl[arch] = libamtl.binary
 
   def EnsureZlib(self):
     if self.zlib is not None:
@@ -327,9 +342,11 @@ class SourcePawn(object):
       lib = self.BuildForArch('libsmx/AMBuilder', arch)
       self.libsmx[arch] = lib
 
-  def BuildForArch(self, scripts, arch):
+  def BuildForArch(self, scripts, arch, extra_vars = {}):
     new_vars = copy.copy(self.vars)
     new_vars['arch'] = arch
+    for key in extra_vars:
+        new_vars[key] = extra_vars[key]
     return builder.Build(scripts, new_vars)
 
 if builder.parent is None:

--- a/compiler/AMBuilder
+++ b/compiler/AMBuilder
@@ -80,6 +80,7 @@ if builder.target.platform == 'linux' and not compiler.like('emscripten'):
 binary.compiler.linkflags[0:0] = [
   SP.libsmx[arch].binary,
   SP.zlib[arch],
+  SP.libamtl[arch],
 ]
 
 rvalue = builder.Add(binary)

--- a/exp/compiler/AMBuilder
+++ b/exp/compiler/AMBuilder
@@ -87,6 +87,7 @@ binary.sources += [
 binary.compiler.linkflags += [
   libspcomp2.binary,
   SP.libsmx[arch].binary,
+  SP.libamtl[arch],
 ]
 builder.Add(binary)
 

--- a/exp/tools/docparse/AMBuilder
+++ b/exp/tools/docparse/AMBuilder
@@ -33,5 +33,6 @@ binary.sources += [
 binary.compiler.linkflags += [
   SP.libspcomp2[arch].binary,
   SP.libsmx[arch].binary,
+  SP.libamtl[arch],
 ]
 builder.Add(binary)

--- a/vm/AMBuilder
+++ b/vm/AMBuilder
@@ -120,6 +120,9 @@ if has_jit:
 shell.sources += [
   'shell.cpp'
 ]
+shell.compiler.linkflags[0:0] = [
+  SP.libamtl[arch],
+]
 spshell = builder.Add(shell)
 
 # Build the verifier.


### PR DESCRIPTION
This removes a bunch of hand-rolled argument parsing code. Two options
have been removed: -^ and -\ which allowed switching the control
character, generally a poor idea for having shareable code.