### PR TITLE
Refactor symbol::usage and symbol::flags.

### DIFF
--- a/compiler/assembler.cpp
+++ b/compiler/assembler.cpp
@@ -1442,7 +1442,7 @@ assemble_to_buffer(SmxByteBuffer* buffer, memfile_t* fin)
             // If a function is marked as missing it should not be a public function
             // with a declaration.
             if (sym->usage & uMISSING) {
-                assert((sym->usage & (uPUBLIC | uDEFINE)) != (uPUBLIC | uDEFINE));
+                assert(!((sym->usage & uPUBLIC) && sym->defined));
                 continue;
             }
 
@@ -1479,7 +1479,7 @@ assemble_to_buffer(SmxByteBuffer* buffer, memfile_t* fin)
         symbol* sym = f.sym;
 
         assert(sym->addr() > 0);
-        assert(sym->usage & uDEFINE);
+        assert(sym->defined);
         assert(sym->codeaddr > sym->addr());
 
         sp_file_publics_t& pubfunc = publics->add();

--- a/compiler/assembler.cpp
+++ b/compiler/assembler.cpp
@@ -1442,14 +1442,14 @@ assemble_to_buffer(SmxByteBuffer* buffer, memfile_t* fin)
             // If a function is marked as missing it should not be a public function
             // with a declaration.
             if (sym->missing) {
-                assert(!((sym->usage & uPUBLIC) && sym->defined));
+                assert(!(sym->is_public && sym->defined));
                 continue;
             }
 
