### PR TITLE
Parse include directives as statements.

### DIFF
--- a/compiler/errors.cpp
+++ b/compiler/errors.cpp
@@ -213,7 +213,7 @@ MessageBuilder::~MessageBuilder()
     ErrorReport report;
     report.number = number_;
     report.fileno = where_.file;
-    report.lineno = where_.line;
+    report.lineno = std::max(where_.line, 1);
     if (report.fileno >= 0) {
         report.filename = get_inputfile(report.fileno);
     } else {
@@ -296,7 +296,7 @@ ErrorReport::create_va(int number, int fileno, int lineno, va_list ap)
     ErrorReport report;
     report.number = number;
     report.fileno = fileno;
-    report.lineno = lineno;
+    report.lineno = std::max(lineno, 1);
     if (report.fileno >= 0) {
         report.filename = get_inputfile(report.fileno);
     } else {

--- a/compiler/lexer.h
+++ b/compiler/lexer.h
@@ -204,6 +204,7 @@ enum TokenKind {
     tSTRING,
     tEXPR,           /* for assigment to "lastst" only (see SC1.C) */
     tSYN_PRAGMA_UNUSED,
+    tSYN_INCLUDE_PATH,
     tENDLESS,        /* endless loop, for assigment to "lastst" only */
     tEMPTYBLOCK,     /* empty blocks for AM bug 4825 */
     tEOL,            /* newline, only returned by peek_new_line() */

--- a/compiler/messages.h
+++ b/compiler/messages.h
@@ -298,6 +298,7 @@ static const char* warnmsg[] = {
     /*244*/ "field '%s' was specified twice\n",
     /*245*/ "function %s implements a forward but is not marked as public\n",
     /*246*/ "function %s returns an array but return type is not marked as an array\n",
+    /*247*/ "include paths should be enclosed in \"quotes\" or <angle brackets>\n",
 };
 
 static const char* errmsg_ex[] = {
@@ -315,4 +316,5 @@ static const char* errmsg_ex[] = {
     /*411*/ "cannot determine fixed array size of return value\n",
     /*412*/ "function %s implements a forward but is not marked as public\n",
     /*413*/ "returned array does not have the same dimension count as return type\n",
+    /*414*/ "include statements are only allowed at the top-level scope\n",
 };

--- a/tests/compile-only/fail-non-toplevel-include.sp
+++ b/tests/compile-only/fail-non-toplevel-include.sp
@@ -1,0 +1,4 @@
+public main()
+{
+     #include <shell>
+}

--- a/tests/compile-only/fail-non-toplevel-include.txt
+++ b/tests/compile-only/fail-non-toplevel-include.txt
@@ -1,0 +1,1 @@
+(3) : error 414: include statements are only allowed at the top-level scope

--- a/tests/compile-only/ok-include-malformed-path.sp
+++ b/tests/compile-only/ok-include-malformed-path.sp
@@ -1,0 +1,5 @@
+#include float
+
+public main()
+{
+}


### PR DESCRIPTION
This is a huge hack, but it will make it much easier to properly clean
up the implementation of scopes. The problem is that #include statements
can appear anywhere, eg:

     public void
     #include "blah.sp"
     () {}

In the current system, static variables are globals that are tied to a
specific file. This requires attaching a file indicator to every name
lookup. It would be much cleaner to place statics into a dedicated
scope.

In the above example, "blah.sp" introduces a new static scope while in
the middle of parsing a function. This is extremely difficult to deal
with and exposes a bunch of crazy edge cases.

The effect of this change is that #include is now legal ONLY as a
top-level statement. It acts much like a declaration now. Due to the
lexer being very tricky, this works by injecting temporary tokens into
the token stream. These tokens are used by the parser to open the file
and reset the lexer.

Thus the above code is now illegal, as are lots of other #include
patterns that would be legal in C.