### PR TITLE
Fix enum increment/multiplier parsing

### DIFF
--- a/compiler/new-parser.cpp
+++ b/compiler/new-parser.cpp
@@ -212,8 +212,6 @@ Parser::parse_enum(int vclass)
 
     EnumDecl* decl = new EnumDecl(pos, vclass, label, name);
 
-    needtoken('{');
-
     cell increment = 1;
     cell multiplier = 1;
     if (matchtoken('(')) {
@@ -228,6 +226,8 @@ Parser::parse_enum(int vclass)
         }
         needtoken(')');
     }
+
+    needtoken('{');
 
     cell size;
     cell value = 0;


### PR DESCRIPTION
In Sourcemod 1.11 the following code fails to compile after moving enum parsing to new-parser.cpp in commit f598f1d22e9a596b70dd212ecf72d9655c965a9c
```
enum CheatType(+=1)
{
	Cheat_HighPerfects = 0,
	Cheat_Auto,
	Cheat_JumpSpam
};
public void OnPluginStart() { }
```
Errors:
```
% ./compile.sh test.sp

Compiling test.sp...
SourcePawn Compiler 1.11.0.6625
Copyright (c) 1997-2006 ITB CompuPhase
Copyright (c) 2004-2018 AlliedModders LLC

test.sp(1) : error 001: expected token: "{", but found "("
test.sp(6) : error 010: invalid function or declaration
test.sp(3) : warning 203: symbol is never used: "Cheat_JumpSpam"
test.sp(3) : warning 203: symbol is never used: "Cheat_Auto"
test.sp(3) : warning 203: symbol is never used: "Cheat_HighPerfects"
```