### PR TITLE
Set tag on array expressions

### DIFF
--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -908,6 +908,7 @@ ArrayExpr::Analyze()
 
     val_.ident = iARRAY;
     val_.constval = litidx - start_litidx;
+    val_.tag = lasttag;
     return true;
 }
 

--- a/tests/compile-only/warn-array-literal-mismatch.sp
+++ b/tests/compile-only/warn-array-literal-mismatch.sp
@@ -1,0 +1,11 @@
+#include <shell>
+
+int f(int c[3]) {
+  printnum(c[0]);
+  printnum(c[1]);
+  printnum(c[2]);
+}
+
+public main() {
+  f({9.0, 5.0, 2.0});
+}

--- a/tests/compile-only/warn-array-literal-mismatch.txt
+++ b/tests/compile-only/warn-array-literal-mismatch.txt
@@ -1,0 +1,1 @@
+(10) : warning 213: tag mismatch


### PR DESCRIPTION
Array expressions would never get their tag set, which causes tag mismatches when the type of the array isn't an `int`.

Fixes #288