### PR TITLE
Allow "any" type as an array index.

### DIFF
--- a/compiler/expressions.cpp
+++ b/compiler/expressions.cpp
@@ -2122,7 +2122,7 @@ SC3ExpressionParser::parse_view_as(value* lval)
 bool
 is_valid_index_tag(int tag)
 {
-    if (tag == 0)
+    if (tag == 0 || tag == pc_anytag)
         return true;
 
     Type* idx_type = gTypes.find(tag);

--- a/tests/compile-only/ok-index-with-any-type.sp
+++ b/tests/compile-only/ok-index-with-any-type.sp
@@ -1,0 +1,8 @@
+int g_bTest[32 + 1] = { 0, ... };
+
+native any GetNativeCell(int index);
+
+public main()
+{
+    return g_bTest[GetNativeCell(1)];
+}


### PR DESCRIPTION
Bug: issue #401
Test: compile-only/ok-index-with-any-type.sp