### PR TITLE
exp::compiler::source-manager - added createFromBuffer method

### DIFF
--- a/exp/compiler/source-manager.cpp
+++ b/exp/compiler/source-manager.cpp
@@ -143,6 +143,22 @@ SourceManager::open(ReportingContext& cc, const char* path)
   return file;
 }
 
+RefPtr<SourceFile>
+SourceManager::createFromBuffer(UniquePtr<char[]>&& buffer, uint32_t length, const char* path)
+{
+  Atom* atom = strings_.add(path);
+  AtomMap<RefPtr<SourceFile>>::Insert p = file_cache_.findForAdd(atom);
+
+  if (p.found())
+    return p->value;
+
+  RefPtr<SourceFile> file = new SourceFile(buffer.take(), length, path);
+
+  file_cache_.add(p, atom, file);
+
+  return file;
+}
+
 bool
 SourceManager::trackExtents(uint32_t length, size_t* index)
 {

--- a/exp/compiler/source-manager.h
+++ b/exp/compiler/source-manager.h
@@ -213,6 +213,8 @@ class SourceManager
 
   RefPtr<SourceFile> open(ReportingContext& cc, const char* path);
 
+  RefPtr<SourceFile> createFromBuffer(UniquePtr<char[]>&& buffer, uint32_t length, const char* path);
+
   // Returns whether two source locations ultimately originate from the same
   // file (i.e., ignoring macros).
   bool sameFiles(const SourceLocation& a, const SourceLocation& b);


### PR DESCRIPTION
### Brief
Adds SourceManager::createFromBuffer to allow creation from a buffer instead of file path

### Motivation
In wasm targets, local file creation are not possible, this method allows the creation of RefPtr<SourceFile> from a buffer instead.