### PR TITLE
Refactor macro expansion to be recursive.

### DIFF
--- a/tests/compile-only/ok-macro-repeat-expansion.sp
+++ b/tests/compile-only/ok-macro-repeat-expansion.sp
@@ -1,0 +1,15 @@
+#define FOO 5
+#define BAR 7
+
+#define DUCK FOO + BAR
+#define QUACK FOO + FOO
+
+public int Apple()
+{
+	return DUCK;	//no error
+}
+
+public int Bread()
+{
+	return QUACK;	//error 017: undefined symbol "FOO"
+}


### PR DESCRIPTION
This small refactoring allows us to easily fix remaining expansion bugs
while retaining all of our previous fixes.

Bug: #597
Test: new compile-only test