### PR TITLE
Remove a bunch of global variables.

### DIFF
--- a/compiler/assembler.cpp
+++ b/compiler/assembler.cpp
@@ -1645,7 +1645,7 @@ splat_to_binary(const char* binfname, void* bytes, size_t size)
 }
 
 void
-assemble(CompileContext& cc, CodegenContext& cg, const char* binfname)
+assemble(CompileContext& cc, CodegenContext& cg, const char* binfname, int compression_level)
 {
     Assembler assembler(cc, cg);
 
@@ -1655,14 +1655,14 @@ assemble(CompileContext& cc, CodegenContext& cg, const char* binfname)
     // Buffer compression logic.
     sp_file_hdr_t* header = (sp_file_hdr_t*)buffer.bytes();
 
-    if (sc_compression_level) {
+    if (compression_level) {
         size_t region_size = header->imagesize - header->dataoffs;
         size_t zbuf_max = compressBound(region_size);
         std::unique_ptr<Bytef[]> zbuf = std::make_unique<Bytef[]>(zbuf_max);
 
         uLong new_disksize = zbuf_max;
         int err = compress2(zbuf.get(), &new_disksize, (Bytef*)(buffer.bytes() + header->dataoffs),
-                            region_size, sc_compression_level);
+                            region_size, compression_level);
         if (err == Z_OK) {
             header->disksize = new_disksize + header->dataoffs;
             header->compression = SmxConsts::FILE_COMPRESSION_GZ;

--- a/compiler/assembler.h
+++ b/compiler/assembler.h
@@ -30,7 +30,8 @@
 #include "shared/byte-buffer.h"
 #include "shared/string-pool.h"
 
-void assemble(CompileContext& cc, CodegenContext& cg, const char* outname);
+void assemble(CompileContext& cc, CodegenContext& cg, const char* outname,
+              int compression_level);
 
 struct BackpatchEntry {
     size_t index;

--- a/compiler/compile-context.h
+++ b/compiler/compile-context.h
@@ -52,6 +52,7 @@ class CompileContext final
     ReportManager* reports() const { return reports_.get(); }
     CompileOptions* options() const { return options_.get(); }
     std::vector<std::string>& input_files() { return input_files_; }
+    std::vector<std::string>& included_files() { return included_files_; }
 
     const std::string& default_include() const { return default_include_; }
     void set_default_include(const std::string& file) { default_include_ = file; }
@@ -74,6 +75,7 @@ class CompileContext final
     std::unordered_set<symbol*> functions_;
     std::unique_ptr<CompileOptions> options_;
     std::vector<std::string> input_files_;
+    std::vector<std::string> included_files_;
 
     // The lexer is in CompileContext rather than Parser until we can eliminate
     // PreprocExpr().

--- a/compiler/compile-options.h
+++ b/compiler/compile-options.h
@@ -27,4 +27,9 @@ struct CompileOptions {
     bool need_semicolon = false;
     std::vector<std::string> source_files;
     std::vector<std::string> include_paths;
+    int tabsize = 8;
+    bool require_newdecls = false;
+    bool asmfile = false;
+    bool warnings_are_errors = false;
+    bool use_stderr = false;
 };

--- a/compiler/emitter.h
+++ b/compiler/emitter.h
@@ -89,8 +89,6 @@ void writetrailer(void);
 void begcseg(void);
 void begdseg(void);
 void setline(int chkbounds);
-void setfiledirect(const char* name);
-void setlinedirect(int line);
 void setlabel(int index);
 void markexpr(optmark type, const char* name, cell offset);
 void startfunc(const char* fname);

--- a/compiler/errors.cpp
+++ b/compiler/errors.cpp
@@ -39,6 +39,7 @@
 #include <vector>
 
 #include "compile-context.h"
+#include "compile-options.h"
 #include "errors.h"
 #include "lexer.h"
 #include "sc.h"
@@ -76,12 +77,12 @@ AutoErrorPos::~AutoErrorPos()
 static inline ErrorType
 DeduceErrorType(int number)
 {
-    if (number < 200 || (number < 300 && sc_warnings_are_errors) || number >= 400)
+    auto& cc = CompileContext::get();
+    if (number < 200 || (number < 300 && cc.options()->warnings_are_errors) || number >= 400)
         return ErrorType::Error;
     if (number >= 300)
         return ErrorType::Fatal;
 
-    auto& cc = CompileContext::get();
     if (cc.reports()->IsWarningDisabled(number))
         return ErrorType::Suppressed;
     return ErrorType::Warning;
@@ -388,7 +389,7 @@ ReportManager::ReportError(ErrorReport&& report)
 void
 ReportManager::DumpErrorReport(bool clear)
 {
-    FILE* stdfp = sc_use_stderr ? stderr : stdout;
+    FILE* stdfp = cc_.options()->use_stderr ? stderr : stdout;
 
     FILE* fp = nullptr;
     if (strlen(errfname) > 0)

--- a/compiler/lexer.h
+++ b/compiler/lexer.h
@@ -308,6 +308,9 @@ class Lexer
     std::vector<bool>& need_semicolon_stack() { return need_semicolon_stack_; }
     std::string& deprecate() { return deprecate_; }
     bool& allow_tags() { return allow_tags_; }
+    int& require_newdecls() { return require_newdecls_stack_.back(); }
+    int& stmtindent() { return stmtindent_; }
+    bool& indent_nowarn() { return indent_nowarn_; }
 
     bool HasMacro(sp::Atom* name) { return FindMacro(name->chars(), name->length(), nullptr); }
 
@@ -361,6 +364,8 @@ class Lexer
     int lexnewline_;
     std::string deprecate_;
     bool allow_tags_ = true;
+    int stmtindent_ = 0;
+    bool indent_nowarn_ = false;
 
     token_buffer_t normal_buffer_;;
     token_buffer_t preproc_buffer_;
@@ -395,4 +400,5 @@ class Lexer
     std::vector<int> current_line_stack_;
     std::vector<std::shared_ptr<SourceFile>> input_file_stack_;
     std::vector<bool> need_semicolon_stack_;
+    std::vector<int> require_newdecls_stack_;
 };

--- a/compiler/name-resolution.cpp
+++ b/compiler/name-resolution.cpp
@@ -922,8 +922,6 @@ FunctionInfo::Bind(SemaContext& outer_sc)
             report(pos_, 17) << alias_;
         sym_->function()->alias = alias_sym;
     }
-
-    sc_err_status = FALSE;
     return ok;
 }
 

--- a/compiler/parse-node.h
+++ b/compiler/parse-node.h
@@ -198,7 +198,7 @@ class ParseTree : public StmtList
 
     bool ResolveNames(SemaContext& sc);
     bool Analyze(SemaContext& sc) override;
-    void Emit(CompileContext& cc);
+    void Emit(CompileContext& cc, int compression_level);
 };
 
 class BlockStmt : public StmtList

--- a/compiler/scvars.cpp
+++ b/compiler/scvars.cpp
@@ -46,34 +46,20 @@ char sc_ctrlchar_org = CTRL_CHAR;          /* the default control character */
 int sc_labnum = 0;                         /* number of (internal) labels */
 cell glb_declared = 0;                     /* number of global cells declared */
 cell code_idx = 0;                         /* number of bytes with generated code */
-int sc_debug = sSYMBOLIC;                 /* by default: bounds checking+assertions */
-int sc_asmfile = FALSE;                    /* create .ASM file? */
-int sc_listing = FALSE;                    /* create .LST file? */
 int curseg = 0;                            /* 1 if currently parsing CODE, 2 if parsing DATA */
 cell pc_stksize = sDEF_AMXSTACK;           /* default stack size */
 cell pc_stksize_override = 0;
 int freading = FALSE;                      /* Is there an input file ready for reading? */
 int fline = 0;                             /* the line number in the current file */
 short fnumber = 0;                         /* the file number in the file table (debugging) */
-int stmtindent = 0;                        /* current indent of the statement */
-int indent_nowarn = FALSE;                 /* skip warning "217 loose indentation" */
-int sc_tabsize = 8;                        /* number of spaces that a TAB represents */
-int sc_err_status;
 int sc_rationaltag = 0;              /* tag for rational numbers */
 int sc_allowproccall = 0;            /* allow/detect tagnames in lex() */
 short sc_is_utf8 = FALSE;            /* is this source file in UTF-8 encoding */
-int pc_optimize = sOPTIMIZE_NOMACRO; /* (peephole) optimization level */
-int sc_showincludes = 0;             /* show include files */
-int sc_require_newdecls = 0;         /* Require new-style declarations */
-bool sc_warnings_are_errors = false;
-int sc_compression_level = 9;
 bool sc_use_new_parser = false;
 int pc_max_func_memory = 0;          /* high stack watermark */
 int pc_current_memory = 0;           /* current stack watermark */
 int pc_max_memory = 0;               /* maximum stack watermark across all stacks */
-int sc_use_stderr = FALSE;
 int pc_current_stack = 0;
-int sc_reparse = 0;
 
 symbol* sScopeChain = nullptr;
 

--- a/compiler/scvars.h
+++ b/compiler/scvars.h
@@ -40,20 +40,12 @@ extern char sc_ctrlchar_org;      /* the default control character */
 extern int sc_labnum;             /* number of (internal) labels */
 extern cell glb_declared;         /* number of global cells declared */
 extern cell code_idx;             /* number of bytes with generated code */
-extern int sc_debug;              /* debug/optimization options (bit field) */
-extern int sc_asmfile;            /* create .ASM file? */
-extern int sc_listing;            /* create .LST file? */
-extern int sc_showincludes;       /* show include files? */
 extern int curseg;                /* 1 if currently parsing CODE, 2 if parsing DATA */
 extern cell pc_stksize;           /* stack size */
 extern cell pc_stksize_override;  /* stack size override */
 extern int freading;              /* is there an input file ready for reading? */
 extern int fline;                 /* the line number in the current file */
 extern short fnumber;             /* number of files in the input file table */
-extern int stmtindent;            /* current indent of the statement */
-extern int indent_nowarn;         /* skip warning "217 loose indentation" */
-extern int sc_tabsize;            /* number of spaces that a TAB represents */
-extern int sc_err_status;         /* TRUE if errors should be generated even if sc_status = SKIP */
 extern int sc_rationaltag;        /* tag for rational numbers */
 extern int pc_functag;            /* global function tag */
 extern int pc_tag_string;         /* global String tag */
@@ -63,15 +55,10 @@ extern int pc_tag_bool;           /* global bool tag */
 extern int pc_tag_null_t;         /* the null type */
 extern int pc_tag_nullfunc_t;     /* the null function type */
 extern int pc_anytag;             /* global any tag */
-extern int sc_require_newdecls;   /* only newdecls are allowed */
-extern bool sc_warnings_are_errors;
-extern int sc_compression_level;
 extern int pc_max_func_memory;    /* high stack watermark */
 extern int pc_current_memory;     /* current stack watermark */
 extern int pc_max_memory;         /* maximum stack watermark across all stacks */
 extern int pc_current_stack;
-extern int sc_use_stderr;
-extern int sc_reparse;            /* needs 3th parse because of changed prototypes? */
 
 extern std::shared_ptr<SourceFile> inpf;      /* file read from (source or include) */
 extern std::shared_ptr<SourceFile> inpf_org;  /* main source file */

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -2982,9 +2982,6 @@ FunctionInfo::DoAnalyze(SemaContext& outer_sc)
         report(pos_, 234) << sym_->name() << ptr; /* deprecated (probably a public function) */
     }
 
-    if (this_tag_)
-        sc_err_status = TRUE;
-
     body_->Analyze(sc);
 
     sym_->returns_value = sc.returns_value();
@@ -3018,8 +3015,6 @@ FunctionInfo::DoAnalyze(SemaContext& outer_sc)
         if (scope_)
             TestSymbols(scope_, TRUE);
     }
-
-    sc_err_status = FALSE;
     return true;
 }
 


### PR DESCRIPTION
These get moved into classes attached to CompileContext and friends.

The "listing" option is now removed, since we've tightly integrated the
preprocessor into the parser.

The "debug" option is now removed. Debug info is unconditionally
emitted.