### PR TITLE
Fix crash when function is missing an exit instruction.

### DIFF
--- a/vm/graph-builder.cpp
+++ b/vm/graph-builder.cpp
@@ -123,6 +123,11 @@ IsControlOpcode(OPCODE op)
 auto
 GraphBuilder::scanFlow() -> FlowState
 {
+  if (!more()) {
+    error(SP_ERROR_INVALID_INSTRUCTION);
+    return FlowState::Error;
+  }
+
   uint32_t cell_number = getCellNumber(cip_);
   assert(insn_bitmap_.test(cell_number));
 


### PR DESCRIPTION
This prevents GraphBuilder from scanning behind the end of the
instruction stream.