### PR TITLE
Fix inconsistencies with function signature type checks.

### DIFF
--- a/compiler/expressions.h
+++ b/compiler/expressions.h
@@ -53,6 +53,7 @@ class ExpressionParser
 #define MATCHTAG_COERCE 0x1      // allow coercion
 #define MATCHTAG_SILENT 0x2      // silence the error(213) warning
 #define MATCHTAG_DEDUCE 0x4      // correct coercion
+#define MATCHTAG_FUNCARG 0x8     // argument in a function signature
 
 bool find_userop(void (*oper)(), int tag1, int tag2, int numparam, const value* lval, UserOperation* op);
 void emit_userop(const UserOperation& user_op, value* lval);

--- a/compiler/sctracker.cpp
+++ b/compiler/sctracker.cpp
@@ -154,13 +154,11 @@ funcenum_for_symbol(symbol* sym)
 
 // Finds a functag that was created intrinsically.
 functag_t*
-functag_find_intrinsic(int tag)
+functag_from_tag(int tag)
 {
     Type* type = gTypes.find(tag);
     funcenum_t* fe = type->asFunction();
     if (!fe)
-        return nullptr;
-    if (strncmp(fe->name, "::ft:", 5) != 0)
         return nullptr;
     if (fe->entries.empty())
         return nullptr;

--- a/compiler/sctracker.h
+++ b/compiler/sctracker.h
@@ -124,7 +124,7 @@ void funcenums_free();
 funcenum_t* funcenums_add(const char* name);
 void functags_add(funcenum_t* en, functag_t* src);
 funcenum_t* funcenum_for_symbol(symbol* sym);
-functag_t* functag_find_intrinsic(int tag);
+functag_t* functag_from_tag(int tag);
 
 /**
  * Given a name or tag, find any extra weirdness it has associated with it.

--- a/tests/compile-only/fail-bad-function-casts.sp
+++ b/tests/compile-only/fail-bad-function-casts.sp
@@ -1,0 +1,47 @@
+native void print(const char[] x);
+native void printnum(int n);
+
+typedef TestAny = function void (any[] b);
+typedef TestChar = function void (char[] b);
+
+public void main()
+{
+	char c[] = "hi";
+	any a[] = {1,2,3};
+
+	CharArg(c);
+	AnyArg(c); // error 178: cannot coerce char[] to any[]; storage classes differ
+	CharArg(a); // error 178: cannot coerce any[] to char[]; storage classes differ
+	AnyArg(a);
+
+	TestAny anyArgFunc = CharArg; // fine?!
+	TestChar charArgFunc = AnyArg; // fine?!
+
+	anyArgFunc = CharArg;
+	charArgFunc = AnyArg;
+
+	TestAnyArg(charArgFunc); // error 100: function prototypes do not match
+	TestCharArg(anyArgFunc); // error 100: function prototypes do not match
+	TestAnyArg(AnyArg);
+	TestAnyArg(CharArg); // fine?!
+	TestCharArg(CharArg);
+	TestCharArg(AnyArg); // fine?!
+}
+
+void TestAnyArg(TestAny f)
+{
+	f = INVALID_FUNCTION;
+}
+void TestCharArg(TestChar f)
+{
+	f = INVALID_FUNCTION;
+}
+
+void CharArg(char[] b)
+{
+	print(b);
+} // warning 209: function "CharArg" should return a value
+void AnyArg(any[] b)
+{
+	printnum(b[1]);
+} // warning 209: function "AnyArg" should return a value

--- a/tests/compile-only/fail-bad-function-casts.txt
+++ b/tests/compile-only/fail-bad-function-casts.txt
@@ -1,0 +1,10 @@
+(13) : error 178: cannot coerce char[] to any[]; storage classes differ
+(14) : error 178: cannot coerce any[] to char[]; storage classes differ
+(17) : error 100: function prototypes do not match
+(18) : error 100: function prototypes do not match
+(20) : error 100: function prototypes do not match
+(21) : error 100: function prototypes do not match
+(23) : error 100: function prototypes do not match
+(24) : error 100: function prototypes do not match
+(26) : error 100: function prototypes do not match
+(28) : error 100: function prototypes do not match

--- a/tests/compile-only/fail-bad-signature-cast.sp
+++ b/tests/compile-only/fail-bad-signature-cast.sp
@@ -1,0 +1,9 @@
+typedef AA = function void(int egg);
+typedef BB = function void(any egg);
+
+public main()
+{
+   AA aa;
+   BB bb;
+   bb = aa;
+}

--- a/tests/compile-only/fail-bad-signature-cast.txt
+++ b/tests/compile-only/fail-bad-signature-cast.txt
@@ -1,0 +1,1 @@
+(8) : error 100: function prototypes do not match

--- a/tests/compile-only/ok-signature-cast-type-pun.sp
+++ b/tests/compile-only/ok-signature-cast-type-pun.sp
@@ -1,0 +1,9 @@
+typedef AA = function void(int egg);
+typedef BB = function void(any egg);
+
+public main()
+{
+   AA aa;
+   BB bb;
+   aa = bb;
+}


### PR DESCRIPTION
This fixes a few bugs in typedef/function signature checks.

First, typedef-to-typedef comparisons are now valid. They previously
would always fail, due to the type checker requiring the type to be
backed by a function symbol.

Second, methodmap checks are now bidirectional. Eg, Handle casts to
DataPack and DataPack casts to Handle. This is a convenience cludge that
is commonly used, we can't easily break it, so now it is codified.

Third, arrays only implicitly cast if tags are identical. This is not
ideal, but it suffices until better rules can be written. For now it
prevents char[] casting to something with integer width.

Finally, a callback using a non-"any" type cannot be passed to a callback
using the "any" type. This prevents illegal implicit casts that we can't
yet do runtime checks on to prevent.

Bug: #548
Test: new compile-only tests