### PR TITLE
Implement perf JIT reporting APIs

### DIFF
--- a/include/sp_vm_api.h
+++ b/include/sp_vm_api.h
@@ -58,6 +58,20 @@ enum SP_NULL_TYPE {
     SP_NULL_STRING = 1, /**< const String[1] reference */
 };
 
+enum {
+  // If this flag is set, any metadata files generated will be deleted at the end of the process.
+  // This is useful when paired with lightweight metadata, as it allows attaching to a running
+  // process without filling up the disk. Enabled by default.
+  JIT_DEBUG_DELETE_ON_EXIT = (1 << 0),
+
+  // Enables output of function name mappings for perf. Linux only, enabled by default.
+  JIT_DEBUG_PERF_BASIC = (1 << 1),
+
+  // Enables output of full function metadata for perf in the jitdump format.
+  // Includes names, bytecode, and source file mappings. Linux only.
+  JIT_DEBUG_PERF_JITDUMP = (1 << 2),
+};
+
 // @brief Interface for a refcounted objects.
 class IRefcountedObject
 {
@@ -1628,6 +1642,10 @@ class ISourcePawnEnvironment
     // @brief Enables the line debugger callbacks. This must be called
     // before any plugins are loaded.
     virtual bool EnableDebugBreak() = 0;
+
+    // @brief See JIT_DEBUG_* flags.
+    // Must be set before any plugin code is executed.
+    virtual void SetDebugMetadataFlags(int flags) = 0;
 };
 
 // @brief This class is the entry-point to using SourcePawn from a DLL.

--- a/vm/AMBuilder
+++ b/vm/AMBuilder
@@ -54,6 +54,7 @@ library.sources += [
   'control-flow.cpp',
   'compiled-function.cpp',
   'debugging.cpp',
+  'debug-metadata.cpp',
   'environment.cpp',
   'file-utils.cpp',
   'graph-builder.cpp',

--- a/vm/api.cpp
+++ b/vm/api.cpp
@@ -287,7 +287,7 @@ SourcePawnEngine2::LoadBinaryFromFile(const char* file, char* error, size_t maxl
     }
   }
 
-  if (!pRuntime->Name())
+  if (*pRuntime->Name() == '\0')
     pRuntime->SetNames(file, file);
 
   return pRuntime;

