### PR TITLE
Check switch cases for tag mismatches.

### DIFF
--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -5981,9 +5981,10 @@ doswitch(void) {
     constvalue *cse, *csp;
     char labelname[sNAMEMAX + 1];
     bool all_cases_return = true;
+    int switch_tag, case_tag;
 
     endtok = matchtoken('(') ? ')' : tDO;
-    doexpr(TRUE, FALSE, FALSE, FALSE, NULL, NULL, TRUE); /* evaluate switch expression */
+    doexpr(TRUE, FALSE, FALSE, FALSE, &switch_tag, NULL, TRUE); /* evaluate switch expression */
     needtoken(endtok);
     /* generate the code for the switch statement, the label is the address
      * of the case table (to be generated later).
@@ -6019,7 +6020,8 @@ doswitch(void) {
                      *     parse all expressions until that special token.
                      */
 
-                    exprconst(&val, NULL, NULL);
+                    exprconst(&val, &case_tag, NULL);
+                    matchtag(switch_tag, case_tag, MATCHTAG_COERCE);
                     /* Search the insertion point (the table is kept in sorted order, so
                      * that advanced abstract machines can sift the case table with a
                      * binary search). Check for duplicate case values at the same time.

--- a/tests/compile-only/warn-switch-tag-mismatch.sp
+++ b/tests/compile-only/warn-switch-tag-mismatch.sp
@@ -1,0 +1,26 @@
+enum Foo
+{
+	Foo1,
+	Foo2,
+	Foo3
+}
+
+enum Bar
+{
+	Bar1,
+	Bar2,
+	Bar3
+}
+
+public void OnPluginStart()
+{
+	Foo whatever = Foo2;
+
+	switch (whatever)
+	{
+		case Bar1: whatever = Foo2;
+		case 3: whatever = Foo3;
+		case 7.4: whatever = Foo1;
+		case Foo3: whatever = Foo3;
+	}
+}

--- a/tests/compile-only/warn-switch-tag-mismatch.txt
+++ b/tests/compile-only/warn-switch-tag-mismatch.txt
@@ -1,0 +1,3 @@
+(21) : warning 213: tag mismatch
+(22) : warning 213: tag mismatch
+(23) : warning 213: tag mismatch


### PR DESCRIPTION
Bug: issue #435
Test: compile-only/warn-switch-tag-mismatch