### PR TITLE
added __FILE_PATH__ and __FILE_NAME__ definitions

### DIFF
--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -168,6 +168,11 @@ plungefile(char* name, int try_currentpath, int try_includepaths)
             if(!pcwd) {
                 error(194, "can't get current working directory, either the internal buffer is too small or the working directory can't be determined.");
             }
+
+#if defined __MSDOS__ || defined __WIN32__ || defined _Windows
+            // make the drive letter on windows lower case to be in line with the rest of SP, as they have a small drive letter in the path
+            cwd[0] = tolower(cwd[0]);
+#endif
         }
     }
 

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -134,6 +134,8 @@ int
 plungefile(char* name, int try_currentpath, int try_includepaths)
 {
     int result = FALSE;
+    char* pcwd = NULL;
+    char cwd[_MAX_PATH];
 
     if (try_currentpath) {
         result = plungequalifiedfile(name);
@@ -153,6 +155,13 @@ plungefile(char* name, int try_currentpath, int try_includepaths)
                 }
             }
         }
+        else {
+            pcwd = getcwd(cwd, sizeof(cwd));
+            error(224, pcwd);
+            if(pcwd == NULL){
+                error(1, "can't get current working directory, either too small or can't be determined.");
+            }
+        }
     }
 
     if (try_includepaths && name[0] != DIRSEP_CHAR) {
@@ -165,7 +174,16 @@ plungefile(char* name, int try_currentpath, int try_includepaths)
         }
     }
 
-    set_file_defines(inpfname);
+    if(pcwd != NULL) {
+        char path[_MAX_PATH];
+        SafeSprintf(path, sizeof(path), "%s%s", pcwd, inpfname);
+        set_file_defines(path);
+        error(224,pcwd);
+        // set_file_defines(inpfname);
+    }
+    else {
+        set_file_defines(inpfname);
+    }
 
     return result;
 }

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -163,10 +163,9 @@ plungefile(char* name, int try_currentpath, int try_includepaths)
                     result = plungequalifiedfile(path);
                 }
             }
-        }
-        else {
+        } else {
             pcwd = getcwd(cwd, sizeof(cwd));
-            if(pcwd == NULL) {
+            if(!pcwd) {
                 error(194, "can't get current working directory, either the internal buffer is too small or the working directory can't be determined.");
             }
         }
@@ -182,12 +181,11 @@ plungefile(char* name, int try_currentpath, int try_includepaths)
         }
     }
 
-    if(pcwd != NULL) {
+    if(pcwd) {
         char path[_MAX_PATH];
         SafeSprintf(path, sizeof(path), "%s%s", pcwd, inpfname);
         set_file_defines(path);
-    }
-    else {
+    } else {
         set_file_defines(inpfname);
     }
 

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -31,6 +31,14 @@
 #include <unordered_set>
 #include <utility>
 
+#if defined __linux__ || defined __FreeBSD__ || defined __OpenBSD__ || defined DARWIN
+#    include <unistd.h>
+#endif
+
+#if defined _MSC_VER && defined _WIN32
+#    include <direct.h>
+#endif
+
 #include "lexer.h"
 #include <amtl/am-hashmap.h>
 #include <amtl/am-platform.h>
@@ -157,9 +165,8 @@ plungefile(char* name, int try_currentpath, int try_includepaths)
         }
         else {
             pcwd = getcwd(cwd, sizeof(cwd));
-            error(224, pcwd);
-            if(pcwd == NULL){
-                error(1, "can't get current working directory, either too small or can't be determined.");
+            if(pcwd == NULL) {
+                error(194, "can't get current working directory, either the internal buffer is too small or the working directory can't be determined.");
             }
         }
     }
@@ -178,8 +185,6 @@ plungefile(char* name, int try_currentpath, int try_includepaths)
         char path[_MAX_PATH];
         SafeSprintf(path, sizeof(path), "%s%s", pcwd, inpfname);
         set_file_defines(path);
-        error(224,pcwd);
-        // set_file_defines(inpfname);
     }
     else {
         set_file_defines(inpfname);

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -165,7 +165,7 @@ plungefile(char* name, int try_currentpath, int try_includepaths)
             }
         } else {
             pcwd = getcwd(cwd, sizeof(cwd));
-            if(!pcwd) {
+            if (!pcwd) {
                 error(194, "can't get current working directory, either the internal buffer is too small or the working directory can't be determined.");
             }
 
@@ -186,7 +186,7 @@ plungefile(char* name, int try_currentpath, int try_includepaths)
         }
     }
 
-    if(pcwd) {
+    if (pcwd) {
         char path[_MAX_PATH];
         SafeSprintf(path, sizeof(path), "%s%s", pcwd, inpfname);
         set_file_defines(path);

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -67,7 +67,7 @@ static cell litchar(const unsigned char** lptr, int flags);
 
 static void substallpatterns(unsigned char* line, int buffersize);
 static int alpha(char c);
-static void set_file_defines(const std::string file);
+static void set_file_defines(std::string file);
 
 #define SKIPMODE 1     /* bit field in "#if" stack */
 #define PARSEMODE 2    /* bit field in "#if" stack */

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -31,6 +31,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <string>
 
 #include <utility>
 
@@ -148,7 +149,7 @@ static void addwhile(int* ptr);
 static void delwhile(void);
 static int* readwhile(void);
 static void inst_datetime_defines(void);
-static void inst_binary_name(char* binfname);
+static void inst_binary_name(std::string binfile);
 static int operatorname(char* name);
 static int reparse_old_decl(declinfo_t* decl, int flags);
 static int reparse_new_decl(declinfo_t* decl, int flags);
@@ -533,33 +534,27 @@ pc_addconstant(const char* name, cell value, int tag) {
 }
 
 static void
-inst_binary_name(char* binfname) {
-    size_t i, len;
-    char* binptr;
-    char newpath[512], newname[512];
+inst_binary_name(std::string binfile) {
+    auto sepIndex = binfile.find_last_of(DIRSEP_CHAR);
 
-    binptr = NULL;
-    len = strlen(binfname);
-    for (i = len - 1; i < len; i--) {
-        if (binfname[i] == '/'
-#if defined WIN32 || defined _WIN32
-            || binfname[i] == '\\'
+    std::string binfileName = sepIndex == std::string::npos ? binfile : binfile.substr(sepIndex + 1);
+
+#if DIRSEP_CHAR == '\\'
+    auto pos = binfile.find('\\');
+    while (pos != std::string::npos) {
+        binfile.insert(pos + 1, 1, '\\');
+        pos = binfile.find('\\', pos + 2);
+    }
 #endif
-        ) {
-            binptr = &binfname[i + 1];
-            break;
-        }
-    }
 
-    if (binptr == NULL) {
-        binptr = binfname;
-    }
+    binfile.insert(binfile.begin(), '"');
+    binfileName.insert(binfileName.begin(), '"');
 
-    snprintf(newpath, sizeof(newpath), "\"%s\"", binfname);
-    snprintf(newname, sizeof(newname), "\"%s\"", binptr);
+    binfile.push_back('"');
+    binfileName.push_back('"');
 
-    insert_subst("__BINARY_PATH__", 15, newpath);
-    insert_subst("__BINARY_NAME__", 15, newname);
+    insert_subst("__BINARY_PATH__", 15, binfile.c_str());
+    insert_subst("__BINARY_NAME__", 15, binfileName.c_str());
 }
 
 static void

--- a/tests/basic/file-const-include.inc
+++ b/tests/basic/file-const-include.inc
@@ -1,0 +1,40 @@
+#include <shell>
+
+#define FILE __FILE_NAME__
+#define PATH __FILE_PATH__
+
+void PrintIncludeName() {
+    print(__FILE_NAME__);
+}
+
+void PrintIncludeName2() {
+    print(FILE);
+}
+
+void PrintIncludePath() {
+    print(__FILE_PATH__);
+}
+
+void PrintIncludePath2() {
+    print(PATH);
+}
+
+void GetIncludeName(char[] buffer, int bufferSize) {
+    char fileName[] = __FILE_NAME__;
+    int copySize = bufferSize < sizeof(fileName) ? bufferSize - 1 : sizeof(fileName) - 1;
+
+    for(int i = 0; i < copySize; i++) {
+        buffer[i] = fileName[i];
+    }
+    buffer[copySize] = 0;
+}
+
+void GetIncludePath(char[] buffer, int bufferSize) {
+    char filePath[] = __FILE_PATH__;
+    int copySize = bufferSize < sizeof(filePath) ? bufferSize - 1 : sizeof(filePath) - 1;
+
+    for(int i = 0; i < copySize; i++) {
+        buffer[i] = filePath[i];
+    }
+    buffer[copySize] = 0;
+}

--- a/tests/basic/file-const-include.inc
+++ b/tests/basic/file-const-include.inc
@@ -23,7 +23,7 @@ void GetIncludeName(char[] buffer, int bufferSize) {
     char fileName[] = __FILE_NAME__;
     int copySize = bufferSize < sizeof(fileName) ? bufferSize - 1 : sizeof(fileName) - 1;
 
-    for(int i = 0; i < copySize; i++) {
+    for (int i = 0; i < copySize; i++) {
         buffer[i] = fileName[i];
     }
     buffer[copySize] = 0;
@@ -33,7 +33,7 @@ void GetIncludePath(char[] buffer, int bufferSize) {
     char filePath[] = __FILE_PATH__;
     int copySize = bufferSize < sizeof(filePath) ? bufferSize - 1 : sizeof(filePath) - 1;
 
-    for(int i = 0; i < copySize; i++) {
+    for (int i = 0; i < copySize; i++) {
         buffer[i] = filePath[i];
     }
     buffer[copySize] = 0;

--- a/tests/basic/file-const.out
+++ b/tests/basic/file-const.out
@@ -3,6 +3,7 @@ file-const.sp
 file-const-include.inc
 file-const-include.inc
 1
+1
 file-const-include.inc
 1
 0

--- a/tests/basic/file-const.out
+++ b/tests/basic/file-const.out
@@ -1,0 +1,10 @@
+file-const.sp
+file-const.sp
+file-const-include.inc
+file-const-include.inc
+1
+file-const-include.inc
+1
+0
+1
+0

--- a/tests/basic/file-const.sp
+++ b/tests/basic/file-const.sp
@@ -1,0 +1,47 @@
+#include <shell>
+#include "file-const-include.inc"
+
+public main() {
+    print(__FILE_NAME__);
+    print("\n");
+    print(FILE);
+    print("\n");
+    PrintIncludeName();
+    print("\n");
+    PrintIncludeName2();
+    print("\n");
+
+    printnum(StringLength(__FILE_PATH__) > StringLength(__FILE_NAME__));
+
+    char buffer[512];
+    GetIncludeName(buffer, sizeof(buffer));
+    print(buffer);
+    print("\n");
+
+    printnum(StringEquals(__FILE_NAME__, FILE));
+    printnum(StringEquals(__FILE_NAME__, buffer));
+
+    GetIncludePath(buffer, sizeof(buffer));
+    printnum(StringEquals(__FILE_PATH__, PATH));
+    printnum(StringEquals(__FILE_PATH__, buffer));
+}
+
+bool StringEquals(char[] leftString, char[] rightString) {
+    for(int i = 0;; i++)
+    {
+        if(leftString[i] != rightString[i])
+            return false;
+
+        if(leftString[i] == 0)
+            return true;
+    }
+}
+
+int StringLength(char[] string) {
+    int length = 0;
+    for(;;)
+    {
+        if(string[length++] == 0)
+            return length;
+    }
+}

--- a/tests/basic/file-const.sp
+++ b/tests/basic/file-const.sp
@@ -28,21 +28,21 @@ public main() {
 }
 
 bool StringEquals(char[] leftString, char[] rightString) {
-    for(int i = 0;; i++)
+    for (int i = 0;; i++)
     {
-        if(leftString[i] != rightString[i])
+        if (leftString[i] != rightString[i])
             return false;
 
-        if(leftString[i] == 0)
+        if (leftString[i] == 0)
             return true;
     }
 }
 
 int StringLength(char[] string) {
     int length = 0;
-    for(;;)
+    for (;;)
     {
-        if(string[length++] == 0)
+        if (string[length++] == 0)
             return length;
     }
 }
@@ -54,11 +54,11 @@ bool EndsWith(char[] string, char[] sequence) {
     int strI = stringLength - 1;
     int seqI = sequnceLength - 1;
 
-    for(; strI > 0; strI--, seqI--) {
-        if(string[strI] != sequence[seqI])
+    for (; strI > 0; strI--, seqI--) {
+        if (string[strI] != sequence[seqI])
             return false;
 
-        if(seqI == 0)
+        if (seqI == 0)
             return true;
     }
 

--- a/tests/basic/file-const.sp
+++ b/tests/basic/file-const.sp
@@ -11,6 +11,7 @@ public main() {
     PrintIncludeName2();
     print("\n");
 
+    printnum(EndsWith(__FILE_PATH__, __FILE_NAME__));
     printnum(StringLength(__FILE_PATH__) > StringLength(__FILE_NAME__));
 
     char buffer[512];
@@ -44,4 +45,22 @@ int StringLength(char[] string) {
         if(string[length++] == 0)
             return length;
     }
+}
+
+bool EndsWith(char[] string, char[] sequence) {
+    int stringLength = StringLength(string);
+    int sequnceLength = StringLength(sequence);
+
+    int strI = stringLength - 1;
+    int seqI = sequnceLength - 1;
+
+    for(; strI > 0; strI--, seqI--) {
+        if(string[strI] != sequence[seqI])
+            return false;
+
+        if(seqI == 0)
+            return true;
+    }
+
+    return false;
 }


### PR DESCRIPTION
This PR implements a feature requested in [#182 (Compiler define \_\_FILE\_\_)](https://github.com/alliedmodders/sourcepawn/issues/182)

It adds two new macros that can be used for debugging purposes, like `__LINE__`:
* ``__FILE_PATH__`` - A string containing the full path the the document where it is used in.
* ``__FILE_NAME__`` - A string containing just the name of the current file without a path.

I used ``__BINARY_PATH__`` and ``__BINARY_NAME__`` as examples on how to implement these definitions.