### PR TITLE
Fix building using GCC

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -97,8 +97,10 @@ class Config(object):
         '-Wno-overloaded-virtual',
       ]
 
-      if have_gcc and cxx.target.arch in ['x86', 'x86_64']:
-        cxx.cflags += ['-mfpmath=sse']
+      if have_gcc:
+        if cxx.target.arch in ['x86', 'x86_64']:
+          cxx.cflags += ['-mfpmath=sse']
+        cxx.cxxflags += ['-Wformat-truncation=0']
 
       cxx.postlink += ['-lm']
 


### PR DESCRIPTION
Error message:
```
In file included from /home/karol/Programs/Repos/sourcepawn/vm/plugin-runtime.h:18,
                 from /home/karol/Programs/Repos/sourcepawn/vm/control-flow.h:23,
                 from /home/karol/Programs/Repos/sourcepawn/vm/control-flow.cpp:14:
/home/karol/Programs/Repos/sourcepawn/third_party/amtl/amtl/am-string.h: In function ‘std::unique_ptr<char []> ke::detail::SprintfArgsImpl.constprop(size_t*, const char*, va_list)’:
/home/karol/Programs/Repos/sourcepawn/third_party/amtl/amtl/am-string.h:89:1: error: ‘block’ directive output truncated writing 5 bytes into a region of size 2 [-Werror=format-truncation=]
   89 | SprintfArgsImpl(size_t* out_len, const char* fmt, va_list ap)
```

The same fix has been applied to [alliedmodders/amtl](https://github.com/alliedmodders/amtl).