### PR TITLE
Adjust memory based on inferred maximum stack size.

### DIFF
--- a/compiler/assembler.cpp
+++ b/compiler/assembler.cpp
@@ -1544,7 +1544,8 @@ assemble_to_buffer(SmxByteBuffer* buffer, memfile_t* fin)
     // by the plugin.
     data->header().datasize = data_buffer.size() * sizeof(cell);
     data->header().memsize =
-        data->header().datasize + glb_declared * sizeof(cell) + pc_stksize * sizeof(cell);
+        data->header().datasize + glb_declared * sizeof(cell) +
+        std::max(pc_max_memory + 4096, pc_stksize) * sizeof(cell);
     data->header().data = sizeof(sp_file_data_t);
     data->setBlob((uint8_t*)data_buffer.data(), data_buffer.size() * sizeof(cell));
 

--- a/compiler/emitter.cpp
+++ b/compiler/emitter.cpp
@@ -825,7 +825,7 @@ defstorage(void)
 }
 
 /*
- *  Inclrement/decrement stack pointer. Note that this routine does
+ *  Increment/decrement stack pointer. Note that this routine does
  *  nothing if the delta is zero.
  */
 void

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -3719,6 +3719,9 @@ newfunc(declinfo_t* decl, const int* thistag, int fpublic, int fstatic, int stoc
     glbdecl = 0;
     assert(loctab.next == NULL); /* local symbol table should be empty */
 
+    pc_max_func_memory = 0;
+    pc_current_memory = 0;
+
     if (symp)
         *symp = NULL;
 
@@ -3901,8 +3904,12 @@ newfunc(declinfo_t* decl, const int* thistag, int fpublic, int fstatic, int stoc
         glb_declared = glbdecl;
         sc_err_status = FALSE;
     }
+
     if (symp)
         *symp = sym;
+
+    pc_max_memory = std::max(pc_max_func_memory, pc_max_memory);
+
     return TRUE;
 }
 

--- a/compiler/scvars.cpp
+++ b/compiler/scvars.cpp
@@ -87,6 +87,9 @@ int sc_require_newdecls = 0;         /* Require new-style declarations */
 bool sc_warnings_are_errors = false;
 int sc_compression_level = 9;
 bool sc_use_new_parser = false;
+int pc_max_func_memory = 0;          /* high stack watermark */
+int pc_current_memory = 0;           /* current stack watermark */
+int pc_max_memory = 0;               /* maximum stack watermark across all stacks */
 
 void* inpf = NULL;      /* file read from (source or include) */
 void* inpf_org = NULL;  /* main source file */

--- a/compiler/scvars.h
+++ b/compiler/scvars.h
@@ -86,6 +86,9 @@ extern bool sc_warnings_are_errors;
 extern unsigned sc_total_errors;
 extern int pc_code_version; /* override the code version */
 extern int sc_compression_level;
+extern int pc_max_func_memory;    /* high stack watermark */
+extern int pc_current_memory;     /* current stack watermark */
+extern int pc_max_memory;         /* maximum stack watermark across all stacks */
 
 extern void* inpf;      /* file read from (source or include) */
 extern void* inpf_org;  /* main source file */

--- a/tests/basic/huge-array-validates.sp
+++ b/tests/basic/huge-array-validates.sp
@@ -1,0 +1,4 @@
+public void main()
+{
+    int buf[8192];
+}


### PR DESCRIPTION
This eliminates a common use case for #pragma dynamic.

Bug: #501
Test: new runtime test