### PR TITLE
Fix a quintet of related bugs.

### DIFF
--- a/compiler/assembler.cpp
+++ b/compiler/assembler.cpp
@@ -1566,8 +1566,41 @@ assemble_to_buffer(SmxByteBuffer* buffer, memfile_t* fin)
 }
 
 static void
-splat_to_binary(const char* binfname, const void* bytes, size_t size)
+FailedValidation(const std::string& message)
 {
+    fprintf(stderr, "Binary validation failed: %s\n", message.c_str());
+    fprintf(stderr, "Internal compilation error detected. Please file a bug:\n");
+    fprintf(stderr, "https://github.com/alliedmodders/sourcepawn/issues/new\n");
+    exit(1);
+}
+
+static void
+VerifyBinary(const char* file, void* buffer, size_t size)
+{
+    std::unique_ptr<ISourcePawnEnvironment> env(ISourcePawnEnvironment::New());
+    if (!env)
+        FailedValidation("could not initialize environment");
+
+    auto api = env->APIv2();
+
+    char msgbuf[255];
+    std::unique_ptr<IPluginRuntime> rt(api->LoadBinaryFromMemory(file, (uint8_t*)buffer, size,
+                                                                 nullptr, msgbuf,  sizeof(msgbuf)));
+    if (!rt)
+        FailedValidation(msgbuf);
+
+    ExceptionHandler eh(api);
+    if (!rt->PerformFullValidation()) {
+        const char* message = eh.HasException() ? eh.Message() : "unknown error";
+        FailedValidation(message);
+    }
+}
+
+static void
+splat_to_binary(const char* binfname, void* bytes, size_t size)
+{
+    VerifyBinary(binfname, bytes, size);
+
     // Note: error 161 will setjmp(), which skips destructors :(
     FILE* fp = fopen(binfname, "wb");
     if (!fp) {
@@ -1580,29 +1613,6 @@ splat_to_binary(const char* binfname, const void* bytes, size_t size)
         return;
     }
     fclose(fp);
-}
-
-static bool
-VerifyBinary(const char* file, uint8_t* bytes, size_t size)
-{
-    std::unique_ptr<ISourcePawnEnvironment> env(ISourcePawnEnvironment::New());
-    auto api = env->APIv2();
-
-    char buffer[255];
-    std::unique_ptr<IPluginRuntime> rt(api->LoadBinaryFromMemory(file, bytes, size, nullptr,
-                                                                 buffer, sizeof(buffer)));
-    if (!rt) {
-        fprintf(stderr, "Binary validation failed: %s\n", buffer);
-        return false;
-    }
-
-    ExceptionHandler eh(api);
-    if (!rt->PerformFullValidation()) {
-        const char* message = eh.HasException() ? eh.Message() : "unknown error";
-        fprintf(stderr, "Binary validation failed: %s\n", message);
-        return false;
-    }
-    return true;
 }
 
 void
@@ -1642,12 +1652,6 @@ assemble(const char* binfname, memfile_t* fin)
 
     header->disksize = 0;
     header->compression = SmxConsts::FILE_COMPRESSION_NONE;
-
-    if (!VerifyBinary(binfname, buffer.bytes(), buffer.size())) {
-        fprintf(stderr, "Internal compilation error detected. Please file a bug:\n");
-        fprintf(stderr, "https://github.com/alliedmodders/sourcepawn/issues/new\n");
-        exit(1);
-    }
 
     splat_to_binary(binfname, buffer.bytes(), buffer.size());
 }

