### PR TITLE
Fix any: not triggering a newdecls warning.

### DIFF
--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -2369,6 +2369,9 @@ parse_old_decl(declinfo_t* decl, int flags) {
     if (type_obj->isEnumStruct())
         error(85, type_obj->name());
 
+    if (sc_require_newdecls)
+        error(147);
+
     // Look for varargs and end early.
     if (matchtoken(tELLIPS)) {
         type->ident = iVARARGS;
@@ -2411,9 +2414,6 @@ parse_old_decl(declinfo_t* decl, int flags) {
         if (matchtoken('['))
             parse_old_array_dims(decl, flags);
     }
-
-    if (sc_require_newdecls)
-        error(147);
 
     return TRUE;
 }

--- a/tests/compile-only/fail-old-any-decl.sp
+++ b/tests/compile-only/fail-old-any-decl.sp
@@ -1,0 +1,5 @@
+#pragma newdecls required
+
+public void Clams(any:...)
+{
+}

--- a/tests/compile-only/fail-old-any-decl.txt
+++ b/tests/compile-only/fail-old-any-decl.txt
@@ -1,0 +1,1 @@
+(3) : error 147: new-style declarations are required


### PR DESCRIPTION
Bug: issue #469
Test: tests/compile-only/fail-old-any-decl.sp