### PR TITLE
Assorted cleanup, enum changes.

### DIFF
--- a/compiler/expressions.cpp
+++ b/compiler/expressions.cpp
@@ -677,30 +677,6 @@ calc(cell left, void (*oper)(), cell right, char* boolresult)
     return 0;
 }
 
-int
-expression(cell* val, int* tag, symbol** symptr, value* _lval)
-{
-    value lval = {0};
-    pushheaplist();
-
-    Parser parser;
-    int lvalue = parser.expression(&lval);
-    if (lvalue)
-        rvalue(&lval);
-    /* scrap any arrays left on the heap */
-    popheaplist(true);
-
-    if (lval.ident == iCONSTEXPR && val != NULL) /* constant expression */
-        *val = lval.constval;
-    if (tag != NULL)
-        *tag = lval.tag;
-    if (symptr != NULL)
-        *symptr = lval.sym;
-    if (_lval)
-        *_lval = lval;
-    return lval.ident;
-}
-
 bool
 is_valid_index_tag(int tag)
 {
@@ -747,35 +723,4 @@ commutative(void (*oper)())
 {
     return oper == ob_add || oper == os_mult || oper == ob_eq || oper == ob_ne || oper == ob_and ||
            oper == ob_xor || oper == ob_or;
-}
-
-/*  exprconst
- */
-bool
-exprconst(cell* val, int* tag, symbol** symptr)
-{
-    int ident;
-    AutoCountErrors errors;
-
-    bool failed;
-    {
-        AutoStage stage;
-        errorset(sEXPRMARK, 0);
-        ident = expression(val, tag, symptr, nullptr);
-        failed = (sc_status == statWRITE && !errors.ok());
-        stage.Rewind();
-    }
-
-    if (ident != iCONSTEXPR) {
-        if (!failed) // Don't pile on errors.
-            error(8); /* must be constant expression */
-        if (val != NULL)
-            *val = 0;
-        if (tag != NULL)
-            *tag = 0;
-        if (symptr != NULL)
-            *symptr = NULL;
-    }
-    errorset(sEXPRRELEASE, 0);
-    return !failed && (ident == iCONSTEXPR);
 }

--- a/compiler/expressions.h
+++ b/compiler/expressions.h
@@ -67,13 +67,11 @@ int check_userop(void (*oper)(void), int tag1, int tag2, int numparam, value* lv
                  int fnumber);
 int matchtag(int formaltag, int actualtag, int flags);
 int matchtag_commutative(int formaltag, int actualtag, int flags);
-int expression(cell* val, int* tag, symbol** symptr, value* _lval);
 int matchtag_string(int ident, int tag);
 int checkval_string(const value* sym1, const value* sym2);
 int checktag_string(int tag, const value* sym1);
 void user_inc();
 void user_dec();
 int checktag(int tag, int exprtag);
-bool exprconst(cell* val, int* tag, symbol** symptr);
 
 #endif // am_sourcepawn_compiler_sc3_h

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -2918,7 +2918,7 @@ declare_methodmap_symbol(CompileContext& cc, methodmap_t* map, bool can_redef)
         AddGlobal(cc, sym);
     }
     sym->defined = true;
-    sym->methodmap = map;
+    sym->set_data(map);
 }
 
 void

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -751,7 +751,7 @@ preproc_expr(cell* val, int* tag)
     term = strchr((char*)pline, '\0');
     assert(term != NULL);
     chrcat((char*)pline, PREPROC_TERM); /* the "DEL" code (see SC.H) */
-    result = exprconst(val, tag, NULL); /* get value (or 0 on error) */
+    result = Parser::PreprocExpr(val, tag); /* get value (or 0 on error) */
     *term = '\0';                       /* erase the token (if still present) */
     lexclr(FALSE);                      /* clear any "pushed" tokens */
     return result;

--- a/compiler/messages.h
+++ b/compiler/messages.h
@@ -302,4 +302,5 @@ static const char* errmsg_ex[] = {
     /*401*/ "cannot specify '...' arguments more than once\n",
     /*402*/ "cannot specify additional arguments after '...'\n",
     /*403*/ "not yet implemented\n",
+    /*404*/ "enum multiplers are no longer supported\n",
 };

--- a/compiler/parse-node.h
+++ b/compiler/parse-node.h
@@ -211,18 +211,19 @@ class LoopControlStmt : public Stmt
 class StaticAssertStmt : public Stmt
 {
   public:
-    explicit StaticAssertStmt(const token_pos_t& pos, int val, PoolString* text)
+    explicit StaticAssertStmt(const token_pos_t& pos, Expr* expr, PoolString* text)
       : Stmt(pos),
-        val_(val),
+        expr_(expr),
         text_(text)
     {}
 
+    bool Bind(SemaContext& sc) override;
     bool Analyze(SemaContext& sc) override;
     void DoEmit(CodegenContext&) override {}
     void ProcessUses(SemaContext& sc) override {}
 
   private:
-    int val_;
+    Expr* expr_;
     PoolString* text_;
 };
 