--- a/compiler/emitter.cpp
+++ b/compiler/emitter.cpp
@@ -858,7 +858,6 @@ modheap_i()
 void
 setheap_save(cell value)
 {
-    assert(value);
     stgwrite("\ttracker.push.c ");
     outval(value, TRUE);
     code_idx += opcodes(1) + opargs(1);

--- a/compiler/parse-node.h
+++ b/compiler/parse-node.h
@@ -601,6 +601,9 @@ class TernaryExpr final : public Expr
     void ProcessUses() override;
 
   private:
+    void EmitImpl(ke::Maybe<cell>* branch1, ke::Maybe<cell>* branch2);
+
+  private:
     Expr* first_;
     Expr* second_;
     Expr* third_;

--- a/tests/compile-only/ok-balanced-ternary-array.sp
+++ b/tests/compile-only/ok-balanced-ternary-array.sp
@@ -1,0 +1,10 @@
+public main() {
+    int a;
+    int array[3];
+    array = a ? {0, 0, 0} : rgb();
+}
+
+int[] rgb() {
+    int array[3];
+    return array;
+}

--- a/vm/control-flow.h
+++ b/vm/control-flow.h
@@ -144,6 +144,13 @@ class Block :
   // Zap all references so the block has no cycles.
   void unlink();
 
+  bool has_compiler_break_bug() const {
+    return has_compiler_break_bug_;
+  }
+  void set_has_compiler_break_bug() {
+    has_compiler_break_bug_ = true;
+  }
+
  private:
   ControlFlowGraph& graph_;
   std::vector<ke::RefPtr<Block>> predecessors_;
@@ -170,6 +177,7 @@ class Block :
 
   // Set to true if this is a loop header.
   bool is_loop_header_ = false;
+  bool has_compiler_break_bug_ = false;
 
   // Label, for the JIT.
   Label label_;

--- a/vm/control-flow.h
+++ b/vm/control-flow.h
@@ -169,7 +169,7 @@ class Block :
   uint32_t num_dominated_;
 
   // Set to true if this is a loop header.
-  bool is_loop_header_;
+  bool is_loop_header_ = false;
 
   // Label, for the JIT.
   Label label_;

--- a/vm/environment.cpp
+++ b/vm/environment.cpp
@@ -569,5 +569,5 @@ Environment::leaveInvoke()
 ISourcePawnEnvironment*
 ISourcePawnEnvironment::New()
 {
-  return new Environment();
+  return Environment::New();
 }

--- a/vm/method-verifier.h
+++ b/vm/method-verifier.h
@@ -64,12 +64,29 @@ class MethodVerifier final
     VerifyData()
      : stack_balance(0)
     {}
+    VerifyData(const VerifyData& other)
+     : stack_balance(other.stack_balance),
+       heap_balance(other.heap_balance),
+       tracker_balance(other.tracker_balance)
+    {}
+
+    VerifyData& operator =(const VerifyData& other) {
+      stack_balance = other.stack_balance;
+      heap_balance = other.heap_balance;
+      tracker_balance = other.tracker_balance;
+      return *this;
+    }
+
     uint32_t stack_balance;
     std::vector<int32_t> heap_balance;
+    std::vector<int32_t> tracker_balance;
+
+    std::unique_ptr<VerifyData> entry;
   };
 
   bool handleJoins();
-  bool verifyJoin(Block* block, VerifyData* a, VerifyData* b);
+  bool mergeTracker(Block* block, VerifyData* other);
+  bool verifyJoin(VerifyData* first, VerifyData* other);
   bool verifyJoins(Block* block);
   bool pushStack(uint32_t num_cells);
   bool popStack(uint32_t num_cells);

--- a/vm/plugin-runtime.cpp
+++ b/vm/plugin-runtime.cpp
@@ -652,7 +652,8 @@ PluginRuntime::PerformFullValidation()
     verifier.collectExternalFuncRefs(onExternFuncRef);
 
     if (!verifier.verify()) {
-      env->ReportErrorFmt(SP_ERROR_USER, "Method %s failed verification: %d\n", name, verifier.error());
+      env->ReportErrorFmt(SP_ERROR_USER, "Method %s failed verification: %s\n", name,
+                          env->GetErrorString(verifier.error()));
       return false;
     }
   }


### PR DESCRIPTION
I discovered that the verify-after-compilation change wasn't actually doing anything, and fixed that. This led to the discovery of a verification bug from an uninitialized variable, that lucky, was extremely rare to manifest.

This led to the discovery of another bug from a [single plugin](https://forums.alliedmods.net/showthread.php?p=2684071) involving ternary operators. Fixing this in the compiler led to verification failures, which led to the discovery of two more bugs. First, the verifier did not track heap allocations versus "heap tracker" state properly. Second, the verifier did not track entry vs exit state separately, which makes it impossible to properly verify backedges.

All of this has been fixed in this patch series. I tested by building the corpus with 1.9 and 1.10, and then making sure all .smx files could verify. Only two did not: the plugin linked above, and [this one](https://forums.alliedmods.net/showthread.php?p=1516348). Both verify after recompiling with 1.11, and both would have failed to run on 1.10.

I also tried to remove the very hacky "detect compiler break bug" verification workaround. This caused two additional verification failures on ancient binaries, [this one](https://forums.alliedmods.net/showthread.php?p=1704321) and [this one](https://forums.alliedmods.net/showthread.php?p=585758). Since at least one of those still seems to have active use on servers, I've retained the workaround for now.