### PR TITLE
Fix double-free when a fatal error occurs during assembly.

### DIFF
--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -443,8 +443,11 @@ pc_compile(int argc, char* argv[]) {
         error(13); /* no entry point (no public functions) */
 
 cleanup:
-    if (inpf != NULL) /* main source file is not closed, do it now */
+    /* main source file is not closed, do it now */
+    if (inpf != NULL) {
         pc_closesrc(inpf);
+        inpf = nullptr;
+    }
 
     // Write the binary file.
     if (!(sc_asmfile || sc_listing) && errnum == 0 && jmpcode == 0) {


### PR DESCRIPTION
Bug: fixes issue #396
Test: spcomp -o /does/not/exist.smx