### PR TITLE
Fix crashes when SMX plugin doesn't have a function name

### DIFF
--- a/vm/jit.cpp
+++ b/vm/jit.cpp
@@ -82,7 +82,7 @@ CompilerBase::emit()
 
   const char* function_name = rt_->image()->LookupFunction(pcode_start_);
 
-  debug_name_ = std::string(rt_->Name()) + "::" + function_name;
+  debug_name_ = std::string(rt_->Name()) + "::" + (function_name ? function_name : "<unknown function>");
 
 #if defined JIT_SPEW
   Environment::get()->debugger()->OnDebugSpew(


### PR DESCRIPTION
Fixes #580
Past changes #533 