--- a/vm/debug-metadata.cpp
+++ b/vm/debug-metadata.cpp
@@ -1,0 +1,216 @@
+// vim: set sts=2 ts=8 sw=2 tw=99 et:
+//
+// Copyright (C) 2021 AlliedModders LLC
+//
+// This file is part of SourcePawn. SourcePawn is free software: you can
+// redistribute it and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License along with
+// SourcePawn. If not, see http://www.gnu.org/licenses/.
+//
+#include "debug-metadata.h"
+
+#include <am-string.h>
+
+using namespace sp;
+
+#if defined(KE_LINUX)
+#include "jitdump.h"
+
+#include <unistd.h>
+
+// clock_gettime
+#include <time.h>
+
+// mmap
+#include <sys/mman.h>
+
+// creat
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+// __rdtsc
+#include <x86intrin.h>
+
+PerfJitFile::PerfJitFile(bool self_delete)
+{
+  self_delete_ = self_delete;
+
+  // The specification requires the file to be located at exactly this path.
+  // https://github.com/torvalds/linux/blob/614cb5894306cfa2c7d9b6168182876ff5948735/tools/perf/Documentation/jit-interface.txt
+  ke::SafeSprintf(path_, sizeof(path_), "/tmp/perf-%d.map", getpid());
+
+  file_ = fopen(path_, "w");
+}
+
+PerfJitFile::~PerfJitFile()
+{
+  if (!file_) {
+    return;
+  }
+
+  fclose(file_);
+
+  if (self_delete_) {
+    unlink(path_);
+  }
+}
+
+void PerfJitFile::Write(void* address, uint64_t length, const char* symbol) {
+  if (!file_) {
+    return;
+  }
+
+  fprintf(file_,
+    (sizeof(long) == 8) ? "%lx %lx %s\n" : "%llx %llx %s\n",
+    (uint64_t)address, length, symbol);
+
+  fflush(file_);
+}
+
+PerfJitdumpFile::PerfJitdumpFile(bool self_delete) {
+  pid_ = getpid();
+  self_delete_ = self_delete;
+
+  // We can keep this file anywhere, but the name must be ".../jit-XXXX.dump", where XXXX is our PID.
+  // https://github.com/torvalds/linux/blob/614cb5894306cfa2c7d9b6168182876ff5948735/tools/perf/Documentation/jitdump-specification.txt
+  ke::SafeSprintf(path_, sizeof(path_), "/tmp/jit-%d.dump", pid_);
+
+  // We have to explicitly open a fd or perf can't find the mmap, using fopen and fileno doesn't work.
+  int fd = open(path_, O_CREAT|O_TRUNC|O_RDWR, 0666);
+  if (fd < 0) {
+    return;
+  }
+
+  // This mmap acts as a marker for perf to find our jitdump file path.
+  mmap_ = mmap(nullptr, sysconf(_SC_PAGESIZE), PROT_READ|PROT_EXEC, MAP_PRIVATE, fd, 0);
+  if (mmap_ == MAP_FAILED) {
+    mmap_ = nullptr;
+  }
+
+  file_ = fdopen(fd, "w+");
+  if (!file_) {
+    close(fd);
+    return;
+  }
+
+  // Use arch timestamps unless the env var is explicitly set to 0.
+  char* env = getenv("JITDUMP_USE_ARCH_TIMESTAMP");
+  use_arch_timestamp_ = !env || *env != '0';
+
+  jitheader header = {};
+  header.magic = JITHEADER_MAGIC;
+  header.version = JITHEADER_VERSION;
+  header.total_size = sizeof(header);
+  header.elf_mach = GetElfMachine();
+  header.pid = pid_;
+  header.timestamp = GetTimestamp();
+  header.flags = use_arch_timestamp_ ? JITDUMP_FLAGS_ARCH_TIMESTAMP : 0;
+
+  fwrite(&header, sizeof(header), 1, file_);
+
+  fflush(file_);
+}
+
+PerfJitdumpFile::~PerfJitdumpFile() {
+  if (!file_) {
+    return;
+  }
+
+  // Write close record?
+
+  fclose(file_);
+
+  if (self_delete_) {
+    unlink(path_);
+  }
+}
+
+void PerfJitdumpFile::Write(void* address, uint64_t length, const char* symbol, const CodeDebugMap& mapping) {
+  if (!file_) {
+    return;
+  }
+
+  if (!mapping.empty()) {
+    jr_code_debug_info dbg_record = {};
+    dbg_record.p.id = JIT_CODE_DEBUG_INFO;
+    dbg_record.p.total_size = sizeof(dbg_record);
+    dbg_record.p.timestamp = GetTimestamp();
+    dbg_record.code_addr = (uint64_t)address;
+    dbg_record.nr_entry = mapping.size();
+
+    for (const auto& map : mapping) {
+      dbg_record.p.total_size += sizeof(debug_entry) + strlen(map.file) + 1;
+    }
+
+    fwrite(&dbg_record, sizeof(dbg_record), 1, file_);
+
+    for (const auto& map : mapping) {
+      // Our special markers can be identified by them having a line number of 0,
+      // perf doesn't like that so we just shift them up to 1 so they're not lost.
+      debug_entry entry = {};
+      entry.addr = (uint64_t)address + map.addr;
+      entry.lineno = map.line >= 1 ? map.line : 1;
+
+      fwrite(&entry, sizeof(entry), 1, file_);
+      fwrite(map.file, 1, strlen(map.file) + 1, file_);
+    }
+  }
+
+  jr_code_load record = {};
+  record.p.id = JIT_CODE_LOAD;
+  record.p.total_size = sizeof(record) + strlen(symbol) + 1 + length;
+  record.p.timestamp = GetTimestamp();
+  record.pid = pid_;
+  record.tid = pid_; // TODO: Use the thread id.
+  record.vma = (uint64_t)address;
+  record.code_addr = (uint64_t)address;
+  record.code_size = length;
+  record.code_index = (uint64_t)address; // We don't re-JIT, so this should be fine.
+
+  fwrite(&record, sizeof(record), 1, file_);
+  fwrite(symbol, 1, strlen(symbol) + 1, file_);
+  fwrite(address, 1, length, file_);
+
+  fflush(file_);
+}
+
+uint64_t PerfJitdumpFile::GetTimestamp() {
+  timespec ts;
+
+  if (use_arch_timestamp_) {
+    return __rdtsc();
+  }
+
+  if (clock_gettime(CLOCK_MONOTONIC, &ts)) {
+    return 0;
+  }
+
+  return ((uint64_t)ts.tv_sec * 1000000000) + ts.tv_nsec;
+}
+
+uint16_t PerfJitdumpFile::GetElfMachine() {
+  uint16_t machine = 0; /* EM_NONE */
+
+  FILE* exe = fopen("/proc/self/exe", "r");
+  if (!exe) {
+    return machine;
+  }
+
+  struct {
+    uint8_t ident[16];
+    uint16_t type;
+    uint16_t machine;
+  } __attribute__((packed)) elf_header;
+
+  if (fread(&elf_header, sizeof(elf_header), 1, exe) != -1) {
+    machine = elf_header.machine;
+  }
+
+  fclose(exe);
+  return machine;
+}
+#endif

