### PR TITLE
Eliminate static/global variables from lexer.cpp.

### DIFF
--- a/compiler/array-helpers.cpp
+++ b/compiler/array-helpers.cpp
@@ -525,7 +525,7 @@ FixedArrayValidator::CheckArgument(Expr* init)
     if (type_.ident == iREFARRAY)
         return true;
 
-    for (int i = 0; i < type_.dim.size(); i++) {
+    for (size_t i = 0; i < type_.dim.size(); i++) {
         if (type_.dim[i] && type_.dim[i] != dim[i]) {
             error(expr->pos(), 48);
             return false;

--- a/compiler/compile-context.cpp
+++ b/compiler/compile-context.cpp
@@ -45,3 +45,9 @@ CompileContext::CreateGlobalScope()
 {
     globals_ = new SymbolScope(nullptr, sGLOBAL);
 }
+
+void
+CompileContext::InitLexer()
+{
+    lexer_ = std::make_shared<Lexer>();
+}

--- a/compiler/compile-context.h
+++ b/compiler/compile-context.h
@@ -20,9 +20,12 @@
 //  3.  This notice may not be removed or altered from any source distribution.
 #pragma once
 
+#include <memory>
 #include <string>
 #include <unordered_set>
 #include <vector>
+
+#include "lexer.h"
 
 class SymbolScope;
 struct symbol;
@@ -39,9 +42,11 @@ class CompileContext final
     static inline CompileContext& get() { return *sInstance; }
 
     void CreateGlobalScope();
+    void InitLexer();
 
     SymbolScope* globals() const { return globals_; }
     std::unordered_set<symbol*>& functions() { return functions_; }
+    const std::shared_ptr<Lexer>& lexer() const { return lexer_; }
 
     const std::string& default_include() const { return default_include_; }
     void set_default_include(const std::string& file) { default_include_ = file; }
@@ -50,4 +55,8 @@ class CompileContext final
     SymbolScope* globals_;
     std::string default_include_;
     std::unordered_set<symbol*> functions_;
+
+    // The lexer is in CompileContext rather than Parser until we can eliminate
+    // PreprocExpr().
+    std::shared_ptr<Lexer> lexer_;
 };

--- a/compiler/errors.cpp
+++ b/compiler/errors.cpp
@@ -38,6 +38,7 @@
 #include <utility>
 #include <vector>
 
+#include "compile-context.h"
 #include "errors.h"
 #include "lexer.h"
 #include "sc.h"
@@ -174,7 +175,7 @@ MessageBuilder::MessageBuilder(int number)
     if (sPosOverride)
         where_ = sPosOverride->pos();
     else
-        where_ = current_pos();
+        where_ = CompileContext::get().lexer()->pos();
 }
 
 MessageBuilder::MessageBuilder(symbol* sym, int number)

--- a/compiler/expressions.cpp
+++ b/compiler/expressions.cpp
@@ -51,19 +51,6 @@ static void (*op1[17])(void) = {
     ob_eq,   ob_ne,                 /* hier10, index 15 */
 };
 
-// The "op1" array in sc3.cpp must have the same ordering as if these lists
-// were flattened.
-int ExpressionParser::list3[] = {'*', '/', '%', 0};
-int ExpressionParser::list4[] = {'+', '-', 0};
-int ExpressionParser::list5[] = {tSHL, tSHR, tSHRU, 0};
-int ExpressionParser::list6[] = {'&', 0};
-int ExpressionParser::list7[] = {'^', 0};
-int ExpressionParser::list8[] = {'|', 0};
-int ExpressionParser::list9[] = {tlLE, tlGE, '<', '>', 0};
-int ExpressionParser::list10[] = {tlEQ, tlNE, 0};
-int ExpressionParser::list11[] = {tlAND, 0};
-int ExpressionParser::list12[] = {tlOR, 0};
-
 /* These two functions are defined because the functions inc() and dec() in
  * SC4.C have a different prototype than the other code generation functions.
  * The arrays for user-defined functions use the function pointers for
@@ -611,31 +598,6 @@ int matchtag_commutative(int formaltag, int actualtag, int flags)
         return TRUE;
     // Report the error.
     return matchtag(formaltag, actualtag, flags);
-}
-
-/*
- *  Searches for a binary operator a list of operators. The list is stored in
- *  the array "list". The last entry in the list should be set to 0.
- *
- *  The index of an operator in "list" (if found) is returned in "opidx". If
- *  no operator is found, nextop() returns 0.
- *
- *  If an operator is found in the expression, it cannot be used in a function
- *  call with omitted parantheses. Mark this...
- */
-int
-ExpressionParser::nextop(int* opidx, int* list)
-{
-    *opidx = 0;
-    while (*list) {
-        if (matchtoken(*list)) {
-            return TRUE; /* found! */
-        } else {
-            list += 1;
-            *opidx += 1;
-        }
-    }
-    return FALSE; /* entire list scanned, nothing found */
 }
 
 cell

--- a/compiler/expressions.h
+++ b/compiler/expressions.h
@@ -24,6 +24,7 @@
 #ifndef am_sourcepawn_compiler_sc3_h
 #define am_sourcepawn_compiler_sc3_h
 
+#include "lexer.h"
 #include "parse-node.h"
 #include "sc.h"
 
@@ -31,24 +32,7 @@ class SemaContext;
 struct value;
 struct svalue;
 
-class ExpressionParser
-{
-  protected:
-    static int nextop(int* opidx, int* list);
-
-    // Each of these lists is an operator precedence level, and each list is a
-    // zero-terminated list of operators in that level (in precedence order).
-    static int list3[];
-    static int list4[];
-    static int list5[];
-    static int list6[];
-    static int list7[];
-    static int list8[];
-    static int list9[];
-    static int list10[];
-    static int list11[];
-    static int list12[];
-};
+int NextExprOp(Lexer* lexer, int* opidx, int* list);
 
 #define MATCHTAG_COERCE 0x1      // allow coercion
 #define MATCHTAG_SILENT 0x2      // silence the error(213) warning

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -237,7 +237,7 @@ Lexer::SynthesizeIncludePathToken()
     char name[PATH_MAX];
 
     int i = 0;
-    while (*lptr != close_c && *lptr != '\0' && i < sizeof(name) - 1) {
+    while (*lptr != close_c && *lptr != '\0' && i < (int)sizeof(name) - 1) {
         if (DIRSEP_CHAR != '/' && *lptr == '/') {
             name[i++] = DIRSEP_CHAR;
             lptr++;
@@ -248,7 +248,7 @@ Lexer::SynthesizeIncludePathToken()
     }
     while (i > 0 && name[i - 1] <= ' ')
         i--; /* strip trailing whitespace */
-    assert(i < sizeof name);
+    assert(i < (int)sizeof name);
     name[i] = '\0'; /* zero-terminate the string */
 
     if (close_c) {

--- a/compiler/main.cpp
+++ b/compiler/main.cpp
@@ -155,6 +155,7 @@ pc_compile(int argc, char* argv[]) {
 
     CompileContext cc;
     cc.CreateGlobalScope();
+    cc.InitLexer();
 
 #ifdef __EMSCRIPTEN__
     setup_emscripten_fs();
@@ -163,7 +164,6 @@ pc_compile(int argc, char* argv[]) {
     /* set global variables to their initial value */
     initglobals();
     errorset(sRESET, 0);
-    lexinit();
 
     /* make sure that we clean up on a fatal error; do this before the first
      * call to error(). */
@@ -228,7 +228,6 @@ pc_compile(int argc, char* argv[]) {
     inpf = inpf_org;
     freading = TRUE;
     inpf->Reset(inpfmark);       /* reset file position */
-    lexinit();                   /* clear internal flags of lex() */
 
     writeleader();
     insert_dbgfile(inpf->name());   /* attach to debug information */

--- a/compiler/name-resolution.cpp
+++ b/compiler/name-resolution.cpp
@@ -84,7 +84,7 @@ bool
 SemaContext::BindType(const token_pos_t& pos, sp::Atom* atom, bool is_label, int* tag)
 {
     if (is_label) {
-        *tag = pc_addtag(atom->chars());
+        *tag = gTypes.defineTag(atom->chars())->tagid();
         return true;
     }
 

--- a/compiler/parser.h
+++ b/compiler/parser.h
@@ -26,7 +26,7 @@
 #include "sc.h"
 #include "sctracker.h"
 
-class Parser : public ExpressionParser
+class Parser
 {
   public:
     explicit Parser(CompileContext& cc);
@@ -124,6 +124,7 @@ class Parser : public ExpressionParser
     Expr* struct_init();
     Expr* parse_new_array(const token_pos_t& pos, const TypenameInfo& rt);
     CallExpr* parse_call(const token_pos_t& pos, int tok, Expr* target);
+    int nextop(int* opidx, int* list);
 
     bool consume_line();
 
@@ -131,4 +132,5 @@ class Parser : public ExpressionParser
     CompileContext& cc_;
     bool in_loop_ = false;
     std::vector<SymbolScope*> static_scopes_;
+    std::shared_ptr<Lexer> lexer_;
 };

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -1400,7 +1400,7 @@ IndexExpr::Analyze(SemaContext& sc)
             /* character index */
             if (expr.constval < 0 ||
                 (base.sym->dim.array.length != 0 &&
-                 base.sym->dim.array.length <= (ucell)expr.constval))
+                 base.sym->dim.array.length <= expr.constval))
             {
                 error(pos_, 32, base.sym->name()); /* array index out of bounds */
                 return false;

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -468,7 +468,7 @@ UnaryExpr::Analyze(SemaContext& sc)
             } else if (val_.ident == iCONSTEXPR) {
                 val_.constval = !val_.constval;
             }
-            val_.tag = pc_addtag("bool");
+            val_.tag = pc_tag_bool;
             break;
         case '-':
             if (val_.ident == iCONSTEXPR && val_.tag == sc_rationaltag) {
@@ -673,7 +673,7 @@ BinaryExpr::Analyze(SemaContext& sc)
         }
 
         if (IsChainedOp(token_) || token_ == tlEQ || token_ == tlNE)
-            val_.tag = pc_addtag("bool");
+            val_.tag = pc_tag_bool;
     }
 
     return true;
@@ -946,7 +946,7 @@ LogicalExpr::Analyze(SemaContext& sc)
         val_.ident = iEXPRESSION;
     }
     val_.sym = nullptr;
-    val_.tag = pc_addtag("bool");
+    val_.tag = pc_tag_bool;
     return true;
 }
 

--- a/compiler/symbols.h
+++ b/compiler/symbols.h
@@ -349,4 +349,5 @@ symbol* FindEnumStructField(Type* type, sp::Atom* name);
 std::string funcdisplayname(const char* funcname);
 void reduce_referrers(CompileContext& cc);
 void deduce_liveness(CompileContext& cc);
+void declare_handle_intrinsics();
 symbol* declare_methodmap_symbol(CompileContext& cc, methodmap_t* map);

--- a/compiler/types.cpp
+++ b/compiler/types.cpp
@@ -294,21 +294,6 @@ pc_tagname(int tag)
     return "__unknown__";
 }
 
-int
-pc_addtag(const char* name)
-{
-    if (name == NULL) {
-        /* no tagname was given, check for one */
-        if (lex() != tLABEL) {
-            lexpush();
-            return 0; /* untagged */
-        }
-        name = current_token()->atom->chars();
-    }
-
-    return gTypes.defineTag(name)->tagid();
-}
-
 bool
 typeinfo_t::isCharArray() const
 {

--- a/compiler/types.h
+++ b/compiler/types.h
@@ -348,7 +348,6 @@ class TypeDictionary
     std::vector<std::unique_ptr<Type>> types_;
 };
 
-int pc_addtag(const char* name);
 const char* pc_tagname(int tag);
 
 extern TypeDictionary gTypes;

--- a/vm/debug-metadata.cpp
+++ b/vm/debug-metadata.cpp
@@ -206,7 +206,7 @@ uint16_t PerfJitdumpFile::GetElfMachine() {
     uint16_t machine;
   } __attribute__((packed)) elf_header;
 
-  if (fread(&elf_header, sizeof(elf_header), 1, exe) != -1) {
+  if (fread(&elf_header, sizeof(elf_header), 1, exe) != 0) {
     machine = elf_header.machine;
   }
 


### PR DESCRIPTION
All lexer state is now encapsulated in a Lexer class.