### PR TITLE
Sync include behavior for subdirectories between windows and linux

### DIFF
--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -210,9 +210,10 @@ doinclude(int silent)
         if (DIRSEP_CHAR != '/' && *lptr == '/') {
             name[i++] = DIRSEP_CHAR;
             lptr++;
-            continue;
         }
-        name[i++] = *lptr++;
+        else {
+            name[i++] = *lptr++;
+        }
     }
     while (i > 0 && name[i - 1] <= ' ')
         i--; /* strip trailing whitespace */

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -206,7 +206,14 @@ doinclude(int silent)
 
     i = 0;
     while (*lptr != c && *lptr != '\0' && i < sizeof name - 1) /* find the end of the string */
+    {
+        if (DIRSEP_CHAR == '\\' && *lptr == '/') {
+            name[i++] = DIRSEP_CHAR;
+            lptr++;
+            continue;
+        }
         name[i++] = *lptr++;
+    }
     while (i > 0 && name[i - 1] <= ' ')
         i--; /* strip trailing whitespace */
     assert(i < sizeof name);

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -207,7 +207,7 @@ doinclude(int silent)
     i = 0;
     while (*lptr != c && *lptr != '\0' && i < sizeof name - 1) /* find the end of the string */
     {
-        if (DIRSEP_CHAR == '\\' && *lptr == '/') {
+        if (DIRSEP_CHAR != '/' && *lptr == '/') {
             name[i++] = DIRSEP_CHAR;
             lptr++;
             continue;

--- a/tests/compile-only/include/extension.inc
+++ b/tests/compile-only/include/extension.inc
@@ -1,2 +1,1 @@
 #include "extension/file"
-#include "extension\\file"

--- a/tests/compile-only/include/extension.inc
+++ b/tests/compile-only/include/extension.inc
@@ -1,0 +1,2 @@
+#include "extension/file"
+#include "extension\\file"

--- a/tests/compile-only/include/extension/file.inc
+++ b/tests/compile-only/include/extension/file.inc
@@ -1,0 +1,1 @@
+#define test 1

--- a/tests/compile-only/ok-relative-includes.sp
+++ b/tests/compile-only/ok-relative-includes.sp
@@ -1,4 +1,3 @@
 #include "include/extension"
-#include "include\\extension"
 
 public void main() {}

--- a/tests/compile-only/ok-relative-includes.sp
+++ b/tests/compile-only/ok-relative-includes.sp
@@ -1,0 +1,4 @@
+#include "include/extension"
+#include "include\\extension"
+
+public void main() {}


### PR DESCRIPTION
This PR aims to solve https://github.com/alliedmodders/sourcepawn/issues/245 (Including files from withing sub directory with relative path is inconsistent/fails)

Motivation:
In larger plugins subdirectories are used to create structure in the project, however with the current handling of include paths it would make cross platform development and automation of multi platform CI/CD a pain.

Potential issues:
This change would be breaking for current projects developed on windows with a subdirectory structure. It would be relatively easy to fix for project maintainers by making the includes relative to the file that is including them.

Credits go to @impact123 for coming up with the proposed solution.