### PR TITLE
Remove NAMEMAX defines.

### DIFF
--- a/compiler/amx.h
+++ b/compiler/amx.h
@@ -177,13 +177,6 @@ typedef struct tagAMX_NATIVE_INFO {
 } AMX_NATIVE_INFO;
 
 #define AMX_USERNUM 4
-#define sEXPMAX 19  /* maximum name length for file version <= 6 */
-#define sNAMEMAX 63 /* maximum name length of symbol name */
-
-typedef struct tagAMX_FUNCSTUB {
-    ucell address;
-    char name[sEXPMAX + 1];
-} AMX_FUNCSTUB;
 
 typedef struct tagFUNCSTUBNT {
     ucell address;

--- a/compiler/array-helpers.cpp
+++ b/compiler/array-helpers.cpp
@@ -27,6 +27,7 @@
 #include "emitter.h"
 #include "errors.h"
 #include "lexer-inl.h"
+#include "symbols.h"
 #include "type-checker.h"
 
 class ArraySizeResolver

--- a/compiler/errors.h
+++ b/compiler/errors.h
@@ -115,6 +115,54 @@ void errorset(int code, int line);
 void clear_errors();
 void dump_error_report(bool clear);
 
+class MessageBuilder
+{
+  public:
+    explicit MessageBuilder(int number);
+    MessageBuilder(symbol* sym, int number);
+    MessageBuilder(MessageBuilder&& other);
+
+    MessageBuilder(const MessageBuilder& other) = delete;
+
+    MessageBuilder(const token_pos_t& where, int number)
+      : where_(where),
+        number_(number)
+    {}
+    ~MessageBuilder();
+
+    MessageBuilder& operator <<(const char* arg) {
+        args_.emplace_back(arg);
+        return *this;
+    }
+    MessageBuilder& operator <<(const std::string& arg) {
+        args_.emplace_back(arg);
+        return *this;
+    }
+    MessageBuilder& operator <<(sp::Atom* atom) {
+        args_.emplace_back(atom ? atom->chars() : "<unknown>");
+        return *this;
+    }
+
+    void operator =(const MessageBuilder& other) = delete;
+    MessageBuilder& operator =(MessageBuilder&& other);
+
+  private:
+    token_pos_t where_;
+    int number_;
+    std::vector<std::string> args_;
+    bool disabled_ = false;
+};
+
+static inline MessageBuilder report(const token_pos_t& where, int number) {
+    return MessageBuilder(where, number);
+}
+static inline MessageBuilder report(int number) {
+    return MessageBuilder(number);
+}
+static inline MessageBuilder report(symbol* sym, int number) {
+    return MessageBuilder(sym, number);
+}
+
 int pc_enablewarning(int number, int enable);
 
 extern bool sc_one_error_per_statement;

--- a/compiler/expressions.cpp
+++ b/compiler/expressions.cpp
@@ -88,7 +88,7 @@ find_userop(void (*oper)(), int tag1, int tag2, int numparam, const value* lval,
     static const char* unoperstr[] = {"!", "-", "++", "--"};
     static void (*unopers[])(void) = {lneg, neg, user_inc, user_dec};
 
-    char opername[4] = "", symbolname[sNAMEMAX + 1];
+    char opername[4] = "";
     size_t i;
     bool savepri, savealt;
     symbol* sym;
@@ -138,7 +138,7 @@ find_userop(void (*oper)(), int tag1, int tag2, int numparam, const value* lval,
 
     /* create a symbol name from the tags and the operator name */
     assert(numparam == 1 || numparam == 2);
-    operator_symname(symbolname, opername, tag1, tag2, numparam, tag2);
+    auto symbolname = operator_symname(opername, tag1, tag2, numparam, tag2);
     bool swapparams = false;
     sym = findglb(symbolname);
     if (!sym) {
@@ -149,7 +149,7 @@ find_userop(void (*oper)(), int tag1, int tag2, int numparam, const value* lval,
          * swap tags and try again
          */
         assert(numparam == 2); /* commutative operator must be a binary operator */
-        operator_symname(symbolname, opername, tag2, tag1, numparam, tag1);
+        symbolname = operator_symname(opername, tag2, tag1, numparam, tag1);
         swapparams = true;
         sym = findglb(symbolname);
         if (!sym)
@@ -160,9 +160,9 @@ find_userop(void (*oper)(), int tag1, int tag2, int numparam, const value* lval,
     if (sym->missing || !sym->prototyped) {
         auto symname = funcdisplayname(sym->name());
         if (sym->missing)
-            error(4, symname.c_str()); /* function not defined */
+            report(4) << symname; /* function not defined */
         if (!sym->prototyped)
-            error(71, symname.c_str()); /* operator must be declared before use */
+            report(71) << symname; /* operator must be declared before use */
     }
 
     /* we don't want to use the redefined operator in the function that
@@ -635,17 +635,6 @@ ExpressionParser::nextop(int* opidx, int* list)
         }
     }
     return FALSE; /* entire list scanned, nothing found */
-}
-
-int
-findnamedarg(arginfo* arg, const char* name)
-{
-    int i;
-
-    for (i = 0; arg[i].ident != 0 && arg[i].ident != iVARARGS; i++)
-        if (strcmp(arg[i].name, name) == 0)
-            return i;
-    return -1;
 }
 
 cell

--- a/compiler/expressions.h
+++ b/compiler/expressions.h
@@ -60,7 +60,6 @@ struct UserOperation;
 bool find_userop(void (*oper)(), int tag1, int tag2, int numparam, const value* lval, UserOperation* op);
 void emit_userop(const UserOperation& user_op, value* lval);
 
-int findnamedarg(arginfo* arg, const char* name);
 int commutative(void (*oper)());
 cell calc(cell left, void (*oper)(), cell right, char* boolresult);
 bool is_valid_index_tag(int tag);

--- a/compiler/lexer.h
+++ b/compiler/lexer.h
@@ -24,11 +24,6 @@
 
 #include "sc.h"
 
-// The method name buffer is larger since we can include our parent class's
-// name, a "." to separate it, a "~" for constructors, or a ".get/.set" for
-// accessors.
-#define METHOD_NAMEMAX sNAMEMAX * 2 + 6
-
 class Type;
 
 struct token_pos_t {
@@ -41,12 +36,12 @@ struct token_pos_t {
 struct token_t {
     int id;
     cell val;
-    char* str;
+    const char* str;
 };
 
 struct token_ident_t {
     token_t tok;
-    char name[METHOD_NAMEMAX + 1];
+    sp::Atom* name;
 };
 
 struct full_token_t {
@@ -269,14 +264,14 @@ int plungefile(char* name, int try_currentpath,
                int try_includepaths); /* search through "include" paths */
 void preprocess(bool allow_synthesized_tokens);
 void lexinit(void);
-int lex(cell* lexvalue, char** lexsym);
+int lex(cell* lexvalue, const char** lexsym);
 int lextok(token_t* tok);
 int lexpeek(int id);
 void lexpush(void);
 void lexclr(int clreol);
 const token_pos_t& current_pos();
 int matchtoken(int token);
-int tokeninfo(cell* val, char** str);
+int tokeninfo(cell* val, const char** str);
 full_token_t* current_token();
 int needtoken(int token);
 int matchtoken2(int id, token_t* tok);
@@ -289,7 +284,6 @@ void litadd_str(const char* str, size_t len, std::vector<cell>* out);
 int alphanum(char c);
 int ishex(char c);
 int isoctal(char c);
-symbol* find_enumstruct_field(Type* type, const char* name);
 void declare_methodmap_symbol(methodmap_t* map, bool can_redef);
 void declare_handle_intrinsics();
 int getlabel(void);

--- a/compiler/parse-node.h
+++ b/compiler/parse-node.h
@@ -1595,7 +1595,7 @@ class EnumStructDecl : public Decl
     PoolList<EnumStructField>& fields() { return fields_; }
 
   private:
-    sp::Atom* DecorateInnerName(const token_pos_t& pos, const char* name);
+    sp::Atom* DecorateInnerName(const token_pos_t& pos, sp::Atom* field_name);
 
   private:
     PoolList<FunctionDecl*> methods_;

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -81,7 +81,7 @@ struct arginfo { /* function argument info */
     void operator =(const arginfo& other) = delete;
     arginfo& operator =(arginfo&& other) = default;
 
-    char name[sNAMEMAX + 1];
+    sp::Atom* name;
     char ident = 0;
     bool is_const = false;
     int tag = 0;
@@ -94,7 +94,7 @@ struct arginfo { /* function argument info */
 /*  Equate table, tagname table, library table */
 struct constvalue {
     constvalue* next;
-    char name[sNAMEMAX + 1];
+    sp::Atom* name;
     cell value;
     int index; /* index level, for constants referring to array sizes/tags
                          * tag for enumeration lists */
@@ -398,7 +398,7 @@ struct svalue {
 
 /* For parsing declarations. */
 struct declinfo_t {
-    char name[sNAMEMAX + 1];
+    sp::Atom* name;
     typeinfo_t type;
     int opertok; // Operator token, if applicable.
 };
@@ -465,12 +465,9 @@ bool parse_new_typename(const token_t* tok, int* tagp);
 /* function prototypes in SC1.C */
 void set_extension(char* filename, const char* extension, int force);
 symbol* fetchfunc(const char* name);
-char* operator_symname(char* symname, const char* opername, int tag1, int tag2, int numtags,
-                       int resulttag);
 std::string funcdisplayname(const char* funcname);
 bool exprconst(cell* val, int* tag, symbol** symptr);
-constvalue* append_constval(constvalue* table, const char* name, cell val, int index);
-constvalue* find_constval(constvalue* table, char* name, int index);
+constvalue* append_constval(constvalue* table, sp::Atom* name, cell val, int index);
 void delete_consttable(constvalue* table);
 symbol* add_constant(const char* name, cell val, int vclass, int tag);
 

--- a/compiler/sctracker.h
+++ b/compiler/sctracker.h
@@ -17,7 +17,7 @@ struct funcenum_t {
        name()
     {}
     int tag;
-    char name[METHOD_NAMEMAX + 1];
+    sp::Atom* name;
     std::vector<functag_t*> entries;
 };
 
@@ -40,9 +40,9 @@ struct structarg_t {
 };
 
 struct pstruct_t {
-    explicit pstruct_t(const char* name);
+    explicit pstruct_t(sp::Atom* name);
 
-    char name[sNAMEMAX + 1];
+    sp::Atom* name;
     std::vector<std::unique_ptr<structarg_t>> args;
 };
 
@@ -67,7 +67,7 @@ struct methodmap_method_t {
        is_static(false)
     {}
 
-    char name[METHOD_NAMEMAX + 1];
+    sp::Atom* name;
     methodmap_t* parent;
     symbol* target;
     symbol* getter;
@@ -89,14 +89,14 @@ struct methodmap_method_t {
 };
 
 struct methodmap_t {
-    methodmap_t(methodmap_t* parent, LayoutSpec spec, const char* name);
+    methodmap_t(methodmap_t* parent, LayoutSpec spec, sp::Atom* name);
 
     methodmap_t* parent;
     int tag;
     bool nullable;
     bool keyword_nullable;
     LayoutSpec spec;
-    char name[sNAMEMAX + 1];
+    sp::Atom* name;
     std::vector<std::unique_ptr<methodmap_method_t>> methods;
 
     bool must_construct_with_new() const {
@@ -111,7 +111,7 @@ struct methodmap_t {
 /**
  * Pawn Structs
  */
-pstruct_t* pstructs_add(const char* name);
+pstruct_t* pstructs_add(sp::Atom* name);
 void pstructs_free();
 pstruct_t* pstructs_find(const char* name);
 structarg_t* pstructs_addarg(pstruct_t* pstruct, const structarg_t* arg);
@@ -121,7 +121,7 @@ const structarg_t* pstructs_getarg(const pstruct_t* pstruct, sp::Atom* name);
  * Function enumeration tags
  */
 void funcenums_free();
-funcenum_t* funcenums_add(const char* name);
+funcenum_t* funcenums_add(sp::Atom* name);
 void functags_add(funcenum_t* en, functag_t* src);
 funcenum_t* funcenum_for_symbol(symbol* sym);
 functag_t* functag_from_tag(int tag);
@@ -177,9 +177,9 @@ void resetheaplist();
 /**
  * Method maps.
  */
-methodmap_t* methodmap_add(methodmap_t* parent, LayoutSpec spec, const char* name);
-methodmap_t* methodmap_find_by_name(const char* name);
-methodmap_method_t* methodmap_find_method(methodmap_t* map, const char* name);
+methodmap_t* methodmap_add(methodmap_t* parent, LayoutSpec spec, sp::Atom* name);
+methodmap_t* methodmap_find_by_name(sp::Atom* name);
+methodmap_method_t* methodmap_find_method(methodmap_t* map, sp::Atom* name);
 void methodmaps_free();
 
 #endif //_INCLUDE_SOURCEPAWN_COMPILER_TRACKER_H_

--- a/compiler/scvars.cpp
+++ b/compiler/scvars.cpp
@@ -38,8 +38,8 @@ symbol loctab;                             /* local symbol table */
 symbol glbtab;                             /* global symbol table */
 unsigned char pline[sLINEMAX + 1];         /* the line read from the input file */
 const unsigned char* lptr;                 /* points to the current position in "pline" */
-constvalue tagname_tab = {NULL, "", 0, 0}; /* tagname table */
-constvalue libname_tab = {NULL, "", 0, 0}; /* library table (#pragma library "..." syntax) */
+constvalue tagname_tab = {nullptr, nullptr, 0, 0}; /* tagname table */
+constvalue libname_tab = {nullptr, nullptr, 0, 0}; /* library table (#pragma library "..." syntax) */
 constvalue* curlibrary = NULL;             /* current library */
 int pc_addlibtable = TRUE;                 /* is the library table added to the AMX file? */
 symbol* curfunc;                           /* pointer to current function */

--- a/compiler/semantics.h
+++ b/compiler/semantics.h
@@ -97,6 +97,6 @@ void ReportFunctionReturnError(symbol* sym);
 bool TestSymbols(symbol* root, int testconst);
 void check_void_decl(const typeinfo_t* type, int variable);
 void check_void_decl(const declinfo_t* decl, int variable);
-int check_operatortag(int opertok, int resulttag, char* opername);
+int check_operatortag(int opertok, int resulttag, const char* opername);
 int argcompare(arginfo* a1, arginfo* a2);
 void fill_arg_defvalue(VarDecl* decl, arginfo* arg);

--- a/compiler/symbols.h
+++ b/compiler/symbols.h
@@ -47,3 +47,7 @@ void markusage(symbol* sym, int usage);
 symbol* addsym(const char* name, cell addr, int ident, int vclass, int tag);
 symbol* addvariable(const char* name, cell addr, int ident, int vclass, int tag, int dim[],
                     int numdim, int idxtag[]);
+int findnamedarg(arginfo* arg, sp::Atom* name);
+symbol* find_enumstruct_field(Type* type, sp::Atom* name);
+sp::Atom* operator_symname(const char* opername, int tag1, int tag2, int numtags,
+                           int resulttag);

--- a/compiler/types.cpp
+++ b/compiler/types.cpp
@@ -300,7 +300,7 @@ pc_addtag(const char* name)
 
     if (name == NULL) {
         /* no tagname was given, check for one */
-        char* nameptr;
+        const char* nameptr;
         if (lex(&val, &nameptr) != tLABEL) {
             lexpush();
             return 0; /* untagged */

--- a/tests/compile-only/fail-method-name-too-long.sp
+++ b/tests/compile-only/fail-method-name-too-long.sp
@@ -1,7 +1,0 @@
-methodmap ThisNameIsReallyLongWowItsVeryLong {
-	public ThisNameIsReallyLongWowItsVeryLong() {
-	}
-}
-
-public main() {
-}

--- a/tests/compile-only/fail-method-name-too-long.txt
+++ b/tests/compile-only/fail-method-name-too-long.txt
@@ -1,1 +1,0 @@
-fully-qualified name "ThisNameIsReallyLongWowItsVeryLong.ThisNameIsReallyLongWowItsVeryLong" is too long, would be truncated to "ThisNameIsReallyLongWowItsVeryLong.ThisNameIsReallyLongWowItsVe"


### PR DESCRIPTION
This is vestigial gunk from when spcomp was C. There is no reason to
have hardcoded identifier lengths anywhere, and no reason to use C-style
string buffers.

This change ports almost all name info to sp::Atom. Atom is a wrapper
around std::string, except only one Atom is ever allocated for a given
string. We aggressively Atom-ize symbols during lexing, since any symbol
will wind up needing an atom anyway. This allows for cheap comparisons
during name lookup, since we can test with pointer identity.

This change also adds a new C++ (eg, non-printf/va_list) based reporting
mechanism. The intent here is to address the fact that error() is unsafe
because the C++ compiler can't check printf-formatting when the format
string is not constant. The new mechanism is backward compatible with
existing messages, but supports std::string and sp::Atom. In the future
it will support Type as well, allowing us to get rid of the ten
different ways of formatting types.