-            if (sym->usage & (uPUBLIC | uREAD)) {
+            if (sym->is_public || (sym->usage & uREAD)) {
                 function_entry entry;
                 entry.sym = sym;
-                if (sym->usage & uPUBLIC) {
+                if (sym->is_public) {
                     entry.name = sym->name();
                 } else {
                     // Create a private name.
@@ -1464,7 +1464,7 @@ assemble_to_buffer(SmxByteBuffer* buffer, memfile_t* fin)
                 continue;
             }
         } else if (sym->ident == iVARIABLE || sym->ident == iARRAY || sym->ident == iREFARRAY) {
-            if ((sym->usage & uPUBLIC) != 0 && (sym->usage & (uREAD | uWRITTEN)) != 0) {
+            if (sym->is_public && (sym->usage & (uREAD | uWRITTEN)) != 0) {
                 sp_file_pubvars_t& pubvar = pubvars->add();
                 pubvar.address = sym->addr();
                 pubvar.name = names->add(sym->nameAtom());

--- a/compiler/assembler.cpp
+++ b/compiler/assembler.cpp
@@ -405,7 +405,7 @@ do_ldgfen(CellWriter* writer, AsmReader* reader, cell opcode)
 {
     symbol* sym = reader->extract_call_target();
     assert(sym->ident == iFUNCTN);
-    assert(!(sym->usage & uNATIVE));
+    assert(!sym->native);
     assert((sym->function()->funcid & 1) == 1);
     assert(sym->usage & uREAD);
     assert(!sym->skipped);
@@ -433,7 +433,7 @@ do_sysreq(CellWriter* writer, AsmReader* reader, cell opcode)
     symbol* sym = reader->extract_call_target();
     ucell nargs = reader->getparam();
 
-    assert(sym->usage & uNATIVE);
+    assert(sym->native);
     if (sym->addr() < 0) {
       sym->setAddr(reader->native_list().length());
       reader->native_list().append(sym);
@@ -1432,7 +1432,7 @@ assemble_to_buffer(SmxByteBuffer* buffer, memfile_t* fin)
     // Build the easy symbol tables.
     for (const auto& sym : global_symbols) {
         if (sym->ident == iFUNCTN) {
-            if (sym->usage & uNATIVE) {
+            if (sym->native) {
                 // Set native addresses to -1 to indicate whether we've seen
                 // them in the assembly yet.
                 sym->setAddr(-1);

--- a/compiler/assembler.cpp
+++ b/compiler/assembler.cpp
@@ -951,7 +951,7 @@ RttiBuilder::add_debug_var(SmxRttiTable<smx_rtti_debug_var>* table, DebugString&
     uint32_t code_end = str.parse();
     int ident = str.parse();
     int vclass = str.parse();
-    int usage = str.parse();
+    bool is_const = !!str.parse();
 
     // We don't care about the ident type, we derive it from the tag.
     (void)ident;
@@ -980,7 +980,7 @@ RttiBuilder::add_debug_var(SmxRttiTable<smx_rtti_debug_var>* table, DebugString&
     // Encode the type.
     uint32_t type_id;
     {
-        variable_type_t type = {tag, dims, dimcount, (usage & uCONST) == uCONST};
+        variable_type_t type = {tag, dims, dimcount, is_const};
         Vector<uint8_t> encoding;
         encode_var_type(encoding, type);
 
@@ -1193,7 +1193,7 @@ RttiBuilder::encode_signature(symbol* sym)
 
         if (arg->ident == iREFERENCE)
             bytes.append(cb::kByRef);
-        variable_type_t info = {tag, arg->dim, numdim, (arg->usage & uCONST) == uCONST};
+        variable_type_t info = {tag, arg->dim, numdim, arg->is_const};
         encode_var_type(bytes, info);
     }
 

--- a/compiler/assembler.cpp
+++ b/compiler/assembler.cpp
@@ -408,7 +408,7 @@ do_ldgfen(CellWriter* writer, AsmReader* reader, cell opcode)
     assert(!(sym->usage & uNATIVE));
     assert((sym->function()->funcid & 1) == 1);
     assert(sym->usage & uREAD);
-    assert(!(sym->usage & uSKIPPED));
+    assert(!sym->skipped);
 
     // Note: we emit const.pri for backward compatibility.
     assert(opcode == sp::OP_UNGEN_LDGFN_PRI);
@@ -421,7 +421,7 @@ do_call(CellWriter* writer, AsmReader* reader, cell opcode)
 {
     symbol* sym = reader->extract_call_target();
     assert(sym->usage & uREAD);
-    assert(!(sym->usage & uSKIPPED));
+    assert(!sym->skipped);
 
     writer->append(opcode);
     writer->append(sym->addr());

--- a/compiler/assembler.cpp
+++ b/compiler/assembler.cpp
@@ -1441,7 +1441,7 @@ assemble_to_buffer(SmxByteBuffer* buffer, memfile_t* fin)
 
             // If a function is marked as missing it should not be a public function
             // with a declaration.
-            if (sym->usage & uMISSING) {
+            if (sym->missing) {
                 assert(!((sym->usage & uPUBLIC) && sym->defined));
                 continue;
             }

--- a/compiler/code-generator.cpp
+++ b/compiler/code-generator.cpp
@@ -431,7 +431,7 @@ SymbolExpr::DoEmit()
             break;
         case iFUNCTN:
             load_glbfn(sym_);
-            markusage(sym_, uCALLBACK);
+            sym_->callback = true;
             break;
         case iVARIABLE:
         case iREFERENCE:

--- a/compiler/code-generator.cpp
+++ b/compiler/code-generator.cpp
@@ -619,7 +619,7 @@ CallExpr::DoEmit()
                     assert(lvalue);
                     /* treat a "const" variable passed to a function with a non-const
                      * "variable argument list" as a constant here */
-                    if ((val.sym->usage & uCONST) && !(arg->usage & uCONST)) {
+                    if (val.sym->is_const && !arg->is_const) {
                         rvalue(val);
                         setheap_pri();
                     } else if (lvalue) {
@@ -671,7 +671,7 @@ DefaultArgExpr::DoEmit()
         case iREFARRAY:
         {
             auto& def = arg_->defvalue.array;
-            bool is_const = (arg_->usage & uCONST) != 0;
+            bool is_const = arg_->is_const;
 
             setdefarray(def.data, def.size, def.arraysize, &def.addr, is_const);
             if (def.data)

--- a/compiler/emitter.cpp
+++ b/compiler/emitter.cpp
@@ -735,7 +735,7 @@ ffcall(symbol* sym, int numargs)
     assert(sym->ident == iFUNCTN);
     if (sc_asmfile)
         funcdisplayname(symname, sym->name());
-    if ((sym->usage & uNATIVE) != 0) {
+    if (sym->native) {
         /* reserve a SYSREQ id if called for the first time */
         stgwrite("\tsysreq.n ");
 
@@ -743,9 +743,8 @@ ffcall(symbol* sym, int numargs)
         symbol* target = sym;
         if (lookup_alias(aliasname, sym->name())) {
             symbol* asym = findglb(aliasname);
-            if (asym && asym->ident == iFUNCTN && ((sym->usage & uNATIVE) != 0)) {
+            if (asym && asym->ident == iFUNCTN && sym->native)
                 target = asym;
-            }
         }
         stgwrite(target->name());
         stgwrite(" ");
@@ -1389,7 +1388,7 @@ void
 load_glbfn(symbol* sym)
 {
     assert(sym->ident == iFUNCTN);
-    assert(!(sym->usage & uNATIVE));
+    assert(!sym->native);
     stgwrite("\tldgfn.pri ");
     stgwrite(sym->name());
     stgwrite("\n");

--- a/compiler/expressions.cpp
+++ b/compiler/expressions.cpp
@@ -161,12 +161,12 @@ find_userop(void (*oper)(), int tag1, int tag2, int numparam, const value* lval,
     }
 
     /* check existance and the proper declaration of this function */
-    if ((sym->usage & uMISSING) != 0 || (sym->usage & uPROTOTYPED) == 0) {
+    if ((sym->usage & uMISSING) != 0 || !sym->prototyped) {
         char symname[2 * sNAMEMAX + 16]; /* allow space for user defined operators */
         funcdisplayname(symname, sym->name());
         if ((sym->usage & uMISSING) != 0)
             error(4, symname); /* function not defined */
-        if ((sym->usage & uPROTOTYPED) == 0)
+        if (!sym->prototyped)
             error(71, symname); /* operator must be declared before use */
     }
 

--- a/compiler/expressions.cpp
+++ b/compiler/expressions.cpp
@@ -411,7 +411,7 @@ matchreturntag(const functag_t* formal, const functag_t* actual)
     if (formal->ret_tag == actual->ret_tag)
         return TRUE;
     if (formal->ret_tag == pc_tag_void) {
-        if (actual->ret_tag == 0 && !(actual->usage & uRETVALUE))
+        if (actual->ret_tag == 0)
             return TRUE;
     }
     return FALSE;
@@ -649,14 +649,14 @@ checkfunction(const value* lval)
         /* function is defined, can now check the return value (but make an
          * exception for directly recursive functions)
          */
-        if (sym != curfunc && (sym->usage & uRETVALUE) == 0) {
+        if (sym != curfunc && !sym->retvalue) {
             char symname[2 * sNAMEMAX + 16]; /* allow space for user defined operators */
             funcdisplayname(symname, sym->name());
             error(209, symname); /* function should return a value */
         }
     } else {
         /* function not yet defined, set */
-        sym->usage |= uRETVALUE; /* make sure that a future implementation of
+        sym->retvalue = true;    /* make sure that a future implementation of
                                   * the function uses "return <value>" */
     }
 }

--- a/compiler/expressions.cpp
+++ b/compiler/expressions.cpp
@@ -161,10 +161,10 @@ find_userop(void (*oper)(), int tag1, int tag2, int numparam, const value* lval,
     }
 
     /* check existance and the proper declaration of this function */
-    if ((sym->usage & uMISSING) != 0 || !sym->prototyped) {
+    if (sym->missing || !sym->prototyped) {
         char symname[2 * sNAMEMAX + 16]; /* allow space for user defined operators */
         funcdisplayname(symname, sym->name());
-        if ((sym->usage & uMISSING) != 0)
+        if (sym->missing)
             error(4, symname); /* function not defined */
         if (!sym->prototyped)
             error(71, symname); /* operator must be declared before use */

--- a/compiler/expressions.cpp
+++ b/compiler/expressions.cpp
@@ -145,8 +145,7 @@ find_userop(void (*oper)(), int tag1, int tag2, int numparam, const value* lval,
     operator_symname(symbolname, opername, tag1, tag2, numparam, tag2);
     swapparams = false;
     sym = findglb(symbolname);
-    if (sym == NULL /*|| (sym->usage & uDEFINE)==0*/)
-    { /* ??? should not check uDEFINE; first pass clears these bits */
+    if (!sym) {
         /* check for commutative operators */
         if (tag1 == tag2 || oper == NULL || !commutative(oper))
             return false; /* not commutative, cannot swap operands */
@@ -157,7 +156,7 @@ find_userop(void (*oper)(), int tag1, int tag2, int numparam, const value* lval,
         operator_symname(symbolname, opername, tag2, tag1, numparam, tag1);
         swapparams = true;
         sym = findglb(symbolname);
-        if (sym == NULL /*|| (sym->usage & uDEFINE)==0*/)
+        if (!sym)
             return false;
     }
 
@@ -646,7 +645,7 @@ checkfunction(const value* lval)
     if (sym == NULL || (sym->ident != iFUNCTN))
         return; /* no known symbol, or not a function result */
 
-    if ((sym->usage & uDEFINE) != 0) {
+    if (sym->defined) {
         /* function is defined, can now check the return value (but make an
          * exception for directly recursive functions)
          */

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -3097,7 +3097,6 @@ symbol::symbol(const char* symname, cell symaddr, int symident, int symvclass, i
    codeaddr(code_idx),
    vclass((char)symvclass),
    ident((char)symident),
-   flags(0),
    compound(0),
    tag(symtag),
    usage(0),
@@ -3117,6 +3116,7 @@ symbol::symbol(const char* symname, cell symaddr, int symident, int symvclass, i
    enumfield(false),
    predefined(false),
    deprecated(false),
+   queued(false),
    x({}),
    fnumber(-1),
    /* assume global visibility (ignored for local symbols) */
@@ -3158,6 +3158,7 @@ symbol::symbol(const symbol& other)
     is_public = other.is_public;
     is_const = other.is_const;
     deprecated = other.deprecated;
+    // Note: explicitly don't add queued.
 
     x = other.x;
 }

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -3103,6 +3103,7 @@ symbol::symbol(const char* symname, cell symaddr, int symident, int symvclass, i
    compound(0),
    tag(symtag),
    defined(false),
+   stock(false),
    prototyped(false),
    missing(false),
    callback(false),
@@ -3148,6 +3149,7 @@ symbol::symbol(const symbol& other)
     retvalue = other.retvalue;
     forward = other.forward;
     native = other.native;
+    stock = other.stock;
 
     x = other.x;
 }

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -3105,6 +3105,7 @@ symbol::symbol(const char* symname, cell symaddr, int symident, int symvclass, i
    defined(false),
    prototyped(false),
    missing(false),
+   callback(false),
    enumroot(false),
    enumfield(false),
    predefined(false),
@@ -3137,6 +3138,7 @@ symbol::symbol(const symbol& other)
     enumroot = other.enumroot;
     enumfield = other.enumfield;
     predefined = other.predefined;
+    callback = other.callback;
     x = other.x;
 }
 

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -3104,6 +3104,7 @@ symbol::symbol(const char* symname, cell symaddr, int symident, int symvclass, i
    tag(symtag),
    defined(false),
    stock(false),
+   is_public(false),
    is_struct(false),
    prototyped(false),
    missing(false),
@@ -3152,6 +3153,7 @@ symbol::symbol(const symbol& other)
     native = other.native;
     stock = other.stock;
     is_struct = other.is_struct;
+    is_public = other.is_public;
 
     x = other.x;
 }

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -2944,7 +2944,7 @@ delete_symbols(symbol* root, int level, int delete_functions)
                 /* optionally preserve globals (variables & functions), but
                  * NOT native functions
                  */
-                mustdelete = delete_functions || (sym->usage & uNATIVE) != 0;
+                mustdelete = delete_functions || sym->native;
                 assert(sym->parent() == NULL);
                 break;
             case iMETHODMAP:
@@ -3109,6 +3109,7 @@ symbol::symbol(const char* symname, cell symaddr, int symident, int symvclass, i
    skipped(false),
    retvalue(false),
    forward(false),
+   native(false),
    enumroot(false),
    enumfield(false),
    predefined(false),
@@ -3146,6 +3147,7 @@ symbol::symbol(const symbol& other)
     skipped = other.skipped;
     retvalue = other.retvalue;
     forward = other.forward;
+    native = other.native;
 
     x = other.x;
 }

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -2980,7 +2980,7 @@ delete_symbols(symbol* root, int level, int delete_functions)
              * user-defined operators *must* be declared before use
              */
             if (sym->ident == iFUNCTN && !alpha(*sym->name()))
-                sym->usage &= ~uPROTOTYPED;
+                sym->prototyped = false;
             if (origRoot == &glbtab)
                 sym->clear_refers();
             root = sym; /* skip the symbol */
@@ -3103,6 +3103,7 @@ symbol::symbol(const char* symname, cell symaddr, int symident, int symvclass, i
    compound(0),
    tag(symtag),
    defined(false),
+   prototyped(false),
    x({}),
    fnumber(-1),
    /* assume global visibility (ignored for local symbols) */
@@ -3127,6 +3128,7 @@ symbol::symbol(const symbol& other)
 {
     name_ = other.name_;
     defined = other.defined;
+    prototyped = other.prototyped;
     x = other.x;
 }
 

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -2938,7 +2938,7 @@ delete_symbols(symbol* root, int level, int delete_functions)
             case iCONSTEXPR:
             case iENUMSTRUCT:
                 /* delete constants, except predefined constants */
-                mustdelete = delete_functions || (sym->usage & uPREDEF) == 0;
+                mustdelete = delete_functions || !sym->predefined;
                 break;
             case iFUNCTN:
                 /* optionally preserve globals (variables & functions), but
@@ -3107,6 +3107,7 @@ symbol::symbol(const char* symname, cell symaddr, int symident, int symvclass, i
    missing(false),
    enumroot(false),
    enumfield(false),
+   predefined(false),
    x({}),
    fnumber(-1),
    /* assume global visibility (ignored for local symbols) */
@@ -3135,6 +3136,7 @@ symbol::symbol(const symbol& other)
     missing = other.missing;
     enumroot = other.enumroot;
     enumfield = other.enumfield;
+    predefined = other.predefined;
     x = other.x;
 }
 

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -3107,6 +3107,7 @@ symbol::symbol(const char* symname, cell symaddr, int symident, int symvclass, i
    missing(false),
    callback(false),
    skipped(false),
+   retvalue(false),
    enumroot(false),
    enumfield(false),
    predefined(false),
@@ -3142,6 +3143,7 @@ symbol::symbol(const symbol& other)
     predefined = other.predefined;
     callback = other.callback;
     skipped = other.skipped;
+    retvalue = other.retvalue;
 
     x = other.x;
 }

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -3103,6 +3103,7 @@ symbol::symbol(const char* symname, cell symaddr, int symident, int symvclass, i
    compound(0),
    tag(symtag),
    defined(false),
+   is_const(false),
    stock(false),
    is_public(false),
    is_struct(false),
@@ -3154,6 +3155,7 @@ symbol::symbol(const symbol& other)
     stock = other.stock;
     is_struct = other.is_struct;
     is_public = other.is_public;
+    is_const = other.is_const;
 
     x = other.x;
 }

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -2973,7 +2973,7 @@ delete_symbols(symbol* root, int level, int delete_functions)
              * mark it as such, so that its use can be flagged
              */
             if (sym->ident == iFUNCTN && !sym->defined)
-                sym->usage |= uMISSING;
+                sym->missing = true;
             if (sym->ident == iFUNCTN || sym->ident == iVARIABLE || sym->ident == iARRAY)
                 sym->defined = false;
             /* for user defined operators, also remove the "prototyped" flag, as
@@ -3104,6 +3104,7 @@ symbol::symbol(const char* symname, cell symaddr, int symident, int symvclass, i
    tag(symtag),
    defined(false),
    prototyped(false),
+   missing(false),
    x({}),
    fnumber(-1),
    /* assume global visibility (ignored for local symbols) */
@@ -3129,6 +3130,7 @@ symbol::symbol(const symbol& other)
     name_ = other.name_;
     defined = other.defined;
     prototyped = other.prototyped;
+    missing = other.missing;
     x = other.x;
 }
 

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -3104,6 +3104,7 @@ symbol::symbol(const char* symname, cell symaddr, int symident, int symvclass, i
    tag(symtag),
    defined(false),
    stock(false),
+   is_struct(false),
    prototyped(false),
    missing(false),
    callback(false),
@@ -3150,6 +3151,7 @@ symbol::symbol(const symbol& other)
     forward = other.forward;
     native = other.native;
     stock = other.stock;
+    is_struct = other.is_struct;
 
     x = other.x;
 }

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -3108,6 +3108,7 @@ symbol::symbol(const char* symname, cell symaddr, int symident, int symvclass, i
    callback(false),
    skipped(false),
    retvalue(false),
+   forward(false),
    enumroot(false),
    enumfield(false),
    predefined(false),
@@ -3144,6 +3145,7 @@ symbol::symbol(const symbol& other)
     callback = other.callback;
     skipped = other.skipped;
     retvalue = other.retvalue;
+    forward = other.forward;
 
     x = other.x;
 }

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -3106,6 +3106,7 @@ symbol::symbol(const char* symname, cell symaddr, int symident, int symvclass, i
    prototyped(false),
    missing(false),
    callback(false),
+   skipped(false),
    enumroot(false),
    enumfield(false),
    predefined(false),
@@ -3132,6 +3133,7 @@ symbol::symbol(const symbol& other)
  : symbol(nullptr, other.addr_, other.ident, other.vclass, other.tag, other.usage)
 {
     name_ = other.name_;
+
     defined = other.defined;
     prototyped = other.prototyped;
     missing = other.missing;
@@ -3139,6 +3141,8 @@ symbol::symbol(const symbol& other)
     enumfield = other.enumfield;
     predefined = other.predefined;
     callback = other.callback;
+    skipped = other.skipped;
+
     x = other.x;
 }
 

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -3089,19 +3089,18 @@ FunctionData::resizeArgs(size_t nargs)
 }
 
 symbol::symbol()
- : symbol("", 0, 0, 0, 0, 0)
+ : symbol("", 0, 0, 0, 0)
 {}
 
-symbol::symbol(const char* symname, cell symaddr, int symident, int symvclass, int symtag,
-               int symusage)
+symbol::symbol(const char* symname, cell symaddr, int symident, int symvclass, int symtag)
  : next(nullptr),
    codeaddr(code_idx),
    vclass((char)symvclass),
    ident((char)symident),
-   usage((char)symusage),
    flags(0),
    compound(0),
    tag(symtag),
+   usage(0),
    defined(false),
    is_const(false),
    stock(false),
@@ -3137,10 +3136,11 @@ symbol::symbol(const char* symname, cell symaddr, int symident, int symvclass, i
 }
 
 symbol::symbol(const symbol& other)
- : symbol(nullptr, other.addr_, other.ident, other.vclass, other.tag, other.usage)
+ : symbol(nullptr, other.addr_, other.ident, other.vclass, other.tag)
 {
     name_ = other.name_;
 
+    usage = other.usage;
     defined = other.defined;
     prototyped = other.prototyped;
     missing = other.missing;
@@ -3212,10 +3212,10 @@ symbol::drop_reference_from(symbol* from)
  *  or global and local constants).
  */
 symbol*
-addsym(const char* name, cell addr, int ident, int vclass, int tag, int usage)
+addsym(const char* name, cell addr, int ident, int vclass, int tag)
 {
     /* first fill in the entry */
-    symbol* sym = new symbol(name, addr, ident, vclass, tag, usage);
+    symbol* sym = new symbol(name, addr, ident, vclass, tag);
 
     /* then insert it in the list */
     if (vclass == sGLOBAL)
@@ -3259,7 +3259,7 @@ addvariable2(const char* name, cell addr, int ident, int vclass, int tag, int di
         int level;
         sym = NULL; /* to avoid a compiler warning */
         for (level = 0; level < numdim; level++) {
-            top = addsym(name, addr, ident, vclass, tag, 0);
+            top = addsym(name, addr, ident, vclass, tag);
             top->defined = true;
             top->dim.array.length = dim[level];
             top->dim.array.slength = 0;
@@ -3280,7 +3280,7 @@ addvariable2(const char* name, cell addr, int ident, int vclass, int tag, int di
                 sym = top;
         }
     } else {
-        sym = addsym(name, addr, ident, vclass, tag, 0);
+        sym = addsym(name, addr, ident, vclass, tag);
         sym->defined = true;
     }
     return sym;

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -3116,6 +3116,7 @@ symbol::symbol(const char* symname, cell symaddr, int symident, int symvclass, i
    enumroot(false),
    enumfield(false),
    predefined(false),
+   deprecated(false),
    x({}),
    fnumber(-1),
    /* assume global visibility (ignored for local symbols) */
@@ -3156,6 +3157,7 @@ symbol::symbol(const symbol& other)
     is_struct = other.is_struct;
     is_public = other.is_public;
     is_const = other.is_const;
+    deprecated = other.deprecated;
 
     x = other.x;
 }

--- a/compiler/lexer.h
+++ b/compiler/lexer.h
@@ -293,7 +293,7 @@ symbol* findglb(const char* name);
 symbol* findloc(const char* name);
 symbol* findconst(const char* name);
 symbol* find_enumstruct_field(Type* type, const char* name);
-symbol* addsym(const char* name, cell addr, int ident, int vclass, int tag, int usage);
+symbol* addsym(const char* name, cell addr, int ident, int vclass, int tag);
 symbol* addvariable(const char* name, cell addr, int ident, int vclass, int tag, int dim[],
                     int numdim, int idxtag[]);
 symbol* addvariable2(const char* name, cell addr, int ident, int vclass, int tag, int dim[],

--- a/compiler/name-resolution.cpp
+++ b/compiler/name-resolution.cpp
@@ -54,7 +54,7 @@ SymbolExpr::Bind()
      * stub in the first pass (i.e. it was "used" but never declared or
      * implemented, issue an error
      */
-    if (sc_status != statFIRST && sym_->ident == iFUNCTN && (sym_->usage & uPROTOTYPED) == 0) {
+    if (sc_status != statFIRST && sym_->ident == iFUNCTN && !sym_->prototyped) {
         error(pos_, 17, name_->chars());
         return false;
     }

--- a/compiler/name-resolution.cpp
+++ b/compiler/name-resolution.cpp
@@ -136,7 +136,7 @@ IsDefinedExpr::Bind()
     symbol* sym = findloc(name_->chars());
     if (!sym)
         sym = findglb(name_->chars());
-    if (sym && sym->ident == iFUNCTN && (sym->usage & uDEFINE) == 0)
+    if (sym && sym->ident == iFUNCTN && !sym->defined)
         sym = nullptr;
     value_ = sym ? 1 : 0;
     if (!value_ && find_subst(name_->chars(), name_->length(), nullptr))

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -4566,15 +4566,8 @@ newfunc(declinfo_t* decl, const int* thistag, int fpublic, int fstatic, int stoc
      * been incorrectly flagged (as the return tag was unknown at the time of
      * the call)
      */
-    if ((sym->usage & (uPROTOTYPED | uREAD)) == uREAD && sym->tag != 0) {
-        int curstatus = sc_status;
-        sc_status = statWRITE; /* temporarily set status to WRITE, so the warning isn't blocked */
-#if 0                          /* SourceMod - silly, should be removed in first pass, so removed */
-    error(208);
-#endif
-        sc_status = curstatus;
+    if (!sym->prototyped && (sym->usage & uREAD) && sym->tag != 0)
         sc_reparse = TRUE; /* must add another pass to "initial scan" phase */
-    }
 
     /* declare all arguments */
     argcnt = declargs(sym, TRUE, thistag);
@@ -4658,7 +4651,7 @@ newfunc(declinfo_t* decl, const int* thistag, int fpublic, int fstatic, int stoc
     }
 
     // Check that return tags match.
-    if ((sym->usage & uPROTOTYPED) && sym->tag != decl->type.tag) {
+    if (sym->prototyped && sym->tag != decl->type.tag) {
         int old_fline = fline;
         fline = funcline;
         error(180, type_to_name(sym->tag), type_to_name(decl->type.tag));

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -4137,7 +4137,7 @@ fetchfunc(const char* name) {
     }
     if (pc_deprecate.length() > 0) {
         assert(sym != NULL);
-        sym->flags |= flgDEPRECATED;
+        sym->deprecated = true;
         if (sc_status == statWRITE) {
             sym->documentation = ke::Move(pc_deprecate);
         } else {
@@ -4616,7 +4616,7 @@ newfunc(declinfo_t* decl, const int* thistag, int fpublic, int fstatic, int stoc
             sc_err_status = TRUE;
     }
 
-    if ((sym->flags & flgDEPRECATED) != 0 && !sym->stock) {
+    if (sym->deprecated && !sym->stock) {
         const char* ptr = sym->documentation.chars();
         error(234, decl->name, ptr); /* deprecated (probably a public function) */
     }

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -1268,13 +1268,13 @@ declstructvar(char* firstname, int fpublic, pstruct_t* pstruct) {
      * Lastly, very lastly, we will insert a copy of this variable.
      * This is soley to expose the pubvar.
      */
-    usage = uREAD | uCONST | uSTRUCT;
+    usage = uREAD | uCONST;
     if (fpublic)
         usage |= uPUBLIC;
     mysym = NULL;
     for (sym = glbtab.next; sym != NULL; sym = sym->next) {
         if (sym->nameAtom() == name) {
-            if ((sym->usage & uSTRUCT) && sym->vclass == sGLOBAL) {
+            if (sym->is_struct && sym->vclass == sGLOBAL) {
                 if (sym->defined) {
                     error(21, name->chars());
                 } else {
@@ -1296,7 +1296,7 @@ declstructvar(char* firstname, int fpublic, pstruct_t* pstruct) {
     if (!matchtoken('=')) {
         matchtoken(';');
         /* Mark it as undefined instead */
-        mysym->usage = uSTRUCT;
+        mysym->is_struct = true;
         mysym->stock = true;
         free(found);
         free(values);
@@ -1304,6 +1304,7 @@ declstructvar(char* firstname, int fpublic, pstruct_t* pstruct) {
     }
 
     mysym->usage = usage;
+    mysym->is_struct = true;
     needtoken('{');
 
     do {

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -1252,7 +1252,6 @@ declstructvar(char* firstname, int fpublic, pstruct_t* pstruct) {
     char* str;
     int cur_litidx = 0;
     cell *values, *found;
-    int usage;
     symbol *mysym, *sym;
 
     sp::Atom* name = gAtoms.add(firstname);
@@ -1268,7 +1267,6 @@ declstructvar(char* firstname, int fpublic, pstruct_t* pstruct) {
      * Lastly, very lastly, we will insert a copy of this variable.
      * This is soley to expose the pubvar.
      */
-    usage = uREAD;
     mysym = NULL;
     for (sym = glbtab.next; sym != NULL; sym = sym->next) {
         if (sym->nameAtom() == name) {
@@ -1287,9 +1285,10 @@ declstructvar(char* firstname, int fpublic, pstruct_t* pstruct) {
         }
     }
     if (!mysym)
-        mysym = addsym(name->chars(), 0, iVARIABLE, sGLOBAL, pc_addtag(pstruct->name), usage);
+        mysym = addsym(name->chars(), 0, iVARIABLE, sGLOBAL, pc_addtag(pstruct->name));
     else
         mysym->codeaddr = code_idx;
+    mysym->usage |= uREAD;
 
     if (!matchtoken('=')) {
         matchtoken(';');
@@ -1301,7 +1300,6 @@ declstructvar(char* firstname, int fpublic, pstruct_t* pstruct) {
         return;
     }
 
-    mysym->usage = usage;
     mysym->is_struct = true;
     mysym->is_public = !!fpublic;
     mysym->is_const = true;
@@ -3458,8 +3456,7 @@ declare_methodmap_symbol(methodmap_t* map, bool can_redef) {
                      0,          // addr
                      iMETHODMAP, // ident
                      sGLOBAL,    // vclass
-                     map->tag,   // tag
-                     0);   // usage
+                     map->tag);  // tag
         sym->defined = true;
     }
     sym->methodmap = map;
@@ -4133,7 +4130,7 @@ fetchfunc(const char* name) {
         assert(sym->vclass == sGLOBAL);
     } else {
         /* don't set the "uDEFINE" flag; it may be a prototype */
-        sym = addsym(name, code_idx, iFUNCTN, sGLOBAL, 0, 0);
+        sym = addsym(name, code_idx, iFUNCTN, sGLOBAL, 0);
         assert(sym != NULL); /* fatal error 103 must be given on error */
         /* set the required stack size to zero (only for non-native functions) */
         sym->function()->stacksize = 1; /* 1 for PROC opcode */
@@ -5342,7 +5339,7 @@ add_constant(const char* name, cell val, int vclass, int tag) {
 
     /* constant doesn't exist yet (or is allowed to be redefined) */
 redef_enumfield:
-    sym = addsym(name, val, iCONSTEXPR, vclass, tag, 0);
+    sym = addsym(name, val, iCONSTEXPR, vclass, tag);
     sym->defined = true;
     if (sc_status == statIDLE)
         sym->predefined = true;

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -4602,7 +4602,7 @@ newfunc(declinfo_t* decl, const int* thistag, int fpublic, int fstatic, int stoc
         glbdecl = glb_declared;
 
         sc_status = statSKIP;
-        sym->usage |= uSKIPPED;
+        sym->skipped = true;
 
         // If this is a method, output errors even if it's unused.
         if (thistag && *thistag != -1)

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -4426,7 +4426,7 @@ funcstub(int tokid, declinfo_t* decl, const int* thistag) {
     sym = fetchfunc(decl->name);
     if (sym == NULL)
         return NULL;
-    if ((sym->usage & uPROTOTYPED) != 0 && sym->tag != decl->type.tag)
+    if (sym->prototyped && sym->tag != decl->type.tag)
         error(25);
     if (!sym->defined) {
         // As long as the function stays undefined, update its address and tag.
@@ -4435,7 +4435,7 @@ funcstub(int tokid, declinfo_t* decl, const int* thistag) {
     }
 
     if (fnative) {
-        sym->usage = (char)(uNATIVE | uRETVALUE | (sym->usage & uPROTOTYPED));
+        sym->usage = (char)(uNATIVE | uRETVALUE);
         sym->defined = true;
     } else if (fpublic) {
         sym->usage |= uPUBLIC;
@@ -4543,7 +4543,7 @@ newfunc(declinfo_t* decl, const int* thistag, int fpublic, int fstatic, int stoc
         return TRUE;
 
     // If the function has not been prototyed, set its tag.
-    if (!(sym->usage & uPROTOTYPED))
+    if (!sym->prototyped)
         sym->tag = decl->type.tag;
 
     // As long as the function stays undefined, update its address.
@@ -4761,14 +4761,14 @@ declargs(symbol* sym, int chkshadow, const int* thistag) {
      * of the existing definition
      */
     oldargcnt = 0;
-    if ((sym->usage & uPROTOTYPED) != 0)
+    if (sym->prototyped)
         while (arglist[oldargcnt].ident != 0)
             oldargcnt++;
     argcnt = 0; /* zero aruments up to now */
 
     if (thistag && *thistag != -1) {
         arginfo* argptr;
-        if ((sym->usage & uPROTOTYPED) == 0) {
+        if (!sym->prototyped) {
             // Push a copy of the terminal argument.
             sym->function()->resizeArgs(argcnt + 1);
 
@@ -4806,7 +4806,7 @@ declargs(symbol* sym, int chkshadow, const int* thistag) {
             check_void_decl(&decl, TRUE);
 
             if (decl.type.ident == iVARARGS) {
-                if ((sym->usage & uPROTOTYPED) == 0) {
+                if (!sym->prototyped) {
                     /* redimension the argument list, add the entry iVARARGS */
                     sym->function()->resizeArgs(argcnt + 1);
 
@@ -4849,7 +4849,7 @@ declargs(symbol* sym, int chkshadow, const int* thistag) {
                 error(59,
                       decl.name); /* arguments of a public function may not have a default value */
 
-            if ((sym->usage & uPROTOTYPED) == 0) {
+            if (!sym->prototyped) {
                 /* redimension the argument list, add the entry */
                 sym->function()->resizeArgs(argcnt + 1);
                 arglist[argcnt] = arg;
@@ -4867,7 +4867,7 @@ declargs(symbol* sym, int chkshadow, const int* thistag) {
         needtoken(')');
     }
 
-    sym->usage |= uPROTOTYPED;
+    sym->prototyped = true;
     errorset(sRESET, 0); /* reset error flag (clear the "panic mode")*/
     return argcnt;
 }

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -5336,7 +5336,7 @@ redef_enumfield:
     sym = addsym(name, val, iCONSTEXPR, vclass, tag, 0);
     sym->defined = true;
     if (sc_status == statIDLE)
-        sym->usage |= uPREDEF;
+        sym->predefined = true;
     return sym;
 }
 

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -4975,7 +4975,7 @@ doarg(symbol* fun, declinfo_t* decl, int offset, int chkshadow, arginfo* arg) {
         argsym->compound = 0;
         if (type->ident == iREFERENCE)
             argsym->usage |= uREAD; /* because references are passed back */
-        if (fun->usage & (uPUBLIC | uSTOCK | uCALLBACK))
+        if (fun->callback || (fun->usage & (uPUBLIC | uSTOCK)))
             argsym->usage |= uREAD; /* arguments of public functions are always "used" */
         if (type->usage & uCONST)
             argsym->usage |= uCONST;

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -3191,7 +3191,7 @@ parse_inline_function(methodmap_t* map, const typeinfo_t* type, const char* name
 
         if (!ok)
             return NULL;
-        if (!target || (target->usage & uFORWARD)) {
+        if (!target || target->forward) {
             error(10);
             return NULL;
         }
@@ -4448,7 +4448,7 @@ funcstub(int tokid, declinfo_t* decl, const int* thistag) {
     } else if (fpublic) {
         sym->usage |= uPUBLIC;
     }
-    sym->usage |= uFORWARD;
+    sym->forward = true;
 
     declargs(sym, FALSE, thistag);
     /* "declargs()" found the ")" */
@@ -4562,7 +4562,7 @@ newfunc(declinfo_t* decl, const int* thistag, int fpublic, int fstatic, int stoc
     if (fstatic)
         sym->fnumber = filenum;
 
-    if (sym->usage & (uPUBLIC | uFORWARD)) {
+    if ((sym->usage & uPUBLIC) || sym->forward) {
         if (decl->type.numdim > 0)
             error(141);
     }
@@ -4593,7 +4593,7 @@ newfunc(declinfo_t* decl, const int* thistag, int fpublic, int fstatic, int stoc
     if (matchtoken(';')) {
         if (sym->usage & uPUBLIC)
             error(10);
-        sym->usage |= uFORWARD;
+        sym->forward = true;
         if (!sc_needsemicolon)
             error(10); /* old style prototypes used with optional semicolumns */
         delete_symbols(&loctab, 0, TRUE); /* prototype is done; forget everything */
@@ -4649,7 +4649,7 @@ newfunc(declinfo_t* decl, const int* thistag, int fpublic, int fstatic, int stoc
     if (sReturnType & RETURN_VALUE) {
         sym->retvalue = true;
     } else {
-        if (sym->tag == pc_tag_void && (sym->usage & uFORWARD) && !decl->type.tag &&
+        if (sym->tag == pc_tag_void && sym->forward && !decl->type.tag &&
             !decl->type.is_new) {
             // We got something like:
             //    forward void X();

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -194,6 +194,9 @@ struct symbol {
     // Variables and functions: discardable without warning
     bool stock : 1;
 
+    // TODO: make this an ident.
+    bool is_struct : 1;
+
     // Functions only.
     bool prototyped : 1;    // prototyped, implicitly via a definition or explicitly
     bool missing : 1;       // the function is not implemented in this source file
@@ -334,7 +337,6 @@ struct symbol {
 #define uWRITTEN 0x004
 #define uCONST 0x008
 #define uPUBLIC 0x010
-#define uSTRUCT 0x200   /* :TODO: make this an ident */
 
 #define flgDEPRECATED 0x01 /* symbol is deprecated (avoid use) */
 #define flgQUEUED 0x02     /* symbol is queued for a local work algorithm */

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -191,6 +191,9 @@ struct symbol {
     // Constant: the symbol is defined in the source file.
     bool defined : 1;
 
+    // Variables and functions: discardable without warning
+    bool stock : 1;
+
     // Functions only.
     bool prototyped : 1;    // prototyped, implicitly via a definition or explicitly
     bool missing : 1;       // the function is not implemented in this source file
@@ -316,13 +319,11 @@ struct symbol {
  *        2     (uWRITTEN) the variable is altered (assigned a value)
  *        3     (uCONST) the variable is constant (may not be assigned to)
  *        4     (uPUBLIC) the variable is public
- *        6     (uSTOCK) the variable is discardable (without warning)
  *
  *  FUNCTION
  *  bits: 0     (uDEFINE) the function is defined ("implemented") in the source file
  *        1     (uREAD) the function is invoked in the source file
  *        4     (uPUBLIC) the function is public
- *        6     (uSTOCK) the function is discardable (without warning)
  *
  *  CONSTANT
  *  bits: 0     (uDEFINE) the symbol is defined in the source file
@@ -333,7 +334,6 @@ struct symbol {
 #define uWRITTEN 0x004
 #define uCONST 0x008
 #define uPUBLIC 0x010
-#define uSTOCK 0x040
 #define uSTRUCT 0x200   /* :TODO: make this an ident */
 
 #define flgDEPRECATED 0x01 /* symbol is deprecated (avoid use) */

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -198,6 +198,7 @@ struct symbol {
     bool skipped : 1;       // skipped in codegen
     bool retvalue : 1;      // function returns (or should return) a value
     bool forward : 1;       // the function is explicitly forwardly declared
+    bool native : 1;        // the function is native
 
     // Constants only.
     bool enumroot : 1;      // the constant is the "root" of an enumeration
@@ -321,7 +322,6 @@ struct symbol {
  *  bits: 0     (uDEFINE) the function is defined ("implemented") in the source file
  *        1     (uREAD) the function is invoked in the source file
  *        4     (uPUBLIC) the function is public
- *        5     (uNATIVE) the function is native
  *        6     (uSTOCK) the function is discardable (without warning)
  *
  *  CONSTANT
@@ -333,7 +333,6 @@ struct symbol {
 #define uWRITTEN 0x004
 #define uCONST 0x008
 #define uPUBLIC 0x010
-#define uNATIVE 0x020
 #define uSTOCK 0x040
 #define uSTRUCT 0x200   /* :TODO: make this an ident */
 

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -215,6 +215,9 @@ struct symbol {
     bool enumfield : 1;     // the constant is a field in a named enumeration
     bool predefined : 1;    // the constant is pre-defined and should be kept between passes
 
+    // General symbol flags.
+    bool deprecated : 1;    // symbol is deprecated (avoid use)
+
     union {
         struct {
             int index; /* array & enum: tag of array indices or the enum item */
@@ -319,7 +322,6 @@ struct symbol {
 #define uREAD       0x1     // Used/accessed.
 #define uWRITTEN    0x2     // Altered/written (variables only).
 
-#define flgDEPRECATED 0x01 /* symbol is deprecated (avoid use) */
 #define flgQUEUED 0x02     /* symbol is queued for a local work algorithm */
 
 #define uMAINFUNC "main"

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -195,6 +195,10 @@ struct symbol {
     bool prototyped : 1;    // prototyped, implicitly via a definition or explicitly
     bool missing : 1;       // the function is not implemented in this source file
 
+    // Constants only.
+    bool enumroot : 1;      // the constant is the "root" of an enumeration
+    bool enumfield : 1;     // the constant is a field in a named enumeration
+
     union {
         struct {
             int index; /* array & enum: tag of array indices or the enum item */
@@ -322,8 +326,6 @@ struct symbol {
  *        1     (uREAD) the constant is "read" (accessed) in the source file
  *        2     (uWRITTEN) redundant, but may be set for constants passed by reference
  *        3     (uPREDEF) the constant is pre-defined and should be kept between passes
- *        5     (uENUMROOT) the constant is the "root" of an enumeration
- *        6     (uENUMFIELD) the constant is a field in a named enumeration
  */
 #define uREAD 0x002
 #define uWRITTEN 0x004
@@ -332,9 +334,7 @@ struct symbol {
 #define uPREDEF 0x008 /* constant is pre-defined */
 #define uPUBLIC 0x010
 #define uNATIVE 0x020
-#define uENUMROOT 0x020
 #define uSTOCK 0x040
-#define uENUMFIELD 0x040
 #define uFORWARD 0x100
 #define uSTRUCT 0x200   /* :TODO: make this an ident */
 #define uCALLBACK 0x400 /* Used as a callback */

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -191,8 +191,9 @@ struct symbol {
     // Constant: the symbol is defined in the source file.
     bool defined : 1;
 
-    // Variables and functions: discardable without warning
-    bool stock : 1;
+    // Variables and functions.
+    bool stock : 1;         // discardable without warning
+    bool is_public : 1;     // publicly exposed
 
     // TODO: make this an ident.
     bool is_struct : 1;
@@ -321,12 +322,10 @@ struct symbol {
  *        1     (uREAD) the variable is "read" (accessed) in the source file
  *        2     (uWRITTEN) the variable is altered (assigned a value)
  *        3     (uCONST) the variable is constant (may not be assigned to)
- *        4     (uPUBLIC) the variable is public
  *
  *  FUNCTION
  *  bits: 0     (uDEFINE) the function is defined ("implemented") in the source file
  *        1     (uREAD) the function is invoked in the source file
- *        4     (uPUBLIC) the function is public
  *
  *  CONSTANT
  *  bits: 0     (uDEFINE) the symbol is defined in the source file
@@ -336,7 +335,6 @@ struct symbol {
 #define uREAD 0x002
 #define uWRITTEN 0x004
 #define uCONST 0x008
-#define uPUBLIC 0x010
 
 #define flgDEPRECATED 0x01 /* symbol is deprecated (avoid use) */
 #define flgQUEUED 0x02     /* symbol is queued for a local work algorithm */

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -181,7 +181,6 @@ struct symbol {
     cell codeaddr; /* address (in the code segment) where the symbol declaration starts */
     char vclass;   /* sLOCAL if "addr" refers to a local symbol */
     char ident;    /* see below for possible values */
-    char flags;    /* see below for possible values */
     int compound;  /* compound level (braces nesting level) */
     int tag;       /* tagname id */
 
@@ -217,6 +216,7 @@ struct symbol {
 
     // General symbol flags.
     bool deprecated : 1;    // symbol is deprecated (avoid use)
+    bool queued : 1;        // symbol is queued for a local work algorithm
 
     union {
         struct {
@@ -321,8 +321,6 @@ struct symbol {
 // Values for symbol::usage.
 #define uREAD       0x1     // Used/accessed.
 #define uWRITTEN    0x2     // Altered/written (variables only).
-
-#define flgQUEUED 0x02     /* symbol is queued for a local work algorithm */
 
 #define uMAINFUNC "main"
 

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -198,6 +198,7 @@ struct symbol {
     // Constants only.
     bool enumroot : 1;      // the constant is the "root" of an enumeration
     bool enumfield : 1;     // the constant is a field in a named enumeration
+    bool predefined : 1;    // the constant is pre-defined and should be kept between passes
 
     union {
         struct {
@@ -325,13 +326,11 @@ struct symbol {
  *  bits: 0     (uDEFINE) the symbol is defined in the source file
  *        1     (uREAD) the constant is "read" (accessed) in the source file
  *        2     (uWRITTEN) redundant, but may be set for constants passed by reference
- *        3     (uPREDEF) the constant is pre-defined and should be kept between passes
  */
 #define uREAD 0x002
 #define uWRITTEN 0x004
 #define uRETVALUE 0x004 /* function returns (or should return) a value */
 #define uCONST 0x008
-#define uPREDEF 0x008 /* constant is pre-defined */
 #define uPUBLIC 0x010
 #define uNATIVE 0x020
 #define uSTOCK 0x040

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -191,8 +191,9 @@ struct symbol {
     // Constant: the symbol is defined in the source file.
     bool defined : 1;
 
-    // Function: prototyped, implicitly via a definition or explicitly
-    bool prototyped : 1;
+    // Functions only.
+    bool prototyped : 1;    // prototyped, implicitly via a definition or explicitly
+    bool missing : 1;       // the function is not implemented in this source file
 
     union {
         struct {
@@ -314,7 +315,6 @@ struct symbol {
  *        4     (uPUBLIC) the function is public
  *        5     (uNATIVE) the function is native
  *        6     (uSTOCK) the function is discardable (without warning)
- *        7     (uMISSING) the function is not implemented in this source file
  *        8     (uFORWARD) the function is explicitly forwardly declared
  *
  *  CONSTANT
@@ -335,7 +335,6 @@ struct symbol {
 #define uENUMROOT 0x020
 #define uSTOCK 0x040
 #define uENUMFIELD 0x040
-#define uMISSING 0x080
 #define uFORWARD 0x100
 #define uSTRUCT 0x200   /* :TODO: make this an ident */
 #define uCALLBACK 0x400 /* Used as a callback */

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -196,6 +196,7 @@ struct symbol {
     bool missing : 1;       // the function is not implemented in this source file
     bool callback : 1;      // used as a callback
     bool skipped : 1;       // skipped in codegen
+    bool retvalue : 1;      // function returns (or should return) a value
 
     // Constants only.
     bool enumroot : 1;      // the constant is the "root" of an enumeration
@@ -318,7 +319,6 @@ struct symbol {
  *  FUNCTION
  *  bits: 0     (uDEFINE) the function is defined ("implemented") in the source file
  *        1     (uREAD) the function is invoked in the source file
- *        2     (uRETVALUE) the function returns a value (or should return a value)
  *        4     (uPUBLIC) the function is public
  *        5     (uNATIVE) the function is native
  *        6     (uSTOCK) the function is discardable (without warning)
@@ -331,18 +331,12 @@ struct symbol {
  */
 #define uREAD 0x002
 #define uWRITTEN 0x004
-#define uRETVALUE 0x004 /* function returns (or should return) a value */
 #define uCONST 0x008
 #define uPUBLIC 0x010
 #define uNATIVE 0x020
 #define uSTOCK 0x040
 #define uFORWARD 0x100
 #define uSTRUCT 0x200   /* :TODO: make this an ident */
-/* uRETNONE is not stored in the "usage" field of a symbol. It is
- * used during parsing a function, to detect a mix of "return;" and
- * "return value;" in a few special cases.
- */
-#define uRETNONE 0x10
 
 #define flgDEPRECATED 0x01 /* symbol is deprecated (avoid use) */
 #define flgQUEUED 0x02     /* symbol is queued for a local work algorithm */

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -69,7 +69,7 @@ typedef int jmp_buf[9];
 struct arginfo { /* function argument info */
     char name[sNAMEMAX + 1];
     char ident; /* iVARIABLE, iREFERENCE, iREFARRAY or iVARARGS */
-    char usage; /* uCONST */
+    bool is_const;
     int tag;    /* argument tag id */
     int dim[sDIMEN_MAX];
     int idxtag[sDIMEN_MAX];
@@ -190,6 +190,7 @@ struct symbol {
     // Function: the function is defined ("implemented") in the source file
     // Constant: the symbol is defined in the source file.
     bool defined : 1;
+    bool is_const : 1;
 
     // Variables and functions.
     bool stock : 1;         // discardable without warning
@@ -321,7 +322,6 @@ struct symbol {
  *  bits: 0     (uDEFINE) the variable is defined in the source file
  *        1     (uREAD) the variable is "read" (accessed) in the source file
  *        2     (uWRITTEN) the variable is altered (assigned a value)
- *        3     (uCONST) the variable is constant (may not be assigned to)
  *
  *  FUNCTION
  *  bits: 0     (uDEFINE) the function is defined ("implemented") in the source file
@@ -334,7 +334,6 @@ struct symbol {
  */
 #define uREAD 0x002
 #define uWRITTEN 0x004
-#define uCONST 0x008
 
 #define flgDEPRECATED 0x01 /* symbol is deprecated (avoid use) */
 #define flgQUEUED 0x02     /* symbol is queued for a local work algorithm */

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -191,6 +191,9 @@ struct symbol {
     // Constant: the symbol is defined in the source file.
     bool defined : 1;
 
+    // Function: prototyped, implicitly via a definition or explicitly
+    bool prototyped : 1;
+
     union {
         struct {
             int index; /* array & enum: tag of array indices or the enum item */
@@ -308,7 +311,6 @@ struct symbol {
  *  bits: 0     (uDEFINE) the function is defined ("implemented") in the source file
  *        1     (uREAD) the function is invoked in the source file
  *        2     (uRETVALUE) the function returns a value (or should return a value)
- *        3     (uPROTOTYPED) the function was prototyped (implicitly via a definition or explicitly)
  *        4     (uPUBLIC) the function is public
  *        5     (uNATIVE) the function is native
  *        6     (uSTOCK) the function is discardable (without warning)
@@ -327,7 +329,6 @@ struct symbol {
 #define uWRITTEN 0x004
 #define uRETVALUE 0x004 /* function returns (or should return) a value */
 #define uCONST 0x008
-#define uPROTOTYPED 0x008
 #define uPREDEF 0x008 /* constant is pre-defined */
 #define uPUBLIC 0x010
 #define uNATIVE 0x020

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -197,6 +197,7 @@ struct symbol {
     bool callback : 1;      // used as a callback
     bool skipped : 1;       // skipped in codegen
     bool retvalue : 1;      // function returns (or should return) a value
+    bool forward : 1;       // the function is explicitly forwardly declared
 
     // Constants only.
     bool enumroot : 1;      // the constant is the "root" of an enumeration
@@ -322,7 +323,6 @@ struct symbol {
  *        4     (uPUBLIC) the function is public
  *        5     (uNATIVE) the function is native
  *        6     (uSTOCK) the function is discardable (without warning)
- *        8     (uFORWARD) the function is explicitly forwardly declared
  *
  *  CONSTANT
  *  bits: 0     (uDEFINE) the symbol is defined in the source file
@@ -335,7 +335,6 @@ struct symbol {
 #define uPUBLIC 0x010
 #define uNATIVE 0x020
 #define uSTOCK 0x040
-#define uFORWARD 0x100
 #define uSTRUCT 0x200   /* :TODO: make this an ident */
 
 #define flgDEPRECATED 0x01 /* symbol is deprecated (avoid use) */

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -195,6 +195,7 @@ struct symbol {
     bool prototyped : 1;    // prototyped, implicitly via a definition or explicitly
     bool missing : 1;       // the function is not implemented in this source file
     bool callback : 1;      // used as a callback
+    bool skipped : 1;       // skipped in codegen
 
     // Constants only.
     bool enumroot : 1;      // the constant is the "root" of an enumeration
@@ -337,7 +338,6 @@ struct symbol {
 #define uSTOCK 0x040
 #define uFORWARD 0x100
 #define uSTRUCT 0x200   /* :TODO: make this an ident */
-#define uSKIPPED 0x800  /* Not generated */
 /* uRETNONE is not stored in the "usage" field of a symbol. It is
  * used during parsing a function, to detect a mix of "return;" and
  * "return value;" in a few special cases.

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -185,6 +185,12 @@ struct symbol {
     char flags;    /* see below for possible values */
     int compound;  /* compound level (braces nesting level) */
     int tag;       /* tagname id */
+
+    // Variable: the variable is defined in the source file.
+    // Function: the function is defined ("implemented") in the source file
+    // Constant: the symbol is defined in the source file.
+    bool defined : 1;
+
     union {
         struct {
             int index; /* array & enum: tag of array indices or the enum item */
@@ -317,7 +323,6 @@ struct symbol {
  *        5     (uENUMROOT) the constant is the "root" of an enumeration
  *        6     (uENUMFIELD) the constant is a field in a named enumeration
  */
-#define uDEFINE 0x001
 #define uREAD 0x002
 #define uWRITTEN 0x004
 #define uRETVALUE 0x004 /* function returns (or should return) a value */

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -174,17 +174,19 @@ struct symbol;
 struct symbol {
     symbol();
     symbol(const symbol& other);
-    symbol(const char* name, cell addr, int ident, int vclass, int tag, int usage);
+    symbol(const char* name, cell addr, int ident, int vclass, int tag);
     ~symbol();
 
     symbol* next;
     cell codeaddr; /* address (in the code segment) where the symbol declaration starts */
     char vclass;   /* sLOCAL if "addr" refers to a local symbol */
     char ident;    /* see below for possible values */
-    short usage;   /* see below for possible values */
     char flags;    /* see below for possible values */
     int compound;  /* compound level (braces nesting level) */
     int tag;       /* tagname id */
+
+    // See uREAD/uWRITTEN above.
+    uint8_t usage : 2;
 
     // Variable: the variable is defined in the source file.
     // Function: the function is defined ("implemented") in the source file
@@ -313,27 +315,9 @@ struct symbol {
     symbol* child_;
 };
 
-/*  Possible entries for "usage"
- *
- *  This byte is used as a serie of bits, the syntax is different for
- *  functions and other symbols:
- *
- *  VARIABLE
- *  bits: 0     (uDEFINE) the variable is defined in the source file
- *        1     (uREAD) the variable is "read" (accessed) in the source file
- *        2     (uWRITTEN) the variable is altered (assigned a value)
- *
- *  FUNCTION
- *  bits: 0     (uDEFINE) the function is defined ("implemented") in the source file
- *        1     (uREAD) the function is invoked in the source file
- *
- *  CONSTANT
- *  bits: 0     (uDEFINE) the symbol is defined in the source file
- *        1     (uREAD) the constant is "read" (accessed) in the source file
- *        2     (uWRITTEN) redundant, but may be set for constants passed by reference
- */
-#define uREAD 0x002
-#define uWRITTEN 0x004
+// Values for symbol::usage.
+#define uREAD       0x1     // Used/accessed.
+#define uWRITTEN    0x2     // Altered/written (variables only).
 
 #define flgDEPRECATED 0x01 /* symbol is deprecated (avoid use) */
 #define flgQUEUED 0x02     /* symbol is queued for a local work algorithm */

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -194,6 +194,7 @@ struct symbol {
     // Functions only.
     bool prototyped : 1;    // prototyped, implicitly via a definition or explicitly
     bool missing : 1;       // the function is not implemented in this source file
+    bool callback : 1;      // used as a callback
 
     // Constants only.
     bool enumroot : 1;      // the constant is the "root" of an enumeration
@@ -336,7 +337,6 @@ struct symbol {
 #define uSTOCK 0x040
 #define uFORWARD 0x100
 #define uSTRUCT 0x200   /* :TODO: make this an ident */
-#define uCALLBACK 0x400 /* Used as a callback */
 #define uSKIPPED 0x800  /* Not generated */
 /* uRETNONE is not stored in the "usage" field of a symbol. It is
  * used during parsing a function, to detect a mix of "return;" and

--- a/compiler/sclist.cpp
+++ b/compiler/sclist.cpp
@@ -68,7 +68,7 @@ struct MacroEntry {
     ke::AString first;
     ke::AString second;
     ke::AString documentation;
-    int flags;
+    bool deprecated;
 };
 static bool sMacroTableInitialized;
 static ke::HashMap<ke::AString, MacroEntry, MacroTablePolicy> sMacros;
@@ -198,9 +198,9 @@ insert_subst(const char* pattern, size_t pattern_length, const char* substitutio
     MacroEntry macro;
     macro.first = pattern;
     macro.second = substitution;
-    macro.flags = 0;
+    macro.deprecated = false;
     if (pc_deprecate.length() > 0) {
-        macro.flags |= flgDEPRECATED;
+        macro.deprecated = true;
         if (sc_status == statWRITE)
             macro.documentation = ke::Move(pc_deprecate);
         else
@@ -224,7 +224,7 @@ find_subst(const char* name, size_t length, macro_t* macro)
         return false;
 
     MacroEntry& entry = p->value;
-    if (entry.flags & flgDEPRECATED)
+    if (entry.deprecated)
         error(234, p->key.chars(), entry.documentation.chars());
 
     if (macro) {

--- a/compiler/sclist.cpp
+++ b/compiler/sclist.cpp
@@ -364,7 +364,7 @@ insert_dbgsymbol(symbol* sym)
         /* address tag:name codestart codeend ident vclass [tag:dim ...] */
         assert(sym->ident != iFUNCTN);
         sprintf(string, "S:%" PRIxC " %x:%s %" PRIxC " %" PRIxC " %x %x %x", sym->addr(), sym->tag,
-                symname, sym->codeaddr, code_idx, sym->ident, sym->vclass, sym->usage);
+                symname, sym->codeaddr, code_idx, sym->ident, sym->vclass, (int)sym->is_const);
         if (sym->ident == iARRAY || sym->ident == iREFARRAY) {
 #if !defined NDEBUG
             int count = sym->dim.array.level;

--- a/compiler/sctracker.cpp
+++ b/compiler/sctracker.cpp
@@ -130,7 +130,7 @@ funcenum_for_symbol(symbol* sym)
         memcpy(dest->dims, arg.dim, arg.numdim * sizeof(int));
 
         dest->ident = arg.ident;
-        dest->fconst = !!(arg.usage & uCONST);
+        dest->fconst = arg.is_const;
         dest->ommittable = FALSE;
     }
 

--- a/compiler/sctracker.cpp
+++ b/compiler/sctracker.cpp
@@ -115,7 +115,6 @@ funcenum_for_symbol(symbol* sym)
     auto ft = ke::MakeUnique<functag_t>();
 
     ft->ret_tag = sym->tag;
-    ft->usage = uPUBLIC & (sym->usage & uRETVALUE);
     ft->argcount = 0;
     ft->ommittable = FALSE;
     for (arginfo& arg : sym->function()->args) {

--- a/compiler/sctracker.h
+++ b/compiler/sctracker.h
@@ -21,13 +21,11 @@ typedef struct funcarg_s {
 struct functag_t {
     functag_t()
      : ret_tag(0),
-       usage(0),
        argcount(0),
        ommittable(0),
        args()
     {}
     int ret_tag;
-    int usage;
     int argcount;
     int ommittable;
     funcarg_t args[SP_MAX_EXEC_PARAMS];

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -217,7 +217,7 @@ IncDecExpr::Analyze()
 
     const auto& expr_val = expr_->val();
     if (expr_val.ident != iACCESSOR) {
-        if ((expr_val.sym->usage & uCONST) != 0) {
+        if (expr_val.sym->is_const) {
             error(pos_, 22); /* assignment to const argument */
             return false;
         }
@@ -407,7 +407,7 @@ BinaryExpr::ValidateAssignmentLHS()
     assert(left_val.sym || left_val.accessor);
 
     // may not change "constant" parameters
-    if (left_val.sym && (left_val.sym->usage & uCONST) != 0) {
+    if (left_val.sym && left_val.sym->is_const) {
         error(pos_, 22);
         return false;
     }
@@ -1590,7 +1590,7 @@ CallExpr::ProcessArg(arginfo* arg, Expr* param, unsigned int pos)
 
             // Always pass by reference.
             if (val->ident == iVARIABLE || val->ident == iREFERENCE) {
-                if ((val->sym->usage & uCONST) && (arg->usage & uCONST) == 0) {
+                if (val->sym->is_const && !arg->is_const) {
                     // Treat a "const" variable passed to a function with a
                     // non-const "variable argument list" as a constant here.
                     if (!lvalue) {
@@ -1631,7 +1631,7 @@ CallExpr::ProcessArg(arginfo* arg, Expr* param, unsigned int pos)
                 error(pos_, 35, visual_pos); // argument type mismatch
                 return false;
             }
-            if (val->sym && (val->sym->usage & uCONST) && !(arg->usage & uCONST)) {
+            if (val->sym && val->sym->is_const && !arg->is_const) {
                 error(pos_, 35, visual_pos); // argument type mismatch
                 return false;
             }
@@ -1644,7 +1644,7 @@ CallExpr::ProcessArg(arginfo* arg, Expr* param, unsigned int pos)
                 error(pos_, 35, visual_pos); // argument type mismatch
                 return false;
             }
-            if (val->sym && (val->sym->usage & uCONST) && !(arg->usage & uCONST)) {
+            if (val->sym && val->sym->is_const && !arg->is_const) {
                 error(pos_, 35, visual_pos); // argument type mismatch
                 return false;
             }

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -1445,7 +1445,7 @@ CallExpr::Analyze()
     // read, then we're encountering some kind of compiler bug. If we're not
     // supposed to emit this code than the status should be statSKIP - so
     // we're generating code that will jump to the wrong address.
-    if ((sym_->usage & uSTOCK) && !(sym_->usage & uREAD) && sc_status == statWRITE) {
+    if (sym_->stock && !(sym_->usage & uREAD) && sc_status == statWRITE) {
         error(pos_, 195, sym_->name());
         return false;
     }

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -1741,13 +1741,13 @@ CallExpr::MarkUsed()
         /* function is defined, can now check the return value (but make an
          * exception for directly recursive functions)
          */
-        if (sym_ != curfunc && (sym_->usage & uRETVALUE) == 0) {
+        if (sym_ != curfunc && !sym_->retvalue) {
             char symname[2 * sNAMEMAX + 16]; /* allow space for user defined operators */
             funcdisplayname(symname, sym_->name());
             error(pos_, 209, symname); /* function should return a value */
         }
     } else {
         /* function not yet defined, set */
-        sym_->usage |= uRETVALUE;
+        sym_->retvalue = true;
     }
 }

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -1457,7 +1457,7 @@ CallExpr::Analyze()
         val_.sym = sym_->array_return();
     }
 
-    if ((sym_->flags & flgDEPRECATED) != 0) {
+    if (sym_->deprecated) {
         const char* ptr = sym_->documentation.chars();
         error(pos_, 234, sym_->name(), ptr); /* deprecated (probably a native function) */
     }

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -801,7 +801,7 @@ SymbolExpr::AnalyzeWithOptions(bool allow_types)
         // If the function is only in the table because it was inserted as
         // a stub in the first pass (used but never declared or implemented),
         // issue an error.
-        if ((sym_->usage & uPROTOTYPED) == 0)
+        if (!sym_->prototyped)
             error(pos_, 17, sym_->name());
 
         if (sym_->usage & uNATIVE) {

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -933,7 +933,7 @@ IndexExpr::Analyze()
         return false;
     }
 
-    if ((base.sym->usage & uENUMROOT)) {
+    if (base.sym->enumroot) {
         if (!matchtag(base.sym->x.tags.index, expr_->val().tag, TRUE))
             return false;
     }

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -792,7 +792,7 @@ SymbolExpr::AnalyzeWithOptions(bool allow_types)
     }
 
     if (sym_->vclass == sGLOBAL && sym_->ident != iFUNCTN) {
-        if ((sym_->usage & uDEFINE) == 0) {
+        if (!sym_->defined) {
             error(pos_, 17, sym_->name());
             return false;
         }
@@ -1326,7 +1326,7 @@ SizeofExpr::Analyze()
     } else if (sym->ident == iFUNCTN) {
         error(pos_, 72); // "function" symbol has no size
         return false;
-    } else if ((sym->usage & uDEFINE) == 0) {
+    } else if (!sym->defined) {
         error(pos_, 17, ident_->chars());
         return false;
     }
@@ -1737,7 +1737,7 @@ CallExpr::ProcessUses()
 void
 CallExpr::MarkUsed()
 {
-    if ((sym_->usage & uDEFINE) != 0) {
+    if (sym_->defined) {
         /* function is defined, can now check the return value (but make an
          * exception for directly recursive functions)
          */

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -804,7 +804,7 @@ SymbolExpr::AnalyzeWithOptions(bool allow_types)
         if (!sym_->prototyped)
             error(pos_, 17, sym_->name());
 
-        if (sym_->usage & uNATIVE) {
+        if (sym_->native) {
             error(pos_, 76);
             return false;
         }

--- a/compiler/types.h
+++ b/compiler/types.h
@@ -64,9 +64,9 @@ struct typeinfo_t {
     // Type information.
     int tag;           // Effective tag.
     int ident;         // Either iREFERENCE, iARRAY, or iVARIABLE.
-    char usage;        // Usage flags.
-    bool is_new;       // New-style declaration.
-    bool has_postdims; // Dimensions, if present, were in postfix position.
+    bool is_const : 1;
+    bool is_new : 1;        // New-style declaration.
+    bool has_postdims : 1;  // Dimensions, if present, were in postfix position.
 
     // If non-zero, this type was originally declared with this type, but was
     // rewritten for desugaring.


### PR DESCRIPTION
These fields are really annoying when debugging, I have to look up the bit assignments every time, and some of them are overlapped. This patch series moves everything but uREAD and uWRITTEN into dedicated fields.