--- a/vm/debug-metadata.h
+++ b/vm/debug-metadata.h
@@ -1,0 +1,76 @@
+// vim: set sts=2 ts=8 sw=2 tw=99 et:
+//
+// Copyright (C) 2021 AlliedModders LLC
+//
+// This file is part of SourcePawn. SourcePawn is free software: you can
+// redistribute it and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License along with
+// SourcePawn. If not, see http://www.gnu.org/licenses/.
+//
+#ifndef _include_sourcepawn_vm_debug_metadata_h_
+#define _include_sourcepawn_vm_debug_metadata_h_
+
+#include <vector>
+
+#include <stdint.h>
+#include <am-platform.h>
+
+#if defined(KE_LINUX)
+#include <stdio.h>
+#endif
+
+namespace sp {
+
+struct CodeDebugMapping {
+  uint64_t addr;
+  const char* file;
+  uint32_t line;
+};
+
+using CodeDebugMap = std::vector<CodeDebugMapping>;
+
+#if defined(KE_LINUX)
+class PerfJitFile
+{
+ public:
+  explicit PerfJitFile(bool self_delete);
+  ~PerfJitFile();
+
+  void Write(void* address, uint64_t length, const char* symbol);
+
+ private:
+  bool self_delete_;
+  char path_[255];
+  FILE* file_;
+};
+
+class PerfJitdumpFile
+{
+ public:
+  explicit PerfJitdumpFile(bool self_delete);
+  ~PerfJitdumpFile();
+
+  void Write(void* address, uint64_t length, const char* symbol, const CodeDebugMap& mapping);
+
+ private:
+  uint64_t GetTimestamp();
+  uint16_t GetElfMachine();
+
+ private:
+  int pid_;
+  bool self_delete_;
+  char path_[255];
+  void *mmap_;
+  FILE* file_;
+
+  // When being used with Intel PT profiling, we need to use the CPU clock as our time source.
+  bool use_arch_timestamp_;
+};
+#endif
+
+} // namespace sp
+
+#endif // _include_sourcepawn_vm_debug_metadata_h_

--- a/vm/jit.h
+++ b/vm/jit.h
@@ -134,6 +134,7 @@ class CompilerBase : public PcodeVisitor
 
   // Debugging.
   Label debug_break_;
+  std::string debug_name_;
 
   std::vector<BackwardJump> backward_jumps_;
   std::vector<CipMapEntry> cip_map_;

