### PR TITLE
Deprecate #file.

### DIFF
--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -950,16 +950,10 @@ command(void)
                 doinclude(tok == tpTRYINCLUDE);
             break;
         case tpFILE:
+            error(242);
             if (!SKIPPING) {
                 char pathname[_MAX_PATH];
                 lptr = getstring((unsigned char*)pathname, sizeof pathname, lptr);
-                if (strlen(pathname) > 0) {
-                    free(inpfname);
-                    inpfname = strdup(pathname);
-                    if (inpfname == NULL)
-                        error(FATAL_ERROR_OOM);
-                    fline = 0;
-                }
             }
             check_empty(lptr);
             break;

--- a/compiler/messages.h
+++ b/compiler/messages.h
@@ -290,4 +290,5 @@ static const char* warnmsg[] = {
     /*239*/ "'%s' is an illegal tag; use %s as a type\n",
     /*240*/ "'%s:' is an old-style tag operation; use view_as<%s>(expression) instead\n",
     /*241*/ "field '%s' was specified twice\n",
+    /*242*/ "#file has no effect\n",
 };

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -300,9 +300,6 @@ pc_compile(int argc, char* argv[]) {
                 strcpy(inpfname, sname); /* avoid invalid filename */
                 error(FATAL_ERROR_READ, sname);
             }
-            pc_writesrc(ftmp, (unsigned char*)"#file \"");
-            pc_writesrc(ftmp, (unsigned char*)sname);
-            pc_writesrc(ftmp, (unsigned char*)"\"\n");
             skip_utf8_bom(fsrc);
             while (!pc_eofsrc(fsrc) && pc_readsrc(fsrc, tstring, sizeof tstring)) {
                 pc_writesrc(ftmp, tstring);


### PR DESCRIPTION
This was never intended for public use. In the 1.11 parser it's too
difficult to separate from internal uses, and it causes assertion
failures.