### PR TITLE
Fix crash on undeclared static methodmap error

### DIFF
--- a/compiler/messages.h
+++ b/compiler/messages.h
@@ -129,7 +129,7 @@ static const char* errmsg[] = {
     /*102*/ "cannot find %s %s\n",
     /*103*/ "%s was already defined on this %s\n",
     /*104*/ "cannot find any methods for %s\n",
-    /*105*/ "cannot find method or property %s.%s\n",
+    /*105*/ "cannot find method or property \"%s.%s\"\n",
     /*106*/ "cannot call methods on an array\n",
     /*107*/ "cannot call methods on a function\n",
     /*108*/ "resolution operator (::) can only resolve field offsets of enum structs\n",

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -1222,7 +1222,7 @@ FieldAccessExpr::AnalyzeWithOptions(bool from_call)
         methodmap_t* map = base_val.sym->methodmap;
         method_ = methodmap_find_method(map, name_->chars());
         if (!method_) {
-            error(pos_, 105, map->name, field_->name());
+            error(pos_, 105, map->name, name_->chars());
             return false;
         }
         if (!method_->is_static) {

--- a/tests/compile-only/fail-enum-struct-field-not-found.txt
+++ b/tests/compile-only/fail-enum-struct-field-not-found.txt
@@ -1,1 +1,1 @@
-(7) : error 105: cannot find method or property Sample.b
+(7) : error 105: cannot find method or property "Sample.b"

--- a/tests/compile-only/fail-undeclared-static-methodmap-call.sp
+++ b/tests/compile-only/fail-undeclared-static-methodmap-call.sp
@@ -1,0 +1,11 @@
+methodmap TestA {
+    public void FuncA() {}
+}
+
+enum struct TestB {
+    void TestB() {
+        TestA.UndeclaredStaticFunc();
+    }
+}
+
+int main() {}

--- a/tests/compile-only/fail-undeclared-static-methodmap-call.sp
+++ b/tests/compile-only/fail-undeclared-static-methodmap-call.sp
@@ -3,6 +3,7 @@ methodmap TestA {
 }
 
 enum struct TestB {
+	int Var;
     void TestB() {
         TestA.UndeclaredStaticFunc();
     }

--- a/tests/compile-only/fail-undeclared-static-methodmap-call.txt
+++ b/tests/compile-only/fail-undeclared-static-methodmap-call.txt
@@ -1,1 +1,1 @@
-(8) : error 105: cannot find method or property TestA.UndeclaredStaticFunc
+(8) : error 105: cannot find method or property "TestA.UndeclaredStaticFunc"

--- a/tests/compile-only/fail-undeclared-static-methodmap-call.txt
+++ b/tests/compile-only/fail-undeclared-static-methodmap-call.txt
@@ -1,0 +1,1 @@
+(8) : error 105: cannot find method or property TestA.UndeclaredStaticFunc


### PR DESCRIPTION
Fixes https://github.com/alliedmodders/sourcemod/issues/1453

This patch just uses the name we looked up instead of the name from the (null) `field_` var.

Now errors with

```
SourcePawn Compiler 1.11
Copyright (c) 1997-2006 ITB CompuPhase
Copyright (c) 2004-2018 AlliedModders LLC 
test.sp(8) : error 105: cannot find method or property TestA.UndeclaredStaticFunc 
```