### PR TITLE
Fix erroneous string assignment check.

### DIFF
--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -673,12 +673,18 @@ BinaryExpr::ValidateAssignmentRHS()
         find_userop(nullptr, left_val.tag, right_val.tag, 2, &left_val, &assignop_);
     }
 
-    if (!oper_ && !checkval_string(&left_val, &right_val)) {
-        if ((left_val.tag == pc_tag_string && right_val.tag != pc_tag_string) ||
-            (left_val.tag != pc_tag_string && right_val.tag == pc_tag_string))
-        {
-            error(pos_, 179, type_to_name(left_val.tag), type_to_name(right_val.tag));
-            return false;
+    if (!oper_) {
+        if (left_val.ident == iARRAYCHAR || left_val.ident == iARRAYCELL) {
+            matchtag(left_val.tag, right_val.tag, MATCHTAG_COERCE);
+            return true;
+        }
+        if (!checkval_string(&left_val, &right_val)) {
+            if ((left_val.tag == pc_tag_string && right_val.tag != pc_tag_string) ||
+                (left_val.tag != pc_tag_string && right_val.tag == pc_tag_string))
+            {
+                error(pos_, 179, type_to_name(left_val.tag), type_to_name(right_val.tag));
+                return false;
+            }
         }
         matchtag(left_val.tag, right_val.tag, TRUE);
     }

--- a/tests/compile-only/ok-assign-int-to-arraychar.sp
+++ b/tests/compile-only/ok-assign-int-to-arraychar.sp
@@ -1,0 +1,13 @@
+
+stock ProduceLittleEndian(any value, char[] output) {
+	output[0] = ((value << 24) >> 24) & 0x000000FF;
+	output[1] = ((value << 16) >> 24) & 0x000000FF;
+	output[2] = ((value << 8) >> 24) & 0x000000FF;
+	output[3] = (value >> 24) & 0x000000FF;
+}
+
+public main()
+{
+	char blah[4];
+	ProduceLittleEndian(5, blah);
+}


### PR DESCRIPTION
Allow assigning an integer to an iARRAYCHAR.

Test: ok-assign-int-to-arraychar.sp