### PR TITLE
Fix assert when using keywords as argument names.

### DIFF
--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -2462,11 +2462,10 @@ parse_new_decl(declinfo_t* decl, const token_t* first, int flags)
             if (decl->opertok == 0)
                 strcpy(decl->name, "__unknown__");
         } else {
-            if (!expecttoken(tSYMBOL, &tok)) {
+            if (expecttoken(tSYMBOL, &tok))
+                strcpy(decl->name, tok.str);
+            else
                 strcpy(decl->name, "__unknown__");
-                return FALSE;
-            }
-            strcpy(decl->name, tok.str);
         }
     }
 

--- a/tests/compile-only/fail-argument-name-is-keyword.sp
+++ b/tests/compile-only/fail-argument-name-is-keyword.sp
@@ -1,0 +1,3 @@
+public void ObjectVariable(int object, int blah)
+{
+}

--- a/tests/compile-only/fail-argument-name-is-keyword.txt
+++ b/tests/compile-only/fail-argument-name-is-keyword.txt
@@ -1,0 +1,1 @@
+(1) : error 001: expected token: "-identifier-", but found "object"


### PR DESCRIPTION
Bug: fixes #458
Test: compile-only/fail-argument-name-is-keyword.sp