### PR TITLE
Fix marking function return values.

### DIFF
--- a/compiler/expressions.cpp
+++ b/compiler/expressions.cpp
@@ -908,7 +908,7 @@ dropout(int lvalue, void (*testfunc)(int val), int exit1, value* lval)
     (*testfunc)(exit1);
 }
 
-void
+static void
 checkfunction(const value* lval)
 {
     symbol* sym = lval->sym;

--- a/compiler/expressions.h
+++ b/compiler/expressions.h
@@ -106,7 +106,6 @@ cell array_totalsize(symbol* sym);
 cell array_levelsize(symbol* sym, int level);
 int commutative(void (*oper)());
 cell calc(cell left, void (*oper)(), cell right, char* boolresult);
-void checkfunction(const value* lval);
 bool is_valid_index_tag(int tag);
 int check_userop(void (*oper)(void), int tag1, int tag2, int numparam, value* lval, int* resulttag);
 int matchtag(int formaltag, int actualtag, int allowcoerce);

--- a/compiler/new-parser.cpp
+++ b/compiler/new-parser.cpp
@@ -47,6 +47,7 @@ Parser::expression(value* lval)
         *lval = value::ErrorValue();
         return FALSE;
     }
+    expr->ProcessUses();
 
     *lval = expr->val();
     if (cc_ok())

--- a/tests/compile-only/ok-void-function-as-value.sp
+++ b/tests/compile-only/ok-void-function-as-value.sp
@@ -1,0 +1,26 @@
+// warnings_are_errors: true
+#pragma newdecls required
+#pragma semicolon 1
+
+native void Call_StartFunction(Function func);
+native void Call_PushCell(any value);
+native int Call_Finish(any &result=0);
+
+typedef Type = function void (const bool bSuccessful);
+stock static Type s_fnCallback;
+
+public void main()
+{
+	bool bSuccessful;
+	if ( s_fnCallback != DoNothing )
+	{
+		Call_StartFunction( s_fnCallback );
+		Call_PushCell( bSuccessful );
+		Call_Finish();
+		s_fnCallback = DoNothing;
+	}
+}
+
+stock static void DoNothing (const bool bSuccessful)
+{
+}


### PR DESCRIPTION
The old parser could not determine whether a function call result was
used or not. To implement the warning, it would aggressively check
whether the inputs to an expression involved a function symbol, and mark
it as needed a return value. This mostly worked because check was copied
into the most common cases in the parser.

This broke in the new parser because functions identifiers are pipelined
rather than immediately evaluated. They always return a function symbol,
and the caller is responsible for evaluating it. This is different from
the old parser, where a function symbol immediately created a call
expression or a "function value" expression. As a result, the hack for
aggressively poking at potential function calls no longer works.

This can be resolved by using the AST. Each node must implement a
ProcessUses() call. For each child expression whose value is consumed,
it must call MarkUsed(). For CallExpr, this will mark the function as
needing a return value.

Bug: issue #402
Test: compile-only/ok-void-function-as-value.sp