### PR TITLE
Fix scalars being assignable to arrays.

### DIFF
--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -440,18 +440,15 @@ BinaryExpr::ValidateAssignmentRHS()
                        !oper_ &&
                        (right_val.ident == iARRAY || right_val.ident == iREFARRAY));
     if (leftarray) {
-        bool exact_match = true;
-        int left_length = left_val.sym->dim.array.length;
-        if (right_val.ident != iARRAY && right_val.ident != iREFARRAY &&
-            (right_val.sym == nullptr || right_val.constval <= 0))
-        {
-            error(pos_, 33, right_val.sym ? right_val.sym->name() : "-unknown-");
+        if (right_val.ident != iARRAY && right_val.ident != iREFARRAY) {
+            error(pos_, 47);
             return false;
         }
 
-        // A lot of this looks overcomplicated or suspect. Audit it.
+        bool exact_match = true;
         cell right_length = 0;
         int right_idxtag = 0;
+        int left_length = left_val.sym->dim.array.length;
         if (right_val.sym) {
             // Change from the old logic - we immediately reject multi-dimensional
             // arrays in assignment and don't bother validating subarray assignment.

--- a/tests/compile-only/fail-assign-scalar-to-array.sp
+++ b/tests/compile-only/fail-assign-scalar-to-array.sp
@@ -1,0 +1,5 @@
+
+public main() {
+  bool vars[2];
+  vars = true;
+}

--- a/tests/compile-only/fail-assign-scalar-to-array.txt
+++ b/tests/compile-only/fail-assign-scalar-to-array.txt
@@ -1,0 +1,1 @@
+(4) : error 047: array sizes do not match, or destination array is too small


### PR DESCRIPTION
I truly do not understand the condition that was supposed to prevent this. Possibly, the original author meant the last "&&" to be an "||". But even taking that into account, it looks bogus. I can't think of anything illegal it actually prevents, except maybe constant literals that are <= 0.