### PR TITLE
Restrict when enum names can be used as a size value.

### DIFF
--- a/compiler/new-parser.cpp
+++ b/compiler/new-parser.cpp
@@ -41,6 +41,7 @@ using namespace sp;
 
 bool Parser::sInPreprocessor = false;
 bool Parser::sDetectedIllegalPreprocessorSymbols = false;
+bool Parser::sAllowEnumNameBinding = false;
 
 void
 Parser::parse()

--- a/compiler/new-parser.h
+++ b/compiler/new-parser.h
@@ -40,6 +40,7 @@ class Parser : public ExpressionParser
 
     static bool sInPreprocessor;
     static bool sDetectedIllegalPreprocessorSymbols;
+    static bool sAllowEnumNameBinding;
 
   private:
     typedef int (Parser::*HierFn)(value*);

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -2063,7 +2063,10 @@ needsub()
     int tag;
     cell val;
     symbol* sym;
+
+    ke::SaveAndSet<bool> allow_enums(&Parser::sAllowEnumNameBinding, true);
     exprconst(&val, &tag, &sym); /* get value (must be constant expression) */
+
     if (!is_valid_index_tag(tag)) {
         error(77, gTypes.find(tag)->prettyName());
         val = 1;
@@ -2265,6 +2268,8 @@ parse_old_array_dims(declinfo_t* decl, int flags) {
             int tag;
             value val;
             symbol* sym;
+
+            ke::SaveAndSet<bool> allow_enums(&Parser::sAllowEnumNameBinding, true);
             int ident = doexpr2(TRUE, FALSE, FALSE, FALSE, &tag, &sym, &val);
 
             if (!is_valid_index_tag(tag))

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -25,6 +25,7 @@
 #include "errors.h"
 #include "expressions.h"
 #include "lexer.h"
+#include "new-parser.h"
 #include "parse-node.h"
 #include "sctracker.h"
 #include "scvars.h"
@@ -1042,10 +1043,13 @@ SymbolExpr::AnalyzeWithOptions(bool allow_types)
     val_.sym = sym_;
 
     // Don't expose the tag of old enumroots.
-    if (sym_->enumroot && !gTypes.find(sym_->tag)->asEnumStruct())
+    if (sym_->enumroot && !gTypes.find(sym_->tag)->asEnumStruct() && !sym_->methodmap) {
         val_.tag = 0;
-    else
+        if (!Parser::sAllowEnumNameBinding)
+            error(pos_, 174, sym_->name());
+    } else {
         val_.tag = sym_->tag;
+    }
 
     if (sym_->ident == iCONSTEXPR) {
         // Hack: __LINE__ is updated by the lexer, so we have to special case


### PR DESCRIPTION
Although we now allow enum names as sizes again, this feature is getting
restricted to only work on array declarations. In any other context it
will error.

This does break a handful of plugins, and those plugins are often doing
something erroneous (like "return Action"). That is the intent behind
this change: it's very difficult to distinguish between valid uses and
typos. Other uses appearing valid actually have off-by-one errors.