### PR TITLE
Fix calling fake natives on x64 Windows

### DIFF
--- a/vm/x64/code-stubs-x64.cpp
+++ b/vm/x64/code-stubs-x64.cpp
@@ -104,11 +104,21 @@ CodeStubs::CreateFakeNativeStub(SPVM_FAKENATIVE_FUNC callback, void* pData)
   __ push(rbp);
   __ movq(rbp, rsp);
 
+#if (defined(KE_WINDOWS)) && (defined(KE_ARCH_X64))
+  // Shadow space.
+  __ subq(rsp, 0x20);
+#endif
+
   // Arguments are already set up. We just need to set the third argument.
   // Note that the stack is aligned too!
   __ movq(ArgReg2, reinterpret_cast<intptr_t>(pData));
   __ movq(rax, reinterpret_cast<intptr_t>(reinterpret_cast<void*>(callback)));
   __ call(rax);
+
+#if (defined(KE_WINDOWS)) && (defined(KE_ARCH_X64))
+  // Shadow space.
+  __ addq(rsp, 0x20);
+#endif
 
   __ leave();
   __ ret();


### PR DESCRIPTION
Microsoft demands 32 bytes of shadow space on the stack before calling a function even if the function has less than 4 parameters.