### PR TITLE
Clean up string literal messes.

### DIFF
--- a/compiler/code-generator.cpp
+++ b/compiler/code-generator.cpp
@@ -470,7 +470,10 @@ CommaExpr::DoEmit()
 void
 ArrayExpr::DoEmit()
 {
-    ldconst(addr_, sPRI);
+    auto addr = (litidx + glb_declared) * sizeof(cell);
+    for (const auto& expr : exprs_)
+        litadd(expr->val().constval);
+    ldconst(addr, sPRI);
 }
 
 void

--- a/compiler/code-generator.cpp
+++ b/compiler/code-generator.cpp
@@ -504,7 +504,9 @@ FloatExpr::DoEmit()
 void
 StringExpr::DoEmit()
 {
-    ldconst(lit_addr_, sPRI);
+    auto addr = (litidx + glb_declared) * sizeof(cell);
+    litadd(text_->chars(), text_->length());
+    ldconst(addr, sPRI);
 }
 
 void

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -1598,7 +1598,7 @@ packedstring(const unsigned char* lptr, int flags)
     i = 0; /* start at least significant byte */
     val = 0;
     glbstringread = 1;
-    while (*lptr != '\"' && *lptr != '\0') {
+    while (*lptr != '\0') {
         if (*lptr == '\a') { /* ignore '\a' (which was inserted at a line concatenation) */
             lptr++;
             continue;
@@ -1616,6 +1616,7 @@ packedstring(const unsigned char* lptr, int flags)
             i = i + 1;
         }
     }
+
     /* save last code; make sure there is at least one terminating zero character */
     if (i != 0)
         litadd(val); /* at least one zero character in "val" */

--- a/compiler/lexer.h
+++ b/compiler/lexer.h
@@ -282,6 +282,7 @@ int matchsymbol(token_ident_t* ident);
 int needsymbol(token_ident_t* ident);
 int peek_same_line();
 void litadd(cell value);
+void litadd(const char* str, size_t len);
 void litinsert(cell value, int pos);
 int alphanum(char c);
 int ishex(char c);

--- a/compiler/lexer.h
+++ b/compiler/lexer.h
@@ -217,7 +217,6 @@ enum TokenKind {
     tSYMBOL,
     tLABEL,
     tSTRING,
-    tPENDING_STRING, /* string, but not yet dequeued */
     tEXPR,           /* for assigment to "lastst" only (see SC1.C) */
     tENDLESS,        /* endless loop, for assigment to "lastst" only */
     tEMPTYBLOCK,     /* empty blocks for AM bug 4825 */
@@ -275,6 +274,7 @@ void lexclr(int clreol);
 const token_pos_t& current_pos();
 int matchtoken(int token);
 int tokeninfo(cell* val, char** str);
+full_token_t* current_token();
 int needtoken(int token);
 int matchtoken2(int id, token_t* tok);
 int expecttoken(int id, token_t* tok);

--- a/compiler/new-parser.cpp
+++ b/compiler/new-parser.cpp
@@ -761,8 +761,10 @@ Parser::constant()
             return new FloatExpr(pos, val);
         case tSTRING:
         {
-            cell addr = (val + glb_declared) * sizeof(cell);
-            return new StringExpr(pos, addr, litidx - val);
+            cell prev_litidx = litidx;
+            cell addr = (prev_litidx + glb_declared) * sizeof(cell);
+            litadd(current_token()->str, current_token()->len);
+            return new StringExpr(pos, addr, litidx - prev_litidx);
         }
         case '{':
         {

--- a/compiler/new-parser.cpp
+++ b/compiler/new-parser.cpp
@@ -760,12 +760,7 @@ Parser::constant()
         case tRATIONAL:
             return new FloatExpr(pos, val);
         case tSTRING:
-        {
-            cell prev_litidx = litidx;
-            cell addr = (prev_litidx + glb_declared) * sizeof(cell);
-            litadd(current_token()->str, current_token()->len);
-            return new StringExpr(pos, addr, litidx - prev_litidx);
-        }
+            return new StringExpr(pos, current_token()->str, current_token()->len);
         case '{':
         {
             ArrayExpr* expr = new ArrayExpr(pos);

--- a/compiler/parse-node.h
+++ b/compiler/parse-node.h
@@ -856,10 +856,9 @@ class FloatExpr final : public Expr
 class StringExpr final : public Expr
 {
   public:
-    StringExpr(const token_pos_t& pos, cell lit_addr, cell length)
+    StringExpr(const token_pos_t& pos, const char* str, size_t len)
       : Expr(pos),
-        lit_addr_(lit_addr),
-        length_(length)
+        text_(new PoolString(str, len))
     {}
 
     bool Analyze() override;
@@ -867,8 +866,7 @@ class StringExpr final : public Expr
     void ProcessUses() override {}
 
   private:
-    cell lit_addr_;
-    cell length_;
+    PoolString* text_;
 };
 
 class ArrayExpr final : public Expr

--- a/compiler/parse-node.h
+++ b/compiler/parse-node.h
@@ -886,6 +886,5 @@ class ArrayExpr final : public Expr
     }
 
   private:
-    cell_t addr_ = 0;
     PoolList<Expr*> exprs_;
 };

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -2360,11 +2360,6 @@ consume_line() {
     return TRUE;
 }
 
-constexpr cell
-char_array_cells(cell size) {
-    return (size + sizeof(cell) - 1) / sizeof(cell);
-}
-
 static int
 parse_new_typename(const token_t* tok) {
     token_t tmp;

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -204,7 +204,7 @@ pc_compile(int argc, char* argv[]) {
     int retcode;
     char incfname[_MAX_PATH];
     void* inpfmark;
-    int lcl_packstr, lcl_needsemicolon, lcl_tabsize, lcl_require_newdecls;
+    int lcl_needsemicolon, lcl_tabsize, lcl_require_newdecls;
     char* ptr;
 
     /* set global variables to their initial value */
@@ -250,7 +250,6 @@ pc_compile(int argc, char* argv[]) {
         setcaption();
     setconfig(argv[0]); /* the path to the include files */
     sc_ctrlchar_org = sc_ctrlchar;
-    lcl_packstr = sc_packstr;
     lcl_needsemicolon = sc_needsemicolon;
     lcl_require_newdecls = sc_require_newdecls;
     lcl_tabsize = sc_tabsize;
@@ -319,10 +318,9 @@ pc_compile(int argc, char* argv[]) {
         char string[150];
         sprintf(string,
                 "#pragma ctrlchar 0x%02x\n"
-                "#pragma pack %s\n"
                 "#pragma semicolon %s\n"
                 "#pragma tabsize %d\n",
-                sc_ctrlchar, sc_packstr ? "true" : "false", sc_needsemicolon ? "true" : "false",
+                sc_ctrlchar, sc_needsemicolon ? "true" : "false",
                 sc_tabsize);
         pc_writeasm(outf, string);
         setfiledirect(inpfname);
@@ -343,7 +341,6 @@ pc_compile(int argc, char* argv[]) {
         funcenums_free();
         methodmaps_free();
         sc_ctrlchar = sc_ctrlchar_org;
-        sc_packstr = lcl_packstr;
         sc_needsemicolon = lcl_needsemicolon;
         sc_require_newdecls = lcl_require_newdecls;
         sc_tabsize = lcl_tabsize;
@@ -398,7 +395,6 @@ pc_compile(int argc, char* argv[]) {
     inst_binary_name(binfname);
     resetglobals();
     sc_ctrlchar = sc_ctrlchar_org;
-    sc_packstr = lcl_packstr;
     sc_needsemicolon = lcl_needsemicolon;
     sc_require_newdecls = lcl_require_newdecls;
     sc_tabsize = lcl_tabsize;
@@ -659,7 +655,6 @@ initglobals(void) {
     verbosity = 1;                     /* verbosity level, no copyright banner */
     sc_debug = sCHKBOUNDS | sSYMBOLIC; /* sourcemod: full debug stuff */
     pc_optimize = sOPTIMIZE_DEFAULT;   /* sourcemod: full optimization */
-    sc_packstr = TRUE;                 /* strings are packed by default */
     sc_needsemicolon = FALSE;          /* semicolon required to terminate expressions? */
     sc_require_newdecls = FALSE;
     sc_dataalign = sizeof(cell);

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -1158,7 +1158,7 @@ declstructvar(char* firstname, int fpublic, pstruct_t* pstruct)
             continue;
         }
         if (tok == tSTRING) {
-            assert(litidx != 0);
+            litadd(current_token()->str, current_token()->len);
             if (arg->dimcount != 1) {
                 error(48);
             } else if (arg->tag != pc_tag_string) {
@@ -1512,6 +1512,8 @@ declloc(int tokid) {
                 if (type->isCharArray() && !lexpeek(tNEW)) {
                     // Error if we're assigning something other than a string literal.
                     needtoken(tSTRING);
+
+                    litadd(current_token()->str, current_token()->len);
 
                     // Note: the genarray call pushes the result array into the stack
                     // slot of our local variable - we can access |sym| after.
@@ -2058,7 +2060,6 @@ initarray(int ident, int tag, int dim[], int numdim, int cur, int startlit, int 
         {
             // We need this since, lex() could add a string to the literal queue,
             // which totally messes up initvector's state tracking. What a mess.
-            AutoDisableLiteralQueue disable;
             if (lexpeek('}'))
                 abortparse = TRUE;
         }
@@ -2235,6 +2236,8 @@ init(int ident, int* tag, int* errorfound) {
             if (errorfound != NULL)
                 *errorfound = TRUE;
             litidx = 1; /* reset literal queue */
+        } else {
+            litadd(current_token()->str, current_token()->len);
         }
         *tag = pc_tag_string;
     } else if (exprconst(&i, tag, NULL)) {

--- a/compiler/pool-allocator.h
+++ b/compiler/pool-allocator.h
@@ -1,4 +1,4 @@
-// vim: set sts=2 ts=8 sw=2 tw=99 et:
+// vim: set sts=4 ts=8 sw=4 tw=99 et:
 //
 // Copyright (C) 2012-2014 David Anderson
 //
@@ -21,6 +21,7 @@
 #include <new>
 #include <stddef.h>
 #include <stdio.h>
+#include <string.h>
 #include <limits.h>
 #include <amtl/am-fixedarray.h>
 #include <amtl/am-uniqueptr.h>
@@ -145,6 +146,27 @@ class PoolObject
     void operator delete [](void* ptr) {
         assert(false);
     }
+};
+
+class PoolString : public PoolObject
+{
+  public:
+    explicit PoolString(const char* chars, size_t len) {
+        length_ = len;
+        chars_ = (char*)gPoolAllocator.rawAllocate(length_ + 1);
+        memcpy(chars_, chars, length_ + 1);
+    }
+
+    const char* chars() const {
+        return chars_;
+    }
+    size_t length() const {
+        return length_;
+    }
+
+  private:
+    char* chars_;
+    size_t length_;
 };
 
 class PoolAllocationPolicy

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -479,6 +479,10 @@ typedef struct array_info_s {
     cell* base;                   /* &litq[startlit] */
 } array_info_t;
 
+constexpr cell char_array_cells(cell size) {
+    return (size + sizeof(cell) - 1) / sizeof(cell);
+}
+
 extern sp::StringPool gAtoms;
 
 #endif /* SC_H_INCLUDED */

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -479,15 +479,6 @@ typedef struct array_info_s {
     cell* base;                   /* &litq[startlit] */
 } array_info_t;
 
-struct AutoDisableLiteralQueue {
-  public:
-    AutoDisableLiteralQueue();
-    ~AutoDisableLiteralQueue();
-
-  private:
-    bool prev_value_;
-};
-
 extern sp::StringPool gAtoms;
 
 #endif /* SC_H_INCLUDED */

--- a/compiler/scvars.cpp
+++ b/compiler/scvars.cpp
@@ -61,7 +61,6 @@ cell code_idx = 0;                         /* number of bytes with generated cod
 int errnum = 0;                            /* number of errors */
 int warnnum = 0;                           /* number of warnings */
 int sc_debug = sCHKBOUNDS;                 /* by default: bounds checking+assertions */
-int sc_packstr = FALSE;                    /* strings are packed by default? */
 int sc_asmfile = FALSE;                    /* create .ASM file? */
 int sc_listing = FALSE;                    /* create .LST file? */
 int sc_needsemicolon = TRUE;               /* semicolon required to terminate expressions? */

--- a/compiler/scvars.h
+++ b/compiler/scvars.h
@@ -53,7 +53,6 @@ extern cell code_idx;             /* number of bytes with generated code */
 extern int errnum;                /* number of errors */
 extern int warnnum;               /* number of warnings */
 extern int sc_debug;              /* debug/optimization options (bit field) */
-extern int sc_packstr;            /* strings are packed by default? */
 extern int sc_asmfile;            /* create .ASM file? */
 extern int sc_listing;            /* create .LST file? */
 extern int sc_needsemicolon;      /* semicolon required to terminate expressions? */

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -893,10 +893,6 @@ ArrayExpr::Analyze()
     AutoErrorPos aep(pos_);
 
     int lasttag = -1;
-    cell start_litidx = litidx;
-
-    addr_ = (start_litidx + glb_declared) * sizeof(cell);
-
     for (const auto& expr : exprs_) {
         if (!expr->Analyze())
             return false;
@@ -910,11 +906,10 @@ ArrayExpr::Analyze()
             lasttag = val.tag;
         else
             matchtag(lasttag, val.tag, FALSE);
-        litadd(val.constval);
     }
 
     val_.ident = iARRAY;
-    val_.constval = litidx - start_litidx;
+    val_.constval = exprs_.length();
     val_.tag = lasttag;
     return true;
 }

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -1063,7 +1063,7 @@ bool
 StringExpr::Analyze()
 {
     val_.ident = iARRAY;
-    val_.constval = -length_;
+    val_.constval = -char_array_cells((cell)text_->length() + 1);
     val_.tag = pc_tag_string;
     return true;
 }


### PR DESCRIPTION
Everything about string literal parsing is a mess, perhaps the worst offense is that the lexer injects the byte stream directly into the DATA section. It's hard to think of a bigger layering violation.

This patch series attempts to clean things up by:
1. Removing code around RAWMODE and unpacked string support which has no use cases and has been continually and incrementally broken for ages. (RAWMODE I'd be happy to bring back with a new syntax, like Python's r"blah").
2. Refactoring code to not lex directly into DATA.
3. Move literal queue usage from the parser into the code generator (for expressions).