### PR TITLE
Allow pstruct args to be specified twice.

### DIFF
--- a/compiler/messages.h
+++ b/compiler/messages.h
@@ -289,4 +289,5 @@ static const char* warnmsg[] = {
     /*238*/ "'%s:' is an illegal cast; use view_as<%s>(expression)\n",
     /*239*/ "'%s' is an illegal tag; use %s as a type\n",
     /*240*/ "'%s:' is an old-style tag operation; use view_as<%s>(expression) instead\n",
+    /*241*/ "field '%s' was specified twice\n",
 };

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -120,10 +120,8 @@ VarDecl::AnalyzePstructArg(const pstruct_t* ps, const StructInitField& field,
         return false;
     }
 
-    if (visited->at(arg->index)) {
-        error(field.value->pos(), 58);
-        return false;
-    }
+    if (visited->at(arg->index))
+        error(field.value->pos(), 241, field.name->chars());
 
     visited->at(arg->index) = true;
 

--- a/tests/compile-only/fail-warn-dup-pstruct-arg.sp
+++ b/tests/compile-only/fail-warn-dup-pstruct-arg.sp
@@ -1,0 +1,14 @@
+// warnings_are_errors: true
+
+struct PlVers {
+	public int version;
+};
+
+public PlVers info = {
+	version = 5,
+	version = 6,
+};
+
+public main()
+{
+}

--- a/tests/compile-only/fail-warn-dup-pstruct-arg.txt
+++ b/tests/compile-only/fail-warn-dup-pstruct-arg.txt
@@ -1,0 +1,1 @@
+(9) : error 241: field 'version' was specified twice


### PR DESCRIPTION
This now emits a warning instead of an error.

Test: fail-warn-dup-pstruct-arg.sp