### PR TITLE
Fix FRM not being restored on error.

### DIFF
--- a/tests/basic/restore-frame.out
+++ b/tests/basic/restore-frame.out
@@ -1,0 +1,7 @@
+hello
+Exception thrown: What the crab?!
+  [0] report_error()
+  [1] restore-frame.sp::callback, line 6
+  [2] execute()
+  [3] restore-frame.sp::main, line 14
+10

--- a/tests/basic/restore-frame.sp
+++ b/tests/basic/restore-frame.sp
@@ -1,0 +1,15 @@
+#include <shell>
+
+void callback() {
+  print("hello\n");
+  report_error();
+  print("world\n");
+}
+
+public int main() {
+  int val = 10;
+
+  execute(callback, 1);
+
+  printnum(val);
+}

--- a/vm/plugin-context.cpp
+++ b/vm/plugin-context.cpp
@@ -441,6 +441,7 @@ PluginContext::Invoke(funcid_t fnid, const cell_t* params, unsigned int num_para
   /* Save our previous state. */
   cell_t save_sp = sp_;
   cell_t save_hp = hp_;
+  cell_t save_frm = frm_;
 
   /* Push parameters */
   sp_ -= sizeof(cell_t) * (num_params + 1);
@@ -475,6 +476,7 @@ PluginContext::Invoke(funcid_t fnid, const cell_t* params, unsigned int num_para
 
   sp_ = save_sp;
   hp_ = save_hp;
+  frm_ = save_frm;
   return ok;
 }
 


### PR DESCRIPTION
This has always been a bug, but its more susceptible to hit thanks to
the new exception handling code. It requires two plugin stacks with C++
in between. If the inner stack returns an error, FRM won't be restored,
because popAmxFrame was never called.

Bug: issue #607
Test: restore-frame.sp