### PR TITLE
Invert the code generator's AST walk.

### DIFF
--- a/compiler/assembler.cpp
+++ b/compiler/assembler.cpp
@@ -777,7 +777,7 @@ struct variable_type_t {
 class RttiBuilder
 {
   public:
-    RttiBuilder(CodegenContext& cg, SmxNameTable* names);
+    RttiBuilder(CodeGenerator& cg, SmxNameTable* names);
 
     void finish(SmxBuilder& builder);
     void add_method(symbol* sym);
@@ -806,7 +806,7 @@ class RttiBuilder
     void build_debuginfo();
 
   private:
-    CodegenContext& cg_;
+    CodeGenerator& cg_;
     RefPtr<SmxNameTable> names_;
     DataPool type_pool_;
     RefPtr<SmxBlobSection<void>> data_;
@@ -830,7 +830,7 @@ class RttiBuilder
     TypeIdCache typeid_cache_;
 };
 
-RttiBuilder::RttiBuilder(CodegenContext& cg, SmxNameTable* names)
+RttiBuilder::RttiBuilder(CodeGenerator& cg, SmxNameTable* names)
  : cg_(cg),
    names_(names)
 {
@@ -1439,7 +1439,7 @@ typedef SmxListSection<sp_file_pubvars_t> SmxPubvarSection;
 typedef SmxBlobSection<sp_file_data_t> SmxDataSection;
 typedef SmxBlobSection<sp_file_code_t> SmxCodeSection;
 
-Assembler::Assembler(CompileContext& cc, CodegenContext& cg)
+Assembler::Assembler(CompileContext& cc, CodeGenerator& cg)
   : cc_(cc),
     cg_(cg)
 {
@@ -1645,7 +1645,7 @@ splat_to_binary(const char* binfname, void* bytes, size_t size)
 }
 
 void
-assemble(CompileContext& cc, CodegenContext& cg, const char* binfname, int compression_level)
+assemble(CompileContext& cc, CodeGenerator& cg, const char* binfname, int compression_level)
 {
     Assembler assembler(cc, cg);
 

--- a/compiler/assembler.h
+++ b/compiler/assembler.h
@@ -30,7 +30,7 @@
 #include "shared/byte-buffer.h"
 #include "shared/string-pool.h"
 
-void assemble(CompileContext& cc, CodegenContext& cg, const char* outname,
+void assemble(CompileContext& cc, CodeGenerator& cg, const char* outname,
               int compression_level);
 
 struct BackpatchEntry {
@@ -43,7 +43,7 @@ class AsmReader;
 class Assembler
 {
   public:
-    explicit Assembler(CompileContext& cc, CodegenContext& cg);
+    explicit Assembler(CompileContext& cc, CodeGenerator& cg);
 
     void Assemble(sp::SmxByteBuffer* buffer);
 
@@ -58,7 +58,7 @@ class Assembler
 
   private:
     CompileContext& cc_;
-    CodegenContext& cg_;
+    CodeGenerator& cg_;
     std::vector<cell> code_buffer_;
     std::vector<cell> data_buffer_;
     std::vector<BackpatchEntry> backpatch_list_;

--- a/compiler/ast-types.h
+++ b/compiler/ast-types.h
@@ -1,0 +1,73 @@
+// vim: set ts=8 sts=4 sw=4 tw=99 et:
+//
+//  Copyright (c) AlliedModders 2021
+//
+//  This software is provided "as-is", without any express or implied warranty.
+//  In no event will the authors be held liable for any damages arising from
+//  the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1.  The origin of this software must not be misrepresented; you must not
+//      claim that you wrote the original software. If you use this software in
+//      a product, an acknowledgment in the product documentation would be
+//      appreciated but is not required.
+//  2.  Altered source versions must be plainly marked as such, and must not be
+//      misrepresented as being the original software.
+//  3.  This notice may not be removed or altered from any source distribution.
+#pragma once
+
+enum class AstKind : uint8_t
+{
+    ParseTree,
+    StmtList,
+    BlockStmt,
+    LoopControlStmt,
+    StaticAssertStmt,
+    VarDecl,
+    EnumDecl,
+    PstructDecl,
+    TypedefDecl,
+    TypesetDecl,
+    UsingDecl,
+    IsDefinedExpr,
+    UnaryExpr,
+    BinaryExpr,
+    LogicalExpr,
+    ChainedCompareExpr,
+    TernaryExpr,
+    IncDecExpr,
+    CastExpr,
+    SizeofExpr,
+    SymbolExpr,
+    CallExpr,
+    CallUserOpExpr,
+    DefaultArgExpr,
+    FieldAccessExpr,
+    IndexExpr,
+    RvalueExpr,
+    CommaExpr,
+    ThisExpr,
+    NullExpr,
+    TaggedValueExpr,
+    StringExpr,
+    NewArrayExpr,
+    ArrayExpr,
+    StructExpr,
+    IfStmt,
+    ExprStmt,
+    ReturnStmt,
+    AssertStmt,
+    DeleteStmt,
+    ExitStmt,
+    DoWhileStmt,
+    ForStmt,
+    SwitchStmt,
+    PragmaUnusedStmt,
+    FunctionDecl,
+    EnumStructDecl,
+    MethodmapDecl,
+    ChangeScopeNode,
+};

--- a/compiler/code-generator.cpp
+++ b/compiler/code-generator.cpp
@@ -264,9 +264,9 @@ VarDecl::EmitLocal()
 
         markexpr(sLDECL, name()->chars(), sym_->addr());
 
-        if (NewArrayExpr* ctor = init_rhs()->AsNewArrayExpr()) {
+        if (NewArrayExpr* ctor = init_rhs()->as<NewArrayExpr>()) {
             ctor->Emit();
-        } else if (StringExpr* ctor = init_rhs()->AsStringExpr()) {
+        } else if (StringExpr* ctor = init_rhs()->as<StringExpr>()) {
             auto queue_size = gDataQueue.size();
             auto str_addr = gDataQueue.dat_address();
             gDataQueue.Add(ctor->text()->chars(), ctor->text()->length());
@@ -300,15 +300,15 @@ VarDecl::EmitPstruct()
 
     sym_->codeaddr = code_idx;
 
-    auto init = init_rhs()->AsStructExpr();
+    auto init = init_rhs()->as<StructExpr>();
     for (const auto& field : init->fields()) {
         auto arg = pstructs_getarg(ps, field.name);
-        if (auto expr = field.value->AsStringExpr()) {
+        if (auto expr = field.value->as<StringExpr>()) {
             values[arg->index] = gDataQueue.dat_address();
             gDataQueue.Add(expr->text()->chars(), expr->text()->length());
-        } else if (auto expr = field.value->AsTaggedValueExpr()) {
+        } else if (auto expr = field.value->as<TaggedValueExpr>()) {
             values[arg->index] = expr->value();
-        } else if (auto expr = field.value->AsSymbolExpr()) {
+        } else if (auto expr = field.value->as<SymbolExpr>()) {
             values[arg->index] = expr->sym()->addr();
         } else {
             assert(false);
@@ -971,7 +971,7 @@ CallExpr::DoEmit()
 
         expr->Emit();
 
-        if (expr->AsDefaultArgExpr()) {
+        if (expr->as<DefaultArgExpr>()) {
             pushreg(sPRI);
             continue;
         }

--- a/compiler/code-generator.h
+++ b/compiler/code-generator.h
@@ -23,28 +23,75 @@
 #include <string>
 #include <vector>
 
+#include "parse-node.h"
+
 class CompileContext;
+class ParseTree;
 struct symbol;
 
-class CodegenContext
+class CodeGenerator final
 {
   public:
-    explicit CodegenContext(CompileContext& cc, symbol* func)
-      : cc_(cc),
-        func_(func)
-    {}
+    CodeGenerator(CompileContext& cc, ParseTree* tree);
+
+    void Generate();
+
+    const std::vector<std::string>& debug_strings() const { return debug_strings_; }
+
+  private:
+    // Statements/decls.
+    void EmitStmtList(StmtList* list);
+    void EmitStmt(Stmt* stmt);
+    void EmitChangeScopeNode(ChangeScopeNode* node);
+    void EmitVarDecl(VarDecl* decl);
+    void EmitPstruct(VarDecl* decl);
+    void EmitGlobalVar(VarDecl* decl);
+    void EmitLocalVar(VarDecl* decl);
+    void EmitIfStmt(IfStmt* stmt);
+    void EmitDeleteStmt(DeleteStmt* stmt);
+    void EmitDoWhileStmt(DoWhileStmt* stmt);
+    void EmitLoopControlStmt(LoopControlStmt* stmt);
+    void EmitForStmt(ForStmt* stmt);
+    void EmitSwitchStmt(SwitchStmt* stmt);
+    void EmitFunctionInfo(FunctionInfo* info);
+    void EmitEnumStructDecl(EnumStructDecl* info);
+    void EmitMethodmapDecl(MethodmapDecl* info);
+    void EmitReturnStmt(ReturnStmt* stmt);
+    void EmitReturnArrayStmt(ReturnStmt* stmt);
+
+    // Expressions.
+    void EmitExpr(Expr* expr);
+    void EmitTest(Expr* expr, bool jump_on_true, int target);
+    void EmitUnary(UnaryExpr* expr);
+    void EmitIncDec(IncDecExpr* expr);
+    void EmitBinary(BinaryExpr* expr);
+    void EmitBinaryInner(OpFunc oper, const UserOperation& in_user_op, Expr* left, Expr* right);
+    void EmitLogicalExpr(LogicalExpr* expr);
+    void EmitChainedCompareExpr(ChainedCompareExpr* expr);
+    void EmitTernaryExpr(TernaryExpr* expr);
+    void EmitTernaryInner(TernaryExpr* expr, ke::Maybe<cell_t>* branch1,
+                          ke::Maybe<cell_t>* branch2);
+    void EmitSymbolExpr(SymbolExpr* expr);
+    void EmitIndexExpr(IndexExpr* expr);
+    void EmitFieldAccessExpr(FieldAccessExpr* expr);
+    void EmitCallExpr(CallExpr* expr);
+    void EmitDefaultArgExpr(DefaultArgExpr* expr);
+    void EmitCallUserOpExpr(CallUserOpExpr* expr);
+    void EmitNewArrayExpr(NewArrayExpr* expr);
+
+    // Logical test helpers.
+    bool EmitUnaryExprTest(UnaryExpr* expr, bool jump_on_true, int target);
+    void EmitLogicalExprTest(LogicalExpr* expr, bool jump_on_true, int target);
+    bool EmitChainedCompareExprTest(ChainedCompareExpr* expr, bool jump_on_true, int target);
 
     void AddDebugFile(const std::string& line);
     void AddDebugLine(int linenr);
     void AddDebugSymbol(symbol* sym);
 
-    CompileContext& cc() { return cc_; }
-    symbol* func() const { return func_; }
-    const std::vector<std::string>& debug_strings() const { return debug_strings_; }
-
   private:
     CompileContext& cc_;
-    symbol* func_;
+    ParseTree* tree_;
+    symbol* func_ = nullptr;
 
     std::vector<std::string> debug_strings_;
 };

--- a/compiler/name-resolution.cpp
+++ b/compiler/name-resolution.cpp
@@ -681,7 +681,7 @@ ReturnStmt::Bind(SemaContext& sc)
 
     // Do some peeking to see if this really returns an array. This is a
     // compatibility hack.
-    if (auto sym_expr = expr_->AsSymbolExpr()) {
+    if (auto sym_expr = expr_->as<SymbolExpr>()) {
         if (auto sym = sym_expr->sym()) {
             if (sym->ident == iARRAY || sym->ident == iREFARRAY)
                 sc.func_node()->set_maybe_returns_array();

--- a/compiler/name-resolution.cpp
+++ b/compiler/name-resolution.cpp
@@ -714,7 +714,7 @@ ForStmt::Bind(SemaContext& sc)
 
     ke::Maybe<AutoEnterScope> enter_scope;
     if (init_) {
-        if (!init_->IsExprStmt()) {
+        if (!init_->is(AstKind::ExprStmt)) {
             enter_scope.init(sc, sLOCAL);
             scope_ = sc.scope();
         }

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -319,7 +319,7 @@ Parser::parse_var(declinfo_t* decl, VarParams& params)
             init = var_init(params.vclass);
 
         // Keep updating this field, as we only care about the last initializer.
-        params.struct_init = init && init->AsStructExpr();
+        params.struct_init = init && init->as<StructExpr>();
 
         VarDecl* var = new VarDecl(pos, decl->name, decl->type, params.vclass, params.is_public,
                                    params.is_static, params.is_stock, init);
@@ -521,7 +521,7 @@ Parser::parse_typedef()
 
     sp::Atom* ident;
     if (!lexer_->needsymbol(&ident))
-        return new ErrorDecl();
+        return nullptr;
 
     lexer_->need('=');
 
@@ -536,7 +536,7 @@ Parser::parse_typeset()
 
     sp::Atom* ident;
     if (!lexer_->needsymbol(&ident))
-        return new ErrorDecl();
+        return nullptr;
 
     TypesetDecl* decl = new TypesetDecl(pos, ident);
 
@@ -575,7 +575,7 @@ Parser::parse_using()
     };
     if (!validate()) {
         lexer_->lexclr(TRUE);
-        return new ErrorDecl();
+        return nullptr;
     }
 
     lexer_->require_newline(TerminatorPolicy::Semicolon);
@@ -899,7 +899,7 @@ Parser::hier2()
                 rt = TypenameInfo{0};
 
             if (!lexer_->need('['))
-                return new ErrorExpr();
+                return nullptr;
 
             return parse_new_array(pos, rt);
         }
@@ -921,7 +921,7 @@ Parser::hier2()
 
             sp::Atom* ident;
             if (!lexer_->needsymbol(&ident))
-                return new ErrorExpr();
+                return nullptr;
             while (parens--)
                 lexer_->need(')');
             return new IsDefinedExpr(pos, ident);
@@ -937,7 +937,7 @@ Parser::hier2()
                 ident = gAtoms.add("this");
             } else {
                 if (!lexer_->needsymbol(&ident))
-                    return new ErrorExpr();
+                    return nullptr;
             }
 
             int array_levels = 0;
@@ -950,7 +950,7 @@ Parser::hier2()
             int token = lexer_->lex();
             if (token == tDBLCOLON || token == '.') {
                 if (!lexer_->needsymbol(&field))
-                    return new ErrorExpr();
+                    return nullptr;
             } else {
                 lexer_->lexpush();
                 token = 0;
@@ -1097,7 +1097,7 @@ Parser::constant()
         }
         default:
           error(29);
-          return new ErrorExpr();
+          return nullptr;
     }
 }
 

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -86,13 +86,6 @@ StmtList::Analyze(SemaContext& sc)
     return ok;
 }
 
-void
-StmtList::DoEmit(CodegenContext& cg)
-{
-    for (const auto& stmt : stmts_)
-        stmt->Emit(cg);
-}
-
 bool
 Decl::Analyze(SemaContext& sc)
 {


### PR DESCRIPTION
This moves codegen out of the AST itself and into a separate generator
class, which manually walks the AST. The primary reason is to improve
encapsulation. There are many nodes that don't emit any code and don't
neatly slot into the previous design. The new design makes it easier to
have separate code generators. It also makes it easier to remove the
text-based emitter, since attaching all the emitter code to input
variables would be really cumbersome.

Currently the generator uses a big switch statement to avoid the cost of
two virtual dispatches.

A similar refactoring for SemaContext will likely happen as well.