### PR TITLE
Begin moving parser.cpp to an AST.

### DIFF
--- a/compiler/assembler.cpp
+++ b/compiler/assembler.cpp
@@ -1225,7 +1225,7 @@ RttiBuilder::add_funcenum(Type* type, funcenum_t* fe)
     typedefs_->add();
 
     Vector<uint8_t> bytes;
-    encode_signature_into(bytes, fe->entries.back().get());
+    encode_signature_into(bytes, fe->entries.back());
     uint32_t signature = type_pool_.add(bytes);
 
     smx_rtti_typedef& def = typedefs_->at(index);
@@ -1251,7 +1251,7 @@ RttiBuilder::add_typeset(Type* type, funcenum_t* fe)
     Vector<uint8_t> bytes;
     CompactEncodeUint32(bytes, typecount);
     for (const auto& iter : fe->entries)
-        encode_signature_into(bytes, iter.get());
+        encode_signature_into(bytes, iter);
 
     smx_rtti_typeset& entry = typesets_->at(index);
     entry.name = names_->add(gAtoms, type->name());

--- a/compiler/assembler.cpp
+++ b/compiler/assembler.cpp
@@ -1357,16 +1357,15 @@ void
 RttiBuilder::encode_signature_into(Vector<uint8_t>& bytes, functag_t* ft)
 {
     bytes.append(cb::kFunction);
-    bytes.append((uint8_t)ft->argcount);
-    if (ft->argcount > 0 && ft->args[ft->argcount - 1].ident == iVARARGS)
+    bytes.append((uint8_t)ft->args.length());
+    if (!ft->args.empty() && ft->args[ft->args.length() - 1].ident == iVARARGS)
         bytes.append(cb::kVariadic);
     if (ft->ret_tag == pc_tag_void)
         bytes.append(cb::kVoid);
     else
         encode_tag_into(bytes, ft->ret_tag);
 
-    for (int i = 0; i < ft->argcount; i++) {
-        const funcarg_t& arg = ft->args[i];
+    for (const auto& arg : ft->args) {
         if (arg.ident == iREFERENCE)
             bytes.append(cb::kByRef);
 

--- a/compiler/code-generator.cpp
+++ b/compiler/code-generator.cpp
@@ -27,6 +27,12 @@
 #include "sctracker.h"
 
 void
+Decl::Emit()
+{
+    // Declarations usually don't emit anything.
+}
+
+void
 Expr::Emit()
 {
     AutoErrorPos aep(pos_);

--- a/compiler/expressions.cpp
+++ b/compiler/expressions.cpp
@@ -492,7 +492,7 @@ matchfunctags(Type* formal, Type* actual)
         return FALSE;
 
     for (const auto& formalfn : e->entries) {
-        if (functag_compare(formalfn.get(), actualfn))
+        if (functag_compare(formalfn, actualfn))
             return TRUE;
     }
 

--- a/compiler/expressions.cpp
+++ b/compiler/expressions.cpp
@@ -450,14 +450,14 @@ functag_compare(const functag_t* formal, const functag_t* actual)
         return FALSE;
 
     // Make sure there are no trailing arguments.
-    if (actual->argcount > formal->argcount)
+    if (actual->args.length() > formal->args.length())
         return FALSE;
 
     // Check arguments.
-    for (int i = 0; i < formal->argcount; i++) {
+    for (int i = 0; i < formal->args.length(); i++) {
         const funcarg_t* formal_arg = &formal->args[i];
 
-        if (i >= actual->argcount)
+        if (i >= actual->args.length())
             return FALSE;
 
         const funcarg_t* actual_arg = &actual->args[i];

--- a/compiler/expressions.cpp
+++ b/compiler/expressions.cpp
@@ -457,11 +457,8 @@ functag_compare(const functag_t* formal, const functag_t* actual)
     for (int i = 0; i < formal->argcount; i++) {
         const funcarg_t* formal_arg = &formal->args[i];
 
-        if (i >= actual->argcount) {
-            if (formal_arg->ommittable)
-                return TRUE;
+        if (i >= actual->argcount)
             return FALSE;
-        }
 
         const funcarg_t* actual_arg = &actual->args[i];
         if (!funcarg_compare(formal_arg, actual_arg))

--- a/compiler/lexer.h
+++ b/compiler/lexer.h
@@ -299,6 +299,8 @@ symbol* addvariable(const char* name, cell addr, int ident, int vclass, int tag,
 symbol* addvariable2(const char* name, cell addr, int ident, int vclass, int tag, int dim[],
                      int numdim, int idxtag[], int slength);
 symbol* addvariable3(declinfo_t* decl, cell addr, int vclass, int slength);
+void declare_methodmap_symbol(methodmap_t* map, bool can_redef);
+void declare_handle_intrinsics();
 int getlabel(void);
 char* itoh(ucell val);
 ke::AString get_token_string(int tok_id);

--- a/compiler/messages.h
+++ b/compiler/messages.h
@@ -117,7 +117,7 @@ static const char* errmsg[] = {
     /*090*/ "public functions may not return arrays (symbol \"%s\")\n",
     /*091*/ "ambiguous constant; tag override is required (symbol \"%s\")\n",
     /*092*/ "number of arguments does not match definition\n",
-    /*093*/ "expected tag name identifier\n",
+    /*093*/ "unused93\n",
     /*094*/ "cannot apply const qualifier to enum struct field \"%s\"\n",
     /*095*/ "type \"%s\" cannot be applied as a tag\n",
     /*096*/ "could not find member \"%s\" in struct \"%s\"\n",

--- a/compiler/name-resolution.cpp
+++ b/compiler/name-resolution.cpp
@@ -164,6 +164,21 @@ TypedefDecl::Bind()
 }
 
 bool
+TypesetDecl::Bind()
+{
+    Type* prev_type = gTypes.find(name_->chars());
+    if (prev_type && prev_type->isDefinedType()) {
+        error(pos_, 110, name_->chars(), prev_type->kindName());
+        return false;
+    }
+
+    funcenum_t* def = funcenums_add(name_->chars());
+    for (const auto& type : types_)
+        functags_add(def, type);
+    return true;
+}
+
+bool
 SymbolExpr::Bind()
 {
     AutoErrorPos aep(pos_);

--- a/compiler/name-resolution.cpp
+++ b/compiler/name-resolution.cpp
@@ -150,6 +150,20 @@ PstructDecl::Bind()
 }
 
 bool
+TypedefDecl::Bind()
+{
+    Type* prev_type = gTypes.find(name_->chars());
+    if (prev_type && prev_type->isDefinedType()) {
+        error(pos_, 110, name_->chars(), prev_type->kindName());
+        return false;
+    }
+
+    funcenum_t* def = funcenums_add(name_->chars());
+    functags_add(def, type_);
+    return true;
+}
+
+bool
 SymbolExpr::Bind()
 {
     AutoErrorPos aep(pos_);

--- a/compiler/name-resolution.cpp
+++ b/compiler/name-resolution.cpp
@@ -164,6 +164,13 @@ TypedefDecl::Bind()
 }
 
 bool
+UsingDecl::Bind()
+{
+    declare_handle_intrinsics();
+    return true;
+}
+
+bool
 TypesetDecl::Bind()
 {
     Type* prev_type = gTypes.find(name_->chars());

--- a/compiler/new-parser.cpp
+++ b/compiler/new-parser.cpp
@@ -175,6 +175,27 @@ Parser::parse_typedef()
     return new TypedefDecl(pos, gAtoms.add(ident.name), type);
 }
 
+Decl*
+Parser::parse_typeset()
+{
+    auto pos = current_pos();
+
+    token_ident_t ident;
+    if (!needsymbol(&ident))
+        return new ErrorDecl();
+
+    TypesetDecl* decl = new TypesetDecl(pos, gAtoms.add(ident.name));
+
+    needtoken('{');
+    while (!matchtoken('}')) {
+        auto type = parse_function_type();
+        decl->types().append(type);
+    }
+
+    require_newline(TerminatorPolicy::NewlineOrSemicolon);
+    return decl;
+}
+
 int
 Parser::expression(value* lval)
 {

--- a/compiler/new-parser.cpp
+++ b/compiler/new-parser.cpp
@@ -196,6 +196,38 @@ Parser::parse_typeset()
     return decl;
 }
 
+Decl*
+Parser::parse_using()
+{
+    auto pos = current_pos();
+
+    auto validate = []() -> bool {
+        token_ident_t ident;
+        if (!needsymbol(&ident))
+            return false;
+        if (strcmp(ident.name, "__intrinsics__") != 0) {
+            error(156);
+            return false;
+        }
+        if (!needtoken('.'))
+            return false;
+        if (!needsymbol(&ident))
+            return false;
+        if (strcmp(ident.name, "Handle") != 0) {
+            error(156);
+            return false;
+        }
+        return true;
+    };
+    if (!validate()) {
+        lexclr(TRUE);
+        return new ErrorDecl();
+    }
+
+    require_newline(TerminatorPolicy::Semicolon);
+    return new UsingDecl(pos);
+}
+
 int
 Parser::expression(value* lval)
 {

--- a/compiler/new-parser.cpp
+++ b/compiler/new-parser.cpp
@@ -160,6 +160,21 @@ Parser::parse_pstruct()
     return struct_decl;
 }
 
+Decl*
+Parser::parse_typedef()
+{
+    auto pos = current_pos();
+
+    token_ident_t ident;
+    if (!needsymbol(&ident))
+        return new ErrorDecl();
+
+    needtoken('=');
+
+    auto type = parse_function_type();
+    return new TypedefDecl(pos, gAtoms.add(ident.name), type);
+}
+
 int
 Parser::expression(value* lval)
 {

--- a/compiler/new-parser.h
+++ b/compiler/new-parser.h
@@ -32,6 +32,7 @@ class Parser : public ExpressionParser
     int expression(value* lval);
 
     Decl* parse_enum(int vclass);
+    Decl* parse_pstruct();
 
   private:
     typedef int (Parser::*HierFn)(value*);
@@ -58,3 +59,6 @@ class Parser : public ExpressionParser
     Expr* constant();
     CallExpr* parse_call(const token_pos_t& pos, int tok, Expr* target);
 };
+
+// Implemented in parser.cpp.
+int parse_new_decl(declinfo_t* decl, const token_t* first, int flags);

--- a/compiler/new-parser.h
+++ b/compiler/new-parser.h
@@ -31,6 +31,8 @@ class Parser : public ExpressionParser
   public:
     int expression(value* lval);
 
+    Decl* parse_enum(int vclass);
+
   private:
     typedef int (Parser::*HierFn)(value*);
     typedef Expr* (Parser::*NewHierFn)();

--- a/compiler/new-parser.h
+++ b/compiler/new-parser.h
@@ -33,6 +33,7 @@ class Parser : public ExpressionParser
 
     Decl* parse_enum(int vclass);
     Decl* parse_pstruct();
+    Decl* parse_typedef();
 
   private:
     typedef int (Parser::*HierFn)(value*);
@@ -62,3 +63,4 @@ class Parser : public ExpressionParser
 
 // Implemented in parser.cpp.
 int parse_new_decl(declinfo_t* decl, const token_t* first, int flags);
+functag_t* parse_function_type();

--- a/compiler/new-parser.h
+++ b/compiler/new-parser.h
@@ -25,21 +25,27 @@
 #include "expressions.h"
 #include "parse-node.h"
 #include "sc.h"
+#include "sctracker.h"
 
 class Parser : public ExpressionParser
 {
   public:
     int expression(value* lval);
 
+    void parse();
+
+    // Temporary until parser.cpp no longer is shimmed.
     Decl* parse_enum(int vclass);
-    Decl* parse_pstruct();
-    Decl* parse_typedef();
-    Decl* parse_typeset();
-    Decl* parse_using();
 
   private:
     typedef int (Parser::*HierFn)(value*);
     typedef Expr* (Parser::*NewHierFn)();
+
+    void parse_unknown_decl(const token_t* tok);
+    Decl* parse_pstruct();
+    Decl* parse_typedef();
+    Decl* parse_typeset();
+    Decl* parse_using();
 
     Expr* hier14();
     Expr* parse_view_as();
@@ -66,3 +72,12 @@ class Parser : public ExpressionParser
 // Implemented in parser.cpp.
 int parse_new_decl(declinfo_t* decl, const token_t* first, int flags);
 functag_t* parse_function_type();
+void dodecl(const token_t* tok);
+void decl_const(int vclass);
+void decl_enumstruct();
+void domethodmap(LayoutSpec spec);
+symbol* funcstub(int tokid, declinfo_t* decl, const int* thistag);
+void declglb(declinfo_t* decl, int fpublic, int fstatic, int stock);
+void declstructvar(char* firstname, int fpublic, pstruct_t* pstruct);
+int newfunc(declinfo_t* decl, const int* thistag, int fpublic, int fstatic, int stock,
+            symbol** symp);

--- a/compiler/new-parser.h
+++ b/compiler/new-parser.h
@@ -35,6 +35,7 @@ class Parser : public ExpressionParser
     Decl* parse_pstruct();
     Decl* parse_typedef();
     Decl* parse_typeset();
+    Decl* parse_using();
 
   private:
     typedef int (Parser::*HierFn)(value*);

--- a/compiler/new-parser.h
+++ b/compiler/new-parser.h
@@ -34,6 +34,7 @@ class Parser : public ExpressionParser
     Decl* parse_enum(int vclass);
     Decl* parse_pstruct();
     Decl* parse_typedef();
+    Decl* parse_typeset();
 
   private:
     typedef int (Parser::*HierFn)(value*);

--- a/compiler/parse-node.h
+++ b/compiler/parse-node.h
@@ -129,6 +129,44 @@ class EnumDecl : public Decl
     PoolList<EnumField> fields_;
 };
 
+struct StructField {
+    StructField(const token_pos_t& pos, sp::Atom* name, const typeinfo_t& typeinfo)
+      : pos(pos), name(name), type(typeinfo)
+    {}
+
+    token_pos_t pos;
+    sp::Atom* name;
+    typeinfo_t type;
+};
+
+class StructDecl : public Decl
+{
+  public:
+    explicit StructDecl(const token_pos_t& pos, sp::Atom* name)
+      : Decl(pos, name)
+    {}
+
+    PoolList<StructField>& fields() {
+        return fields_;
+    }
+
+  protected:
+    PoolList<StructField> fields_;
+};
+
+// "Pawn Struct", or p-struct, a hack to effect a replacement for register_plugin()
+// when SourceMod was first being prototyped. Theoretically these could be retooled
+// as proper structs.
+class PstructDecl : public StructDecl
+{
+  public:
+    explicit PstructDecl(const token_pos_t& pos, sp::Atom* name)
+      : StructDecl(pos, name)
+    {}
+
+    bool Bind() override;
+};
+
 class Expr : public ParseNode
 {
   public:

--- a/compiler/parse-node.h
+++ b/compiler/parse-node.h
@@ -180,6 +180,24 @@ class TypedefDecl : public Decl
     functag_t* type_;
 };
 
+// Unsafe typeset - only supports function types. This is a transition hack for SP2.
+class TypesetDecl : public Decl
+{
+  public:
+    explicit TypesetDecl(const token_pos_t& pos, sp::Atom* name)
+      : Decl(pos, name)
+    {}
+
+    bool Bind() override;
+
+    PoolList<functag_t*>& types() {
+        return types_;
+    }
+
+  private:
+    PoolList<functag_t*> types_;
+};
+
 // "Pawn Struct", or p-struct, a hack to effect a replacement for register_plugin()
 // when SourceMod was first being prototyped. Theoretically these could be retooled
 // as proper structs.

--- a/compiler/parse-node.h
+++ b/compiler/parse-node.h
@@ -211,6 +211,16 @@ class PstructDecl : public StructDecl
     bool Bind() override;
 };
 
+class UsingDecl : public Decl
+{
+  public:
+    explicit UsingDecl(const token_pos_t& pos)
+      : Decl(pos, nullptr)
+    {}
+
+    bool Bind() override;
+};
+
 class Expr : public ParseNode
 {
   public:

--- a/compiler/parse-node.h
+++ b/compiler/parse-node.h
@@ -81,11 +81,19 @@ class ParseNode : public PoolObject
     token_pos_t pos_;
 };
 
-class Decl : public ParseNode
+class Stmt : public ParseNode
+{
+  public:
+    explicit Stmt(const token_pos_t& pos)
+      : ParseNode(pos)
+    {}
+};
+
+class Decl : public Stmt
 {
   public:
     explicit Decl(const token_pos_t& pos, sp::Atom* name)
-      : ParseNode(pos),
+      : Stmt(pos),
         name_(name)
     {}
 

--- a/compiler/parse-node.h
+++ b/compiler/parse-node.h
@@ -100,6 +100,18 @@ class Decl : public ParseNode
     sp::Atom* name_;
 };
 
+class ErrorDecl final : public Decl
+{
+  public:
+    ErrorDecl()
+      : Decl(token_pos_t{}, nullptr)
+    {}
+
+    bool Bind() override {
+        return false;
+    }
+};
+
 struct EnumField {
     EnumField(const token_pos_t& pos, sp::Atom* name, cell value)
       : pos(pos), name(name), value(value)
@@ -152,6 +164,20 @@ class StructDecl : public Decl
 
   protected:
     PoolList<StructField> fields_;
+};
+
+class TypedefDecl : public Decl
+{
+  public:
+    explicit TypedefDecl(const token_pos_t& pos, sp::Atom* name, functag_t* type)
+      : Decl(pos, name),
+        type_(type)
+    {}
+
+    bool Bind() override;
+
+  private:
+    functag_t* type_;
 };
 
 // "Pawn Struct", or p-struct, a hack to effect a replacement for register_plugin()

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -150,7 +150,6 @@ static int dodo(void);
 static int dofor(void);
 static int doswitch(void);
 static void doreturn(void);
-static void dotypedef();
 static void dotypeset();
 static void domethodmap(LayoutSpec spec);
 static bool dousing();
@@ -1132,8 +1131,12 @@ parse(void) {
                 error(FATAL_ERROR_FUNCENUM);
                 break;
             case tTYPEDEF:
-                dotypedef();
+            {
+                Parser parser;
+                Decl* decl = parser.parse_typedef();
+                decl->Bind();
                 break;
+            }
             case tTYPESET:
                 dotypeset();
                 break;
@@ -3669,7 +3672,7 @@ dodelete() {
  *                 | function-type-inner
  * function-type-inner ::= "function" type-expr "(" new-style-args ")"
  */
-static functag_t*
+functag_t*
 parse_function_type()
 {
     int lparen = matchtoken('(');
@@ -3725,24 +3728,6 @@ parse_function_type()
     require_newline(TerminatorPolicy::Semicolon);
     errorset(sRESET, 0);
     return type;
-}
-
-static void
-dotypedef() {
-    token_ident_t ident;
-    if (!needsymbol(&ident))
-        return;
-
-    Type* prev_type = gTypes.find(ident.name);
-    if (prev_type && prev_type->isDefinedType())
-        error(110, ident.name, prev_type->kindName());
-
-    needtoken('=');
-
-    funcenum_t* def = funcenums_add(ident.name);
-
-    auto type = parse_function_type();
-    functags_add(def, type);
 }
 
 // Unsafe typeset - only supports function types. This is a transition hack for SP2.

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -150,7 +150,6 @@ static int dodo(void);
 static int dofor(void);
 static int doswitch(void);
 static void doreturn(void);
-static void dotypeset();
 static void domethodmap(LayoutSpec spec);
 static bool dousing();
 static void dobreak(void);
@@ -1138,8 +1137,12 @@ parse(void) {
                 break;
             }
             case tTYPESET:
-                dotypeset();
+            {
+                Parser parser;
+                Decl* decl = parser.parse_typeset();
+                decl->Bind();
                 break;
+            }
             case tSTRUCT:
             {
                 Parser parser;
@@ -3728,27 +3731,6 @@ parse_function_type()
     require_newline(TerminatorPolicy::Semicolon);
     errorset(sRESET, 0);
     return type;
-}
-
-// Unsafe typeset - only supports function types. This is a transition hack for SP2.
-static void
-dotypeset() {
-    token_ident_t ident;
-    if (!needsymbol(&ident))
-        return;
-
-    Type* prev_type = gTypes.find(ident.name);
-    if (prev_type && prev_type->isDefinedType())
-        error(110, ident.name, prev_type->kindName());
-
-    funcenum_t* def = funcenums_add(ident.name);
-    needtoken('{');
-    while (!matchtoken('}')) {
-        auto type = parse_function_type();
-        functags_add(def, type);
-    }
-
-    require_newline(TerminatorPolicy::NewlineOrSemicolon);
 }
 
 /*  decl_enum   - declare enumerated constants

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -199,6 +199,9 @@ static HWND hwndFinish = 0;
 int glbstringread = 0;
 char g_tmpfile[_MAX_PATH] = {0};
 
+args::ToggleOption opt_show_stats(nullptr, "--show-stats", Some(false),
+                                  "Show compiler statistics on exit.");
+
 /*  "main" of the compiler
  */
 int
@@ -459,6 +462,14 @@ cleanup:
             pc_printf("Total requirements:%8ld bytes\n", (long)code_idx +
                                                              (long)glb_declared * sizeof(cell) +
                                                              (long)pc_stksize * sizeof(cell));
+        }
+        if (opt_show_stats.value()) {
+            size_t allocated, reserved, bookkeeping;
+            gPoolAllocator.memoryUsage(&allocated, &reserved, &bookkeeping);
+
+            pc_printf("Pool allocation:   %8" KE_FMT_SIZET " bytes\n", allocated);
+            pc_printf("Pool unused:       %8" KE_FMT_SIZET " bytes\n", reserved - allocated);
+            pc_printf("Pool bookkeeping:  %8" KE_FMT_SIZET " bytes\n", bookkeeping);
         }
     }
 
@@ -1100,12 +1111,6 @@ parse(void) {
                 /* ignore zero's */
                 break;
             case tSYMBOL:
-#if 0
-      if (strcmp(tok.str, "class") == 0) {
-        domethodmap(Layout_Class);
-        break;
-      }
-#endif
                 // Fallthrough.
             case tINT:
             case tOBJECT:

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -3691,7 +3691,7 @@ parse_function_type(const ke::UniquePtr<functag_t>& type) {
         matchtoken(tSYMBOL);
 
         // Error once when we're past max args.
-        if (type->argcount == SP_MAX_EXEC_PARAMS) {
+        if (type->args.length() == SP_MAX_EXEC_PARAMS) {
             error(45);
             continue;
         }
@@ -3699,15 +3699,16 @@ parse_function_type(const ke::UniquePtr<functag_t>& type) {
         // Account for strings.
         fix_char_size(&decl);
 
-        funcarg_t* arg = &type->args[type->argcount++];
-        arg->tag = decl.type.tag;
-        arg->dimcount = decl.type.numdim;
-        memcpy(arg->dims, decl.type.dim, arg->dimcount * sizeof(decl.type.dim[0]));
-        arg->fconst = decl.type.is_const;
+        funcarg_t arg;
+        arg.tag = decl.type.tag;
+        arg.dimcount = decl.type.numdim;
+        memcpy(arg.dims, decl.type.dim, arg.dimcount * sizeof(decl.type.dim[0]));
+        arg.fconst = decl.type.is_const;
         if (decl.type.ident == iARRAY)
-            arg->ident = iREFARRAY;
+            arg.ident = iREFARRAY;
         else
-            arg->ident = decl.type.ident;
+            arg.ident = decl.type.ident;
+        type->args.append(arg);
 
         if (!matchtoken(',')) {
             needtoken(')');

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -3669,10 +3669,13 @@ dodelete() {
  *                 | function-type-inner
  * function-type-inner ::= "function" type-expr "(" new-style-args ")"
  */
-static void
-parse_function_type(const ke::UniquePtr<functag_t>& type) {
+static functag_t*
+parse_function_type()
+{
     int lparen = matchtoken('(');
     needtoken(tFUNCTION);
+
+    functag_t* type = new functag_t;
 
     parse_new_typename(NULL, &type->ret_tag);
 
@@ -3721,6 +3724,7 @@ parse_function_type(const ke::UniquePtr<functag_t>& type) {
 
     require_newline(TerminatorPolicy::Semicolon);
     errorset(sRESET, 0);
+    return type;
 }
 
 static void
@@ -3737,9 +3741,8 @@ dotypedef() {
 
     funcenum_t* def = funcenums_add(ident.name);
 
-    auto type = ke::MakeUnique<functag_t>();
-    parse_function_type(type);
-    functags_add(def, ke::Move(type));
+    auto type = parse_function_type();
+    functags_add(def, type);
 }
 
 // Unsafe typeset - only supports function types. This is a transition hack for SP2.
@@ -3756,9 +3759,8 @@ dotypeset() {
     funcenum_t* def = funcenums_add(ident.name);
     needtoken('{');
     while (!matchtoken('}')) {
-        auto type = ke::MakeUnique<functag_t>();
-        parse_function_type(type);
-        functags_add(def, ke::Move(type));
+        auto type = parse_function_type();
+        functags_add(def, type);
     }
 
     require_newline(TerminatorPolicy::NewlineOrSemicolon);

--- a/compiler/sctracker.cpp
+++ b/compiler/sctracker.cpp
@@ -115,20 +115,18 @@ funcenum_for_symbol(symbol* sym)
     auto ft = ke::MakeUnique<functag_t>();
 
     ft->ret_tag = sym->tag;
-    ft->argcount = 0;
     for (arginfo& arg : sym->function()->args) {
         if (!arg.ident)
             break;
 
-        funcarg_t* dest = &ft->args[ft->argcount++];
+        funcarg_t dest;
+        dest.tag = arg.tag;
+        dest.dimcount = arg.numdim;
+        memcpy(dest.dims, arg.dim, arg.numdim * sizeof(int));
+        dest.ident = arg.ident;
+        dest.fconst = arg.is_const;
 
-        dest->tag = arg.tag;
-
-        dest->dimcount = arg.numdim;
-        memcpy(dest->dims, arg.dim, arg.numdim * sizeof(int));
-
-        dest->ident = arg.ident;
-        dest->fconst = arg.is_const;
+        ft->args.append(dest);
     }
 
     char name[METHOD_NAMEMAX + 1];

--- a/compiler/sctracker.cpp
+++ b/compiler/sctracker.cpp
@@ -112,7 +112,7 @@ funcenums_add(const char* name)
 funcenum_t*
 funcenum_for_symbol(symbol* sym)
 {
-    auto ft = ke::MakeUnique<functag_t>();
+    functag_t* ft = new functag_t;
 
     ft->ret_tag = sym->tag;
     for (arginfo& arg : sym->function()->args) {
@@ -133,7 +133,7 @@ funcenum_for_symbol(symbol* sym)
     ke::SafeSprintf(name, sizeof(name), "::ft:%s:%d:%d", sym->name(), sym->addr(), sym->codeaddr);
 
     funcenum_t* fe = funcenums_add(name);
-    functags_add(fe, ke::Move(ft));
+    functags_add(fe, ft);
 
     return fe;
 }
@@ -150,14 +150,13 @@ functag_find_intrinsic(int tag)
         return nullptr;
     if (fe->entries.empty())
         return nullptr;
-    return fe->entries.back().get();
+    return fe->entries.back();
 }
 
-functag_t*
-functags_add(funcenum_t* en, ke::UniquePtr<functag_t>&& src)
+void
+functags_add(funcenum_t* en, functag_t* src)
 {
-    en->entries.append(ke::Move(src));
-    return en->entries.back().get();
+    en->entries.append(src);
 }
 
 static void

--- a/compiler/sctracker.cpp
+++ b/compiler/sctracker.cpp
@@ -116,7 +116,6 @@ funcenum_for_symbol(symbol* sym)
 
     ft->ret_tag = sym->tag;
     ft->argcount = 0;
-    ft->ommittable = FALSE;
     for (arginfo& arg : sym->function()->args) {
         if (!arg.ident)
             break;
@@ -130,7 +129,6 @@ funcenum_for_symbol(symbol* sym)
 
         dest->ident = arg.ident;
         dest->fconst = arg.is_const;
-        dest->ommittable = FALSE;
     }
 
     char name[METHOD_NAMEMAX + 1];

--- a/compiler/sctracker.h
+++ b/compiler/sctracker.h
@@ -3,6 +3,7 @@
 #define _INCLUDE_SOURCEPAWN_COMPILER_TRACKER_H_
 
 #include "lexer.h"
+#include "pool-allocator.h"
 #include "scvars.h"
 
 #define MEMUSE_STATIC 0
@@ -19,12 +20,10 @@ typedef struct funcarg_s {
 struct functag_t {
     functag_t()
      : ret_tag(0),
-       argcount(0),
        args()
     {}
     int ret_tag;
-    int argcount;
-    funcarg_t args[SP_MAX_EXEC_PARAMS];
+    PoolList<funcarg_t> args;
 };
 
 struct funcenum_t {

--- a/compiler/sctracker.h
+++ b/compiler/sctracker.h
@@ -9,23 +9,6 @@
 #define MEMUSE_STATIC 0
 #define MEMUSE_DYNAMIC 1
 
-typedef struct funcarg_s {
-    int tag;
-    int dimcount;
-    int dims[sDIMEN_MAX];
-    int ident;
-    bool fconst : 1;
-} funcarg_t;
-
-struct functag_t {
-    functag_t()
-     : ret_tag(0),
-       args()
-    {}
-    int ret_tag;
-    PoolList<funcarg_t> args;
-};
-
 struct funcenum_t {
     funcenum_t()
      : tag(0),
@@ -33,7 +16,7 @@ struct funcenum_t {
     {}
     int tag;
     char name[METHOD_NAMEMAX + 1];
-    ke::Vector<ke::UniquePtr<functag_t>> entries;
+    ke::Vector<functag_t*> entries;
 };
 
 struct structarg_t {
@@ -141,7 +124,7 @@ structarg_t* pstructs_getarg(pstruct_t* pstruct, const char* member);
  */
 void funcenums_free();
 funcenum_t* funcenums_add(const char* name);
-functag_t* functags_add(funcenum_t* en, ke::UniquePtr<functag_t>&& src);
+void functags_add(funcenum_t* en, functag_t* src);
 funcenum_t* funcenum_for_symbol(symbol* sym);
 functag_t* functag_find_intrinsic(int tag);
 

--- a/compiler/sctracker.h
+++ b/compiler/sctracker.h
@@ -13,20 +13,17 @@ typedef struct funcarg_s {
     int dimcount;
     int dims[sDIMEN_MAX];
     int ident;
-    int fconst;
-    int ommittable;
+    bool fconst : 1;
 } funcarg_t;
 
 struct functag_t {
     functag_t()
      : ret_tag(0),
        argcount(0),
-       ommittable(0),
        args()
     {}
     int ret_tag;
     int argcount;
-    int ommittable;
     funcarg_t args[SP_MAX_EXEC_PARAMS];
 };
 

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -29,6 +29,13 @@
 #include "sctracker.h"
 #include "scvars.h"
 
+bool
+Decl::Analyze()
+{
+    // No analysis needed for most decls.
+    return true;
+}
+
 static inline OpFunc TokenToOpFunc(int token) {
     switch (token) {
         case '*':
@@ -95,7 +102,7 @@ CompareOp::CompareOp(const token_pos_t& pos, int token, Expr* expr)
 }
 
 void
-Expr::error(const token_pos_t& pos, int number, ...)
+ParseNode::error(const token_pos_t& pos, int number, ...)
 {
     va_list ap;
     va_start(ap, number);

--- a/compiler/types.h
+++ b/compiler/types.h
@@ -32,6 +32,7 @@
 #include <amtl/am-vector.h>
 #include <sp_vm_types.h>
 #include "amx.h"
+#include "pool-allocator.h"
 
 #define TAGTYPEMASK (0x3E000000)
 #define TAGFLAGMASK (TAGTYPEMASK | 0x40000000)
@@ -76,6 +77,24 @@ struct typeinfo_t {
         return tag ? tag : declared_tag;
     }
     bool isCharArray() const;
+};
+
+struct funcarg_t {
+    int tag;
+    int dimcount;
+    int dims[sDIMEN_MAX];
+    int ident;
+    bool fconst : 1;
+};
+
+struct functag_t : public PoolObject
+{
+    functag_t()
+     : ret_tag(0),
+       args()
+    {}
+    int ret_tag;
+    PoolList<funcarg_t> args;
 };
 
 class Type


### PR DESCRIPTION
This patch series moves a bunch of top-level statement parsing code into the new AST-based parser. To preserve behavior, each statement is immediately resolved after being parsed. The major change here is that the parsing, name resolution, and evaluation now occurs in three distinct steps and is no longer intermingled.

This covers the easy global statement cases. The most difficult case is function statements, which cannot be moved until all non-global statements have been moved as well.