### PR TITLE
Ensure function signatures are checked when performing casts.

### DIFF
--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -984,6 +984,8 @@ CastExpr::Analyze()
     } else if (ltype->isFunction() != atype->isFunction()) {
         // Warn: unsupported cast.
         error(pos_, 237);
+    } else if (ltype->isFunction() && atype->isFunction()) {
+        matchtag(tag_, val_.tag, MATCHTAG_COERCE);
     } else if (val_.sym && val_.sym->tag == pc_tag_void) {
         error(pos_, 89);
     } else if (atype->isEnumStruct()) {


### PR DESCRIPTION
This makes it invalid to view_as to a different signature type. In
fact, view_as should *never* be used on functions. This is the first
step in battening down the hatches.