--- a/vm/jitdump.h
+++ b/vm/jitdump.h
@@ -1,0 +1,66 @@
+// Below structs cribbed from tools/perf/util/jitdump.h in the Linux source tree.
+
+#define JITHEADER_MAGIC 0x4A695444
+#define JITHEADER_VERSION 1
+
+enum jitdump_flags_bits {
+  JITDUMP_FLAGS_ARCH_TIMESTAMP_BIT,
+  JITDUMP_FLAGS_MAX_BIT,
+};
+
+#define JITDUMP_FLAGS_ARCH_TIMESTAMP (1ULL << JITDUMP_FLAGS_ARCH_TIMESTAMP_BIT)
+
+struct jitheader {
+  uint32_t magic;      /* characters "jItD" */
+  uint32_t version;    /* header version */
+  uint32_t total_size; /* total size of header */
+  uint32_t elf_mach;   /* elf mach target */
+  uint32_t pad1;       /* reserved */
+  uint32_t pid;        /* JIT process id */
+  uint64_t timestamp;  /* timestamp */
+  uint64_t flags;      /* flags */
+};
+
+enum jit_record_type {
+  JIT_CODE_LOAD       = 0,
+  JIT_CODE_MOVE       = 1,
+  JIT_CODE_DEBUG_INFO = 2,
+  JIT_CODE_CLOSE      = 3,
+  JIT_CODE_MAX,
+};
+
+/* record prefix (mandatory in each record) */
+struct jr_prefix {
+  uint32_t id;
+  uint32_t total_size;
+  uint64_t timestamp;
+};
+
+struct jr_code_load {
+  struct jr_prefix p;
+
+  uint32_t pid;
+  uint32_t tid;
+  uint64_t vma;
+  uint64_t code_addr;
+  uint64_t code_size;
+  uint64_t code_index;
+  const char name[0];
+  unsigned char bytes[0];
+};
+
+struct debug_entry {
+  uint64_t addr;
+  int lineno;
+  int discrim;
+  const char name[0];
+};
+
+struct jr_code_debug_info {
+  struct jr_prefix p;
+
+  uint64_t code_addr;
+  uint64_t nr_entry;
+  struct debug_entry entries[0];
+};
+

--- a/vm/linking.cpp
+++ b/vm/linking.cpp
@@ -16,15 +16,21 @@
 using namespace sp;
 
 CodeChunk
-sp::LinkCode(Environment* env, Assembler& masm)
+sp::LinkCode(Environment* env, Assembler& masm, const char* name, const CodeDebugMap& mapping)
 {
   if (masm.outOfMemory())
     return CodeChunk();
 
-  CodeChunk code = env->AllocateCode(masm.length());
-  if (!code.address())
+  auto length = masm.length();
+  CodeChunk code = env->AllocateCode(length);
+
+  auto address = code.address();
+  if (!address)
     return code;
 
-  masm.emitToExecutableMemory(code.address());
+  masm.emitToExecutableMemory(address);
+
+  env->WriteDebugMetadata(address, length, name, mapping);
+
   return code;
 }

--- a/vm/linking.h
+++ b/vm/linking.h
@@ -13,14 +13,18 @@
 #ifndef _include_sourcepawn_vm_x86_utils_h_
 #define _include_sourcepawn_vm_x86_utils_h_
 
+#include <vector>
 #include <stdint.h>
+
 #include "macro-assembler.h"
 
 namespace sp {
 
 class Environment;
+struct CodeDebugMapping;
+using CodeDebugMap = std::vector<CodeDebugMapping>;
 
-CodeChunk LinkCode(Environment* env, Assembler& masm);
+CodeChunk LinkCode(Environment* env, Assembler& masm, const char* name, const CodeDebugMap& mapping);
 
 }
 

--- a/vm/shell.cpp
+++ b/vm/shell.cpp
@@ -291,6 +291,10 @@ int main(int argc, char** argv)
     "w", "disable-watchdog",
     Some(false),
     "Disable the watchdog timer.");
+  ToggleOption enable_jitdump(parser,
+    "p", "jitdump",
+    Some(false),
+    "Enable perf metadata recording for profiling.");
   StringOption filename(parser,
     "file",
     "SMX file to execute.");
@@ -326,6 +330,10 @@ int main(int argc, char** argv)
 
   if (!getenv("DISABLE_WATCHDOG") && !disable_watchdog.value())
     sEnv->InstallWatchdogTimer(5000);
+
+  if (enable_jitdump.value()) {
+    sEnv->SetDebugMetadataFlags(JIT_DEBUG_PERF_BASIC | JIT_DEBUG_PERF_JITDUMP);
+  }
 
   int errcode = Execute(filename.value().c_str());
 

--- a/vm/x64/code-stubs-x64.cpp
+++ b/vm/x64/code-stubs-x64.cpp
@@ -89,7 +89,7 @@ CodeStubs::CompileInvokeStub()
   __ bind(&error);
   __ jmp(&ret);
 
-  invoke_stub_ = LinkCode(env_, masm);
+  invoke_stub_ = LinkCode(env_, masm, "<jit invoke stub>", {});
   if (!invoke_stub_.address())
     return false;
 

--- a/vm/x86/code-stubs-x86.cpp
+++ b/vm/x86/code-stubs-x86.cpp
@@ -15,6 +15,7 @@
 #include "linking.h"
 #include "jit_x86.h"
 #include "environment.h"
+#include "debug-metadata.h"
 
 using namespace sp;
 using namespace SourcePawn;
@@ -26,7 +27,7 @@ CodeStubs::InitializeFeatureDetection()
 {
   MacroAssembler masm;
   MacroAssembler::GenerateFeatureDetection(masm);
-  CodeChunk code = LinkCode(env_, masm);
+  CodeChunk code = LinkCode(env_, masm, "<cpu feature detection>", {});
   if (!code.address())
     return false;
   MacroAssembler::RunFeatureDetection(code.address());
@@ -97,7 +98,7 @@ CodeStubs::CompileInvokeStub()
   __ bind(&error);
   __ jmp(&ret);
 
-  invoke_stub_ = LinkCode(env_, masm);
+  invoke_stub_ = LinkCode(env_, masm, "<jit invoke stub>", {});
   if (!invoke_stub_.address())
     return false;
 


### PR DESCRIPTION
Implemented here is the [original perf JIT format](https://github.com/torvalds/linux/blob/614cb5894306cfa2c7d9b6168182876ff5948735/tools/perf/Documentation/jit-interface.txt) which is widely supported but only supports simple name mapping, and the [newer "jitdump" format](https://github.com/torvalds/linux/blob/614cb5894306cfa2c7d9b6168182876ff5948735/tools/perf/Documentation/jitdump-specification.txt) which additionally supports embedding the machine code and source mapping information (along with a bunch of other things we don't currently have in the JIT).

Example usage:
```
# perf record -F 999 -g ./vm/spshell/linux-x86/spshell ./fib.smx
fib(42) = 267914296
[ perf record: Woken up 9 times to write data ]
[ perf record: Captured and wrote 2.124 MB perf.data (6339 samples) ]

# perf inject --jit -i perf.data -o perf.jit.data

# perf report -i perf.jit.data --stdio -q | head -n 15
    99.97%     0.00%  spshell  libc-2.29.so                [.] __libc_start_main
            |
            ---__libc_start_main
               main
               Execute
               sp::ScriptedInvoker::Invoke
               sp::PluginContext::Invoke
               sp::Environment::Invoke
               <jit invoke stub>
               fib.smx::main
               |
                --99.95%--fib.smx::fib
                          fib.smx::fib
                          fib.smx::fib
                          fib.smx::fib
```

Using the jitdump source mapping will probably require compiling perf from source, due to [this bug](https://lkml.org/lkml/2020/5/28/56), but it works [very well](https://gist.github.com/asherkin/3cc5a239cf77e0925baa33589bb16493).