### PR TITLE
Fix up location tracking for symbols

### DIFF
--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -49,7 +49,6 @@ using namespace sp;
 /* flags for litchar() */
 #define UTF8MODE 0x1
 static cell litchar(const unsigned char** lptr, int flags);
-static symbol* find_symbol(const symbol* root, const char* name, int fnumber);
 
 static void substallpatterns(unsigned char* line, int buffersize);
 static int alpha(char c);
@@ -2856,24 +2855,6 @@ delete_symbols(symbol* root, int level, int delete_functions)
     }
 }
 
-static symbol*
-find_symbol(const symbol* root, const char* name, int fnumber)
-{
-    symbol* sym = root->next;
-    sp::Atom* atom = gAtoms.add(name);
-    while (sym != NULL) {
-        if (atom == sym->nameAtom() &&
-            (sym->parent() == NULL ||
-             sym->ident ==
-                 iCONSTEXPR) /* sub-types (hierarchical types) are skipped, except for enum fields */
-            && (!sym->is_static || sym->fnumber == fnumber)) /* check file number for scope */
-        {
-            return sym; /* return first match */
-        }               /*  */
-        sym = sym->next;
-    }
-    return nullptr;
-}
 
 void
 markusage(symbol* sym, int usage)
@@ -2912,7 +2893,19 @@ findglb(const char* name)
 symbol*
 findloc(const char* name)
 {
-    return find_symbol(&loctab, name, -1);
+    symbol* sym = loctab.next;
+    sp::Atom* atom = gAtoms.add(name);
+    while (sym != NULL) {
+        if (atom == sym->nameAtom() &&
+            (sym->parent() == NULL ||
+             sym->ident ==
+                 iCONSTEXPR)) /* sub-types (hierarchical types) are skipped, except for enum fields */
+        {
+            return sym; /* return first match */
+        }
+        sym = sym->next;
+    }
+    return nullptr;
 }
 
 symbol*
@@ -2920,7 +2913,7 @@ findconst(const char* name)
 {
     symbol* sym;
 
-    sym = find_symbol(&loctab, name, -1);          /* try local symbols first */
+    sym = findloc(name);          /* try local symbols first */
     if (sym == NULL || sym->ident != iCONSTEXPR) { /* not found, or not a constant */
         sym = FindInHashTable(sp_Globals, name, fcurrent);
     }

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -2866,7 +2866,7 @@ find_symbol(const symbol* root, const char* name, int fnumber)
             (sym->parent() == NULL ||
              sym->ident ==
                  iCONSTEXPR) /* sub-types (hierarchical types) are skipped, except for enum fields */
-            && (sym->fnumber < 0 || sym->fnumber == fnumber)) /* check file number for scope */
+            && (!sym->is_static || sym->fnumber == fnumber)) /* check file number for scope */
         {
             return sym; /* return first match */
         }               /*  */
@@ -2971,6 +2971,7 @@ symbol::symbol(const char* symname, cell symaddr, int symident, int symvclass, i
    is_const(false),
    stock(false),
    is_public(false),
+   is_static(false),
    is_struct(false),
    prototyped(false),
    missing(false),
@@ -2985,7 +2986,7 @@ symbol::symbol(const char* symname, cell symaddr, int symident, int symvclass, i
    deprecated(false),
    queued(false),
    x({}),
-   fnumber(-1),
+   fnumber(fcurrent),
    /* assume global visibility (ignored for local symbols) */
    lnumber(fline),
    documentation(nullptr),

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -1123,7 +1123,10 @@ declglb(declinfo_t* decl, int fpublic, int fstatic, int fstock)
         if (fstock)
             sym->stock = true;
         if (fstatic)
-            sym->fnumber = filenum;
+            sym->is_static = true;
+
+        sym->fnumber = filenum;
+
         if (sc_status == statSKIP) {
             sc_status = statWRITE;
             code_idx = cidx;
@@ -3743,7 +3746,9 @@ newfunc(declinfo_t* decl, const int* thistag, int fpublic, int fstatic, int stoc
     if (fpublic)
         sym->is_public = true;
     if (fstatic)
-        sym->fnumber = filenum;
+        sym->is_static = true;
+
+    sym->fnumber = filenum;
 
     if (sym->is_public || sym->forward) {
         if (decl->type.numdim > 0)

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -186,6 +186,7 @@ struct symbol {
     // Variables and functions.
     bool stock : 1;         // discardable without warning
     bool is_public : 1;     // publicly exposed
+    bool is_static : 1;     // declared as static
 
     // TODO: make this an ident.
     bool is_struct : 1;
@@ -222,8 +223,8 @@ struct symbol {
             short level;  /* number of dimensions below this level */
         } array;
     } dim;       /* for 'dimension', both functions and arrays */
-    int fnumber; /* static global variables: file number in which the declaration is visible */
-    int lnumber; /* line number (in the current source file) for the declaration */
+    int fnumber; /* file number in which the symbol is declared */
+    int lnumber; /* line number for the declaration */
     ke::AString documentation; /* optional documentation string */
     methodmap_t* methodmap;    /* if ident == iMETHODMAP */
 

--- a/compiler/sp_symhash.cpp
+++ b/compiler/sp_symhash.cpp
@@ -33,7 +33,7 @@ struct SymbolHashPolicy {
     static bool matches(const NameAndScope& key, symbol* sym) {
         if (sym->parent() && sym->ident != iCONSTEXPR)
             return false;
-        if (sym->fnumber >= 0 && sym->fnumber != key.fnumber)
+        if (sym->is_static && sym->fnumber != key.fnumber)
             return false;
         if (key.name != sym->nameAtom())
             return false;

--- a/tests/compile-only/warn-report-right-file.inc
+++ b/tests/compile-only/warn-report-right-file.inc
@@ -1,0 +1,2 @@
+//whee
+void unused() {}

--- a/tests/compile-only/warn-report-right-file.sp
+++ b/tests/compile-only/warn-report-right-file.sp
@@ -1,0 +1,2 @@
+#include "warn-report-right-file"
+public void main() {}

--- a/tests/compile-only/warn-report-right-file.txt
+++ b/tests/compile-only/warn-report-right-file.txt
@@ -1,0 +1,1 @@
+warn-report-right-file.inc(2) : warning 203: symbol is never used: "unused"


### PR DESCRIPTION
This could probably be used to report stuff like the location of a shadowed symbol instead of just the name.  Maybe other compiler messages could also use it.