### PR TITLE
Fix ternary rejecting expr ? null : obj

### DIFF
--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -832,7 +832,7 @@ TernaryExpr::Analyze()
         return false;
     }
 
-    if (!matchtag(left.tag, right.tag, FALSE))
+    if (!matchtag_commutative(left.tag, right.tag, FALSE))
         return false;
 
     /* If both sides are arrays, we should return the maximal as the lvalue.

--- a/tests/compile-only/ok-ternary-obj-types.sp
+++ b/tests/compile-only/ok-ternary-obj-types.sp
@@ -1,0 +1,17 @@
+using __intrinsics__.Handle;
+methodmap ArrayList < Handle {
+	public ArrayList() { return view_as<ArrayList>(1); }
+}
+
+public void OnPluginStart()
+{
+	bool b;
+
+	// ok
+	ArrayList x = b ? new ArrayList() : null;
+
+	// error 132: cannot coerce non-object type ArrayList to object type null_t
+	ArrayList y = b ? null : new ArrayList();
+
+	if (x || y) {}
+}


### PR DESCRIPTION
Bug: #536
Test: tests/compile-only/ok-ternary-obj-types.sp

`matchtag(some_methodmap, null_t)` works but `matchtag(null_t, some_methodmap)`.  Use `matchtag_commutative` instead so both `expr ? obj : null` and `expr ? null : obj` work.