### PR TITLE
exp::parser - generic json renderer outstream

### DIFF
--- a/exp/compiler/parser/json-tools.h
+++ b/exp/compiler/parser/json-tools.h
@@ -18,6 +18,8 @@
 #ifndef _include_spcomp_json_tools_h_
 #define _include_spcomp_json_tools_h_
 
+#include <iostream>
+#include <sstream>
 #include "shared/string-pool.h"
 #include "pool-allocator.h"
 #include "boxed-value.h"
@@ -45,13 +47,14 @@ class JsonObject;
 class JsonRenderer
 {
  public:
-  JsonRenderer(FILE* fp);
+  JsonRenderer(std::ostream& output);
 
   void Render(JsonValue* value);
 
-  FILE* fp() const {
-    return fp_;
+  std::ostream& stream() {
+    return out_;
   }
+
 
   void RenderNull(JsonNull* val);
   void RenderBool(JsonBool* val);
@@ -66,7 +69,7 @@ class JsonRenderer
   void prefix();
 
  private:
-  FILE* fp_;
+  std::ostream& out_;
   size_t indent_;
 };
 

--- a/exp/tools/docparse/docparse.cpp
+++ b/exp/tools/docparse/docparse.cpp
@@ -480,7 +480,7 @@ int main(int argc, char **argv)
       return 1;
     }
 
-    JsonRenderer renderer(stdout);
+    JsonRenderer renderer(std::cout);
     renderer.Render(obj);
 
     if (reports.HasMessages())


### PR DESCRIPTION
## Summary of change

JsonRenderer constructor param was changed to a more generic out stream from std

## Change motivation

To allow the ability to store serialized JSON into a buffer and used else other (in my case, ffi), instead of stdout.

Docparse output has been linted with jq