### PR TITLE
Fix single quote bug in preprocessor

### DIFF
--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -1360,16 +1360,11 @@ substpattern(unsigned char* line, size_t buffersize, const char* pattern,
                 s += 2;
             }
             e++; /* skip %, digit is skipped later */
-        } else if (*e == '"') {
+        } else if (is_startstring(e)) {
             p = e;
-            if (is_startstring(e)) {
-                e = skipstring(e);
-                strins((char*)s, (char*)p, (e - p + 1));
-                s += (e - p + 1);
-            } else {
-                strins((char*)s, (char*)e, 1);
-                s++;
-            }
+            e = skipstring(e);
+            strins((char*)s, (char*)p, (e - p + 1));
+            s += (e - p + 1);
         } else {
             strins((char*)s, (char*)e, 1);
             s++;

--- a/tests/compile-only/ok-char-literal-in-macro.sp
+++ b/tests/compile-only/ok-char-literal-in-macro.sp
@@ -1,0 +1,7 @@
+#define test c = '"';
+public void main()
+{
+    char c;
+    {
+        test }
+}


### PR DESCRIPTION
The lexer checks for a double quote before doing a pretty nugatory microoptimization. This check is incorrect, single quotes need to be fed into skipstring() as well. I've retained the optimization and simplified the code a bit.

I've also refactored this code a bit since it had way too much nesting, all to dance around needing manual free() calls.