### PR TITLE
Fix line numbers in stack traces in the interpreter.

### DIFF
--- a/tests/basic/restore-frame.out
+++ b/tests/basic/restore-frame.out
@@ -1,7 +1,7 @@
 hello
 Exception thrown: What the crab?!
   [0] report_error()
-  [1] restore-frame.sp::callback, line 6
+  [1] restore-frame.sp::callback, line 5
   [2] execute()
-  [3] restore-frame.sp::main, line 14
+  [3] restore-frame.sp::main, line 12
 10

--- a/vm/interpreter.cpp
+++ b/vm/interpreter.cpp
@@ -60,7 +60,7 @@ Interpreter::run()
 {
   assert(reader_.peekOpcode() == OP_PROC);
 
-  InterpInvokeFrame ivk(cx_, method_, reader_.cip());
+  InterpInvokeFrame ivk(cx_, method_, reader_.insn_begin());
   ke::SaveAndSet<InterpInvokeFrame*> enterIvk(&ivk_, &ivk);
 
   reader_.begin();

--- a/vm/pcode-reader.h
+++ b/vm/pcode-reader.h
@@ -42,6 +42,7 @@ class PcodeReader
     auto& code = rt->code();
     code_ = reinterpret_cast<const cell_t*>(code.bytes);
     cip_ = code_ + (startOffset / sizeof(cell_t));
+    insn_begin_ = cip_;
     stop_at_ = reinterpret_cast<const cell_t*>(code.bytes + code.length);
   }
   PcodeReader(PluginRuntime* rt, Block* block, T* visitor)
@@ -54,6 +55,7 @@ class PcodeReader
     auto& code = rt->code();
     code_ = reinterpret_cast<const cell_t*>(code.bytes);
     cip_ = reinterpret_cast<const cell_t*>(block->start());
+    insn_begin_ = cip_;
 
     const uint8_t* end = block->end();
     if (block->endType() == BlockEnd::Insn)
@@ -69,6 +71,7 @@ class PcodeReader
 
   // Read the next opcode, return true on success, false otherwise.
   bool visitNext() {
+    insn_begin_ = cip_;
     OPCODE op = (OPCODE)readCell();
     return visitOp(op);
   }
@@ -85,8 +88,13 @@ class PcodeReader
   }
 
   // Return the current position in the code stream.
-  const cell_t* const& cip() const {
+  const cell_t* cip() const {
     return cip_;
+  }
+
+  // Return the start of the current instruction.
+  const cell_t* const& insn_begin() const {
+    return insn_begin_;
   }
   cell_t cip_offset() const {
     return (cip_ - code_) * sizeof(cell_t);
@@ -671,6 +679,7 @@ class PcodeReader
   PluginRuntime* rt_;
   T* visitor_;
   const cell_t* code_;
+  const cell_t* insn_begin_;
   const cell_t* cip_;
   const cell_t* stop_at_;
 };


### PR DESCRIPTION
The interpreter should be using the "beginning of instruction" location,
not "end of instruction".