### PR TITLE
Simplify the lexer API.

### DIFF
--- a/compiler/lexer.h
+++ b/compiler/lexer.h
@@ -28,28 +28,16 @@ class CompileContext;
 class Type;
 
 struct token_pos_t {
-    int file;
-    int line;
-    int col;
-};
-
-// Helper for token info.
-struct token_t {
-    int id;
-    cell val;
-    const char* str;
-};
-
-struct token_ident_t {
-    token_t tok;
-    sp::Atom* name;
+    int file = 0;
+    int line = 0;
+    int col = 0;
 };
 
 struct full_token_t {
-    int id;
-    int value;
-    char str[sLINEMAX + 1];
-    size_t len;
+    int id = 0;
+    int value = 0;
+    std::string data;
+    sp::Atom* atom = nullptr;
     token_pos_t start;
     token_pos_t end;
 };
@@ -264,20 +252,16 @@ int plungefile(const char* name, int try_currentpath,
                int try_includepaths); /* search through "include" paths */
 void preprocess(bool allow_synthesized_tokens);
 void lexinit(void);
-int lex(cell* lexvalue, const char** lexsym);
-int lextok(token_t* tok);
+int lex();
 int lexpeek(int id);
 void lexpush(void);
 void lexclr(int clreol);
 const token_pos_t& current_pos();
 int matchtoken(int token);
-int tokeninfo(cell* val, const char** str);
 full_token_t* current_token();
 int needtoken(int token);
-int matchtoken2(int id, token_t* tok);
-int expecttoken(int id, token_t* tok);
-int matchsymbol(token_ident_t* ident);
-int needsymbol(token_ident_t* ident);
+int matchsymbol(sp::Atom** name);
+int needsymbol(sp::Atom** name);
 int peek_same_line();
 int lex_same_line();
 void litadd_str(const char* str, size_t len, std::vector<cell>* out);
@@ -291,6 +275,12 @@ std::string get_token_string(int tok_id);
 int is_variadic(symbol* sym);
 int alpha(char c);
 bool NeedSemicolon();
+
+static inline full_token_t lex_tok()
+{
+    lex();
+    return *current_token();
+}
 
 enum class TerminatorPolicy {
     Newline,

--- a/compiler/parser.h
+++ b/compiler/parser.h
@@ -46,7 +46,7 @@ class Parser : public ExpressionParser
 
     static symbol* ParseInlineFunction(int tokid, const declinfo_t& decl, const int* this_tag);
 
-    Stmt* parse_unknown_decl(const token_t* tok);
+    Stmt* parse_unknown_decl(const full_token_t* tok);
     Decl* parse_enum(int vclass);
     Stmt* parse_const(int vclass);
     Stmt* parse_stmt(int* lastindent, bool allow_decl);
@@ -77,10 +77,10 @@ class Parser : public ExpressionParser
 
     bool parse_decl(declinfo_t* decl, int flags);
     bool parse_old_decl(declinfo_t* decl, int flags);
-    bool parse_new_decl(declinfo_t* decl, const token_t* first, int flags);
+    bool parse_new_decl(declinfo_t* decl, const full_token_t* first, int flags);
     void parse_post_array_dims(declinfo_t* decl, int flags);
-    bool parse_new_typeexpr(typeinfo_t* type, const token_t* first, int flags);
-    bool parse_new_typename(const token_t* tok, TypenameInfo* out);
+    bool parse_new_typeexpr(typeinfo_t* type, const full_token_t* first, int flags);
+    bool parse_new_typename(const full_token_t* tok, TypenameInfo* out);
     bool reparse_old_decl(declinfo_t* decl, int flags);
     bool reparse_new_decl(declinfo_t* decl, int flags);
     void fix_mispredicted_postdims(declinfo_t* decl);

--- a/compiler/types.cpp
+++ b/compiler/types.cpp
@@ -297,16 +297,13 @@ pc_tagname(int tag)
 int
 pc_addtag(const char* name)
 {
-    int val;
-
     if (name == NULL) {
         /* no tagname was given, check for one */
-        const char* nameptr;
-        if (lex(&val, &nameptr) != tLABEL) {
+        if (lex() != tLABEL) {
             lexpush();
             return 0; /* untagged */
         }
-        name = nameptr;
+        name = current_token()->atom->chars();
     }
 
     return gTypes.defineTag(name)->tagid();


### PR DESCRIPTION
There is a lot of unnecessary duplication in the lexer API, both in ways
to match tokens and in structures used. This eliminates a bunch of it.