### PR TITLE
Require RTTI-enabled plugins to have valid RTTI entries.

### DIFF
--- a/vm/environment.cpp
+++ b/vm/environment.cpp
@@ -351,10 +351,12 @@ Environment::Invoke(PluginContext* cx,
 #endif
 
   // The JIT performs its own validation. Handle the interpreter here.
-  int err = method->Validate();
-  if (err != SP_ERROR_NONE) {
-    cx->ReportErrorNumber(err);
-    return false;
+  {
+    auto graph = method->Validate();
+    if (!graph) {
+      cx->ReportErrorNumber(method->validationError());
+      return false;
+    }
   }
 
   return Interpreter::Run(cx, method, result);

--- a/vm/interpreter.cpp
+++ b/vm/interpreter.cpp
@@ -155,10 +155,12 @@ Interpreter::visitCALL(cell_t offset)
     cx_->ReportErrorNumber(SP_ERROR_INVALID_ADDRESS);
     return false;
   }
-  int err = target->Validate();
-  if (err != SP_ERROR_NONE) {
-    cx_->ReportErrorNumber(err);
-    return false;
+  {
+    auto graph = target->Validate();
+    if (!graph) {
+      cx_->ReportErrorNumber(target->validationError());
+      return false;
+    }
   }
 
   // We don't interleave between the interpreter and JIT (yet).

--- a/vm/jit.cpp
+++ b/vm/jit.cpp
@@ -71,7 +71,7 @@ CompilerBase::Compile(PluginContext* cx, RefPtr<MethodInfo> method, int* err)
 CompiledFunction*
 CompilerBase::emit()
 {
-  graph_ = method_info_->ValidateWithGraph();
+  graph_ = method_info_->Validate();
   if (!graph_) {
     reportError(method_info_->validationError());
     return nullptr;

--- a/vm/legacy-image.h
+++ b/vm/legacy-image.h
@@ -15,6 +15,7 @@
 
 #include <string.h>
 #include <smx/smx-headers.h>
+#include <smx/smx-typeinfo.h>
 
 namespace sp {
 
@@ -58,6 +59,8 @@ class LegacyImage
   virtual bool LookupLineAddress(const uint32_t line, const char* file, ucell_t* addr) = 0;
   virtual size_t NumFiles() const = 0;
   virtual const char* GetFileName(size_t index) const = 0;
+  virtual bool HasRtti() const = 0;
+  virtual const smx_rtti_method* GetMethodRttiByOffset(uint32_t pcode_offset) = 0;
 };
 
 class EmptyImage : public LegacyImage
@@ -137,6 +140,12 @@ class EmptyImage : public LegacyImage
   }
   const char* GetFileName(size_t index) const override {
     return nullptr;
+  }
+  const smx_rtti_method* GetMethodRttiByOffset(uint32_t pcode_offset) override {
+    return nullptr;
+  }
+  bool HasRtti() const override {
+    return false;
   }
 
  private:

--- a/vm/method-info.h
+++ b/vm/method-info.h
@@ -28,14 +28,7 @@ class MethodInfo final : public ke::Refcounted<MethodInfo>
   MethodInfo(PluginRuntime* rt, uint32_t codeOffset);
   ~MethodInfo();
 
-  int Validate() {
-    if (!checked_) {
-      InternalValidate();
-      graph_ = nullptr;
-    }
-    return validation_error_;
-  }
-  ke::RefPtr<ControlFlowGraph> ValidateWithGraph() {
+  ke::RefPtr<ControlFlowGraph> Validate() {
     if (!checked_ || !graph_)
       InternalValidate();
     return graph_.take();

--- a/vm/method-verifier.cpp
+++ b/vm/method-verifier.cpp
@@ -56,6 +56,15 @@ MethodVerifier::verify()
     return nullptr;
   }
 
+  auto image = rt_->image();
+  if (image->HasRtti()) {
+    auto rtti = image->GetMethodRttiByOffset(startOffset_);
+    if (!rtti || rtti->pcode_start != startOffset_) {
+      reportError(SP_ERROR_INVALID_ADDRESS);
+      return nullptr;
+    }
+  }
+
   GraphBuilder gb(rt_, startOffset_);
   graph_ = gb.build();
   if (!graph_) {

--- a/vm/smx-v1-image.h
+++ b/vm/smx-v1-image.h
@@ -62,6 +62,8 @@ class SmxV1Image
   bool LookupLineAddress(const uint32_t line, const char* file, ucell_t* addr) override;
   size_t NumFiles() const override;
   const char* GetFileName(size_t index) const override;
+  bool HasRtti() const override;
+  const smx_rtti_method* GetMethodRttiByOffset(uint32_t pcode_offset) override;
 
  private:
    struct Section


### PR DESCRIPTION
This validates that all method calls have an associated RTTI entry, if
the RTTI table is present. Signature validation will come in 1.12.

No opcode depends on RTTI yet, so the compiler does not yet enforce
RTTI tables to be emitted. This is to allow 1.11-compiled plugins to run
on SourceMod 1.10.

Bug: issue #580
Bug: alliedmodders/sourcemod #1525