### PR TITLE
Fix bad error messages on multi-character sequences.

### DIFF
--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -2126,10 +2126,18 @@ lex_once(full_token_t* tok, cell* lexvalue)
             lptr += 1; /* skip quote */
             tok->id = tNUMBER;
             *lexvalue = tok->value = litchar(&lptr, UTF8MODE);
-            if (*lptr == '\'')
+            if (*lptr == '\'') {
                 lptr += 1; /* skip final quote */
-            else
+            } else {
                 error(27); /* invalid character constant (must be one character) */
+
+                // Eat tokens on the same line until we can close the malformed
+                // string.
+                while (*lptr && *lptr != '\'')
+                    litchar(&lptr, UTF8MODE);
+                if (*lptr && *lptr == '\'')
+                    lptr++;
+            }
             return;
 
         case ';':

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -1082,6 +1082,7 @@ declglb(declinfo_t* decl, int fpublic, int fstatic, int fstock)
         cidx = 0; /* only to avoid a compiler warning */
         if (sc_status == statWRITE && sym != NULL && (sym->usage & (uREAD | uWRITTEN)) == 0) {
             sc_status = statSKIP;
+            sc_err_status = TRUE;
             cidx = code_idx;
 #if !defined NDEBUG
             glbdecl = glb_declared;
@@ -1133,6 +1134,7 @@ declglb(declinfo_t* decl, int fpublic, int fstatic, int fstock)
 
         if (sc_status == statSKIP) {
             sc_status = statWRITE;
+            sc_err_status = FALSE;
             code_idx = cidx;
             assert(glb_declared == glbdecl);
         } else {

--- a/tests/compile-only/fail-crash-on-redecl-function.sp
+++ b/tests/compile-only/fail-crash-on-redecl-function.sp
@@ -1,0 +1,8 @@
+native PrintToServer(const int[] test);
+void PrintToServer(const int[] test)
+{
+}
+
+int main()
+{
+}

--- a/tests/compile-only/fail-crash-on-redecl-function.txt
+++ b/tests/compile-only/fail-crash-on-redecl-function.txt
@@ -1,0 +1,1 @@
+(2) : error 021: symbol already defined: "PrintToServer"

--- a/tests/compile-only/fail-multi-character-sequence.sp
+++ b/tests/compile-only/fail-multi-character-sequence.sp
@@ -1,0 +1,2 @@
+char s = 'test';
+

--- a/tests/compile-only/fail-multi-character-sequence.txt
+++ b/tests/compile-only/fail-multi-character-sequence.txt
@@ -1,0 +1,1 @@
+(1) : error 027: invalid character constant


### PR DESCRIPTION
This also fixes a bug where if the compiler encountered an error while
parsing a global variable initializer, the error would be ignored if the
variable was unused.

Bug: issue #506
Test: tests/compile-only/fail-multi-character-sequence.sp