@@ -314,18 +315,16 @@ class ConstDecl : public VarDecl
 {
   public:
     ConstDecl(const token_pos_t& pos, sp::Atom* name, const typeinfo_t& type, int vclass,
-              int tag, int value)
+              Expr* expr)
       : VarDecl(pos, name, type, vclass, false, false, false, nullptr),
-        expr_tag_(tag),
-        value_(value)
+        expr_(expr)
     {}
 
     bool Bind(SemaContext& sc) override;
     bool Analyze(SemaContext& sc) override;
 
   private:
-    int expr_tag_;
-    int value_;
+    Expr* expr_;
 };
 
 struct EnumField {

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -299,13 +299,19 @@ Parser::parse_enum(int vclass)
     if (matchtoken('(')) {
         error(228);
         if (matchtoken(taADD)) {
-            exprconst(&increment, NULL, NULL);
+            if (needtoken(tNUMBER)) {
+                if (current_token()->value != 1)
+                    report(404);
+            }
         } else if (matchtoken(taMULT)) {
-            exprconst(&multiplier, NULL, NULL);
+            if (needtoken(tNUMBER))
+                report(404);
         } else if (matchtoken(taSHL)) {
-            exprconst(&val, NULL, NULL);
-            while (val-- > 0)
-                multiplier *= 2;
+            if (needtoken(tNUMBER)) {
+                if (current_token()->value != 1)
+                    report(404);
+                multiplier = 2;
+            }
         }
         needtoken(')');
     }

--- a/compiler/parser.h
+++ b/compiler/parser.h
@@ -32,14 +32,34 @@ class Parser : public ExpressionParser
     Parser();
     ~Parser();
 
-    int expression(value* lval);
+    static bool PreprocExpr(cell* val, int* tag);
 
     void parse();
 
-    // Temporary until parser.cpp no longer is shimmed.
+    static bool sInPreprocessor;
+    static bool sDetectedIllegalPreprocessorSymbols;
+    static int sActive;
+
+  private:
+    typedef int (Parser::*HierFn)(value*);
+    typedef Expr* (Parser::*NewHierFn)();
+
+    static symbol* ParseInlineFunction(int tokid, const declinfo_t& decl, const int* this_tag);
+
+    Stmt* parse_unknown_decl(const token_t* tok);
     Decl* parse_enum(int vclass);
     Stmt* parse_const(int vclass);
     Stmt* parse_stmt(int* lastindent, bool allow_decl);
+    Stmt* parse_static_assert();
+    Decl* parse_pstruct();
+    Decl* parse_typedef();
+    Decl* parse_typeset();
+    Decl* parse_using();
+    Decl* parse_enumstruct();
+    Decl* parse_methodmap();
+    bool parse_methodmap_method(MethodmapDecl* map);
+    bool parse_methodmap_property(MethodmapDecl* map);
+    bool parse_methodmap_property_accessor(MethodmapDecl* map, MethodmapProperty* prop);
 
     struct VarParams {
         int vclass;
@@ -52,28 +72,6 @@ class Parser : public ExpressionParser
     Stmt* parse_var(declinfo_t* decl, const VarParams& params);
     void parse_post_dims(typeinfo_t* type);
     Expr* var_init(int vclass);
-
-    static symbol* ParseInlineFunction(int tokid, const declinfo_t& decl, const int* this_tag);
-
-    static bool sInPreprocessor;
-    static bool sDetectedIllegalPreprocessorSymbols;
-    static int sActive;
-
-  private:
-    typedef int (Parser::*HierFn)(value*);
-    typedef Expr* (Parser::*NewHierFn)();
-
-    Stmt* parse_unknown_decl(const token_t* tok);
-    Stmt* parse_static_assert();
-    Decl* parse_pstruct();
-    Decl* parse_typedef();
-    Decl* parse_typeset();
-    Decl* parse_using();
-    Decl* parse_enumstruct();
-    Decl* parse_methodmap();
-    bool parse_methodmap_method(MethodmapDecl* map);
-    bool parse_methodmap_property(MethodmapDecl* map);
-    bool parse_methodmap_property_accessor(MethodmapDecl* map, MethodmapProperty* prop);
 
     bool parse_decl(declinfo_t* decl, int flags);
     bool parse_old_decl(declinfo_t* decl, int flags);

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -185,12 +185,12 @@ struct symbol : public PoolObject
     int tag;       /* tagname id */
 
     // See uREAD/uWRITTEN above.
-    uint8_t usage;
+    uint8_t usage : 2;
 
     // Variable: the variable is defined in the source file.
     // Function: the function is defined ("implemented") in the source file
     // Constant: the symbol is defined in the source file.
-    bool defined    ;       // remove when moving to a single-pass system
+    bool defined : 1;       // remove when moving to a single-pass system
     bool is_const : 1;
 
     // Variables and functions.
@@ -203,7 +203,7 @@ struct symbol : public PoolObject
 
     // Functions only.
     bool prototyped : 1;    // prototyped, implicitly via a definition or explicitly
-    bool missing  ;       // the function is not implemented in this source file
+    bool missing : 1;       // the function is not implemented in this source file
     bool callback : 1;      // used as a callback
     bool skipped : 1;       // skipped in codegen
     bool retvalue : 1;      // function returns (or should return) a value

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -132,6 +132,9 @@ class SymbolData : public PoolObject
     virtual EnumStructVarData* asEnumStructVar() {
         return nullptr;
     }
+    virtual methodmap_t* asMethodmap() {
+        return nullptr;
+    }
 };
 
 class FunctionData final : public SymbolData
@@ -237,7 +240,6 @@ struct symbol : public PoolObject
     int fnumber; /* file number in which the symbol is declared */
     int lnumber; /* line number for the declaration */
     PoolString* documentation; /* optional documentation string */
-    methodmap_t* methodmap;    /* if ident == iMETHODMAP */
 
     int addr() const {
         return addr_;

--- a/compiler/sctracker.cpp
+++ b/compiler/sctracker.cpp
@@ -59,7 +59,7 @@ std::vector<MemoryScope> sStackScopes;
 std::vector<MemoryScope> sHeapScopes;
 std::vector<std::unique_ptr<funcenum_t>> sFuncEnums;
 std::vector<std::unique_ptr<pstruct_t>> sStructs;
-std::vector<std::unique_ptr<methodmap_t>> sMethodmaps;
+std::vector<methodmap_t*> sMethodmaps;
 
 pstruct_t::pstruct_t(sp::Atom* name)
 {
@@ -394,7 +394,7 @@ methodmap_t::methodmap_t(methodmap_t* parent, LayoutSpec spec, sp::Atom* name)
 methodmap_t*
 methodmap_add(methodmap_t* parent, LayoutSpec spec, sp::Atom* name)
 {
-    auto map = std::make_unique<methodmap_t>(parent, spec, name);
+    auto map = new methodmap_t(parent, spec, name);
 
     if (spec == Layout_MethodMap && parent) {
         if (parent->nullable)
@@ -404,12 +404,12 @@ methodmap_add(methodmap_t* parent, LayoutSpec spec, sp::Atom* name)
     }
 
     if (spec == Layout_MethodMap)
-        map->tag = gTypes.defineMethodmap(name->chars(), map.get())->tagid();
+        map->tag = gTypes.defineMethodmap(name->chars(), map)->tagid();
     else
         map->tag = gTypes.defineObject(name->chars())->tagid();
     sMethodmaps.push_back(std::move(map));
 
-    return sMethodmaps.back().get();
+    return sMethodmaps.back();
 }
 
 methodmap_t*

--- a/compiler/sctracker.h
+++ b/compiler/sctracker.h
@@ -84,8 +84,10 @@ struct methodmap_method_t {
     }
 };
 
-struct methodmap_t {
+struct methodmap_t : public SymbolData {
     methodmap_t(methodmap_t* parent, LayoutSpec spec, sp::Atom* name);
+
+    methodmap_t* asMethodmap() override { return this; }
 
     methodmap_t* parent;
     int tag;

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -249,9 +249,6 @@ VarDecl::AnalyzePstructArg(const pstruct_t* ps, const StructInitField& field,
 bool
 ConstDecl::Analyze(SemaContext& sc)
 {
-    AutoErrorPos aep(pos_);
-
-    matchtag(type_.tag, expr_tag_, 0);
     return true;
 }
 
@@ -2185,7 +2182,18 @@ CallExpr::MarkUsed(SemaContext& sc)
 
 bool StaticAssertStmt::Analyze(SemaContext& sc)
 {
-    if (val_)
+    if (!expr_->Analyze(sc))
+        return false;
+
+    // :TODO: insert coercion to bool.
+    int tag;
+    cell value;
+    if (!expr_->EvalConst(&value, &tag)) {
+        report(pos_, 8);
+        return false;
+    }
+
+    if (value)
         return true;
 
     std::string message;
@@ -2193,7 +2201,6 @@ bool StaticAssertStmt::Analyze(SemaContext& sc)
         message += ": " + std::string(text_->chars(), text_->length());
 
     report(pos_, 70) << message;
-
     return false;
 }
 

--- a/compiler/symbols.cpp
+++ b/compiler/symbols.cpp
@@ -207,7 +207,7 @@ ShouldDeleteSymbol(symbol* sym, bool delete_functions)
         case iMETHODMAP:
             // We delete methodmap symbols at the end, but since methodmaps
             // themselves get wiped, we null the pointer.
-            sym->methodmap = nullptr;
+            sym->set_data(nullptr);
             mustdelete = delete_functions;
             assert(!sym->parent());
             break;
@@ -313,7 +313,6 @@ symbol::symbol(sp::Atom* symname, cell symaddr, int symident, int symvclass, int
    /* assume global visibility (ignored for local symbols) */
    lnumber(fline),
    documentation(nullptr),
-   methodmap(nullptr),
    addr_(symaddr),
    name_(nullptr),
    referred_from_count_(0),


### PR DESCRIPTION
These are some small cleanups, most importantly we've chosen a middle ground on enum feature removal. The +=1 and <<=1 cases have been pattern-matched (with a warning). Other values or operators will no longer work.