### PR TITLE
Add "kind" field to methods in docparse

### DIFF
--- a/exp/tools/docparse/docparse.cpp
+++ b/exp/tools/docparse/docparse.cpp
@@ -205,6 +205,10 @@ class Analyzer : public PartialAstVisitor
     startDoc(obj, "method", node->name(), node->loc());
 
     FunctionNode *fun = node->method();
+    if (fun->signature()->native())
+        obj->add(atom_kind_, toJson("native"));
+    else
+        obj->add(atom_kind_, toJson("stock"));
     obj->add(atom_returnType_, toJson(fun->signature()->returnType()));
     obj->add(atom_parameters_, toJson(fun->signature()->parameters()));
     methods_->add(obj);


### PR DESCRIPTION
Currently there is no way to distinguish between native methods and regular methods in methodmaps. This adds a new `kind` field like the one in functions that can be either `native` or `stock`.