### PR TITLE
Fix section header strings validation

### DIFF
--- a/vm/smx-v1-image.cpp
+++ b/vm/smx-v1-image.cpp
@@ -135,7 +135,7 @@ SmxV1Image::validate()
 
   // Validate sanity of section header strings.
   bool found_terminator = false;
-  for (const uint8_t* iter = header_strings_ + last_header_string;
+  for (const char* iter = header_strings_ + last_header_string;
        iter < buffer() + hdr_->dataoffs;
        iter++)
   {

--- a/vm/smx-v1-image.cpp
+++ b/vm/smx-v1-image.cpp
@@ -136,7 +136,7 @@ SmxV1Image::validate()
   // Validate sanity of section header strings.
   bool found_terminator = false;
   for (const char* iter = header_strings_ + last_header_string;
-       iter < buffer() + hdr_->dataoffs;
+       iter < reinterpret_cast<const char*>(buffer() + hdr_->dataoffs);
        iter++)
   {
     if (*iter == '\0') {

--- a/vm/smx-v1-image.cpp
+++ b/vm/smx-v1-image.cpp
@@ -135,7 +135,7 @@ SmxV1Image::validate()
 
   // Validate sanity of section header strings.
   bool found_terminator = false;
-  for (const uint8_t* iter = buffer() + last_header_string;
+  for (const uint8_t* iter = header_strings_ + last_header_string;
        iter < buffer() + hdr_->dataoffs;
        iter++)
   {


### PR DESCRIPTION
According to the description, last_header_string (the nameoffs field of one of the sp_file_section_t structure) is an offset relative to header_strings_, instead of being an offset relative to the beginning of the buffer.