### PR TITLE
Add another parsing phase.

### DIFF
--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -375,7 +375,7 @@ pc_compile(int argc, char* argv[]) {
         parser.parse();      /* process all input */
 
         sc_parsenum++;
-    } while (sc_reparse);
+    } while (sc_reparse || sc_parsenum == 1);
 
     /* second (or third) pass */
     sc_status = statWRITE; /* set, to enable warnings */


### PR DESCRIPTION
Obviously this is the exact opposite of where we're trying to go with
the parser, but unfortunately it's the only simple way to fix a large
class of bugs.

The first pass of the compiler is designed to collect declarations and
usage information. Any errors are thrown away. The second pass then uses
the first pass to do proper error checking.

In the old model of semantics-as-you-parse, this sort of worked because
the compiler tried very hard to analyze everything in the first pass,
even if the analysis was bogus. In the new parser, it doesn't work as
well, because the analysis early-aborts in the first pass. This can
leave critical things missing. For example, we might skip checking a
function call or user operator, because we don't have type info. The
function then gets omitted in the assembly when it shouldn't have.

To address this we simply re-run the first pass, which should guarantee
all the symbolic information has been entered, and thus can be analyzed
correctly.

Like many other idiosyncracies this will be removed when the new parser
is complete.