### PR TITLE
Use AMTL defines for perf jit log printing

### DIFF
--- a/vm/debug-metadata.cpp
+++ b/vm/debug-metadata.cpp
@@ -65,7 +65,7 @@ void PerfJitFile::Write(void* address, uint64_t length, const char* symbol) {
   }
 
   fprintf(file_,
-    (sizeof(long) == 8) ? "%lx %lx %s\n" : "%llx %llx %s\n",
+    "%" KE_FMT_X64 " %" KE_FMT_X64 " %s\n",
     (uint64_t)address, length, symbol);
 
   fflush(file_);


### PR DESCRIPTION
64-bit number format specifiers are platform dependant, and the older Clang version used by SM can't figure out the ternary here at compile time so throws a warning.