### PR TITLE
Fix assignment counting as "read" usage.

### DIFF
--- a/compiler/parse-node.h
+++ b/compiler/parse-node.h
@@ -69,6 +69,9 @@ class ParseNode : public PoolObject
     virtual bool Bind() {
         return true;
     }
+    virtual bool BindLval() {
+        return Bind();
+    }
     virtual bool Analyze() = 0;
     virtual void Emit() = 0;
     virtual bool HasSideEffects() {
@@ -448,11 +451,7 @@ class BinaryExprBase : public Expr
   public:
     BinaryExprBase(const token_pos_t& pos, int token, Expr* left, Expr* right);
 
-    bool Bind() override {
-        bool ok = left_->Bind();
-        ok &= right_->Bind();
-        return ok;
-    }
+    bool Bind() override;
     bool HasSideEffects() override;
     void ProcessUses() override;
 
@@ -686,6 +685,7 @@ class SymbolExpr final : public Expr
     }
 
     bool Bind() override;
+    bool BindLval() override;
     bool Analyze() override;
     void DoEmit() override;
     void ProcessUses() override {}
@@ -696,6 +696,9 @@ class SymbolExpr final : public Expr
     }
 
     bool AnalyzeWithOptions(bool allow_types);
+
+  private:
+    bool DoBind(bool is_lval);
 
   private:
     sp::Atom* name_;

--- a/tests/compile-only/fail-assign-is-not-usage.sp
+++ b/tests/compile-only/fail-assign-is-not-usage.sp
@@ -1,0 +1,6 @@
+// warnings_are_errors: true
+int x
+
+public main() {
+  x = 3;
+}

--- a/tests/compile-only/fail-assign-is-not-usage.txt
+++ b/tests/compile-only/fail-assign-is-not-usage.txt
@@ -1,0 +1,1 @@
+(5) : error 204: symbol is assigned a value that is never used: "x"


### PR DESCRIPTION
A hack in the new parser caused assigned-but-not-used symbols to be
counted as used. Add a hack to this hack to differentiate lval from rval
assignment.

This will go away if we can remove the two-pass parser.

Bug: #545
Test: new compile-only test