### PR TITLE
Use visitor pattern (kinda) for semantic analysis.

### DIFF
--- a/compiler/AMBuilder
+++ b/compiler/AMBuilder
@@ -54,6 +54,7 @@ binary.sources += [
   'lexer.cpp',
   'main.cpp',
   'name-resolution.cpp',
+  'parse-node.cpp',
   'parser.cpp',
   'pawncc.cpp',
   'pool-allocator.cpp',

--- a/compiler/array-helpers.h
+++ b/compiler/array-helpers.h
@@ -18,21 +18,20 @@
 //  2.  Altered source versions must be plainly marked as such, and must not be
 //      misrepresented as being the original software.
 //  3.  This notice may not be removed or altered from any source distribution.
-//
-//  Version: $Id$
 #pragma once
 
 #include "parse-node.h"
 
+class Semantics;
+
 // Determine the static size of an iARRAY based on dimension expressions and
 // array initializers. The array may be converted to an iREFARRAY if it is
 // determined to be dynamic.
-void ResolveArraySize(SemaContext& sc, VarDecl* decl);
-void ResolveArraySize(SemaContext& sc, const token_pos_t& pos, typeinfo_t* type, int vclass);
+void ResolveArraySize(Semantics* sema, VarDecl* decl);
+void ResolveArraySize(Semantics* sema, const token_pos_t& pos, typeinfo_t* type, int vclass);
 
 // Perform type and size checks of an array and its initializer if present.
-bool CheckArrayDeclaration(SemaContext& sc, VarDecl* decl);
-bool CheckArrayInitialization(SemaContext& sc, const typeinfo_t& type, Expr* init);
+bool CheckArrayInitialization(Semantics* sema, const typeinfo_t& type, Expr* init);
 
 struct ArrayData : public PoolObject {
     PoolList<cell> iv;

--- a/compiler/errors.cpp
+++ b/compiler/errors.cpp
@@ -42,6 +42,7 @@
 #include "compile-options.h"
 #include "errors.h"
 #include "lexer.h"
+#include "parse-node.h"
 #include "sc.h"
 #include "scvars.h"
 #include "symbols.h"
@@ -184,6 +185,12 @@ MessageBuilder::MessageBuilder(MessageBuilder&& other)
     disabled_(false)
 {
     other.disabled_ = true;
+}
+
+MessageBuilder::MessageBuilder(ParseNode* node, int number)
+{
+    where_ = node->pos();
+    number_ = number;
 }
 
 MessageBuilder&

--- a/compiler/errors.h
+++ b/compiler/errors.h
@@ -33,6 +33,8 @@
 #include "lexer.h"
 #include "sc.h"
 
+class ParseNode;
+
 enum class ErrorType {
     Suppressed,
     Warning,
@@ -101,6 +103,7 @@ class MessageBuilder
   public:
     explicit MessageBuilder(int number);
     MessageBuilder(symbol* sym, int number);
+    MessageBuilder(ParseNode* node, int number);
     MessageBuilder(MessageBuilder&& other);
 
     MessageBuilder(const MessageBuilder& other) = delete;
@@ -123,15 +126,14 @@ class MessageBuilder
         args_.emplace_back(atom ? atom->chars() : "<unknown>");
         return *this;
     }
-    MessageBuilder& operator <<(size_t n) {
-        args_.emplace_back(std::to_string(n));
-        return *this;
-    }
-    MessageBuilder& operator <<(int n) {
-        args_.emplace_back(std::to_string(n));
-        return *this;
-    }
     MessageBuilder& operator <<(Type* type);
+
+    template <typename Integer,
+              std::enable_if_t<std::is_integral<Integer>::value, bool> = true>
+    MessageBuilder& operator <<(Integer n) {
+        args_.emplace_back(std::to_string(n));
+        return *this;
+    }
 
     void operator =(const MessageBuilder& other) = delete;
     MessageBuilder& operator =(MessageBuilder&& other);
@@ -151,6 +153,9 @@ static inline MessageBuilder report(int number) {
 }
 static inline MessageBuilder report(symbol* sym, int number) {
     return MessageBuilder(sym, number);
+}
+static inline MessageBuilder report(ParseNode* node, int number) {
+    return MessageBuilder(node, number);
 }
 
 #ifdef NDEBUG

--- a/compiler/messages.h
+++ b/compiler/messages.h
@@ -247,6 +247,7 @@ static const char* fatalmsg[] = {
     /*313*/
     "deprecated syntax; see https://wiki.alliedmods.net/SourcePawn_Transitional_Syntax#Typedefs\n",
     /*314*/ "only one source file can be specified at a time\n",
+    /*315*/ "unhandled AST type: %d\n",
 };
 
 static const char* warnmsg[] = {

--- a/compiler/parse-node.cpp
+++ b/compiler/parse-node.cpp
@@ -1,0 +1,97 @@
+// vim: set ts=8 sts=4 sw=4 tw=99 et:
+//
+//  Copyright (c) 2021 AlliedModders LLC
+//
+//  This software is provided "as-is", without any express or implied warranty.
+//  In no event will the authors be held liable for any damages arising from
+//  the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1.  The origin of this software must not be misrepresented; you must not
+//      claim that you wrote the original software. If you use this software in
+//      a product, an acknowledgment in the product documentation would be
+//      appreciated but is not required.
+//  2.  Altered source versions must be plainly marked as such, and must not be
+//      misrepresented as being the original software.
+//  3.  This notice may not be removed or altered from any source distribution.
+#include "parse-node.h"
+
+#include "errors.h"
+
+VarDecl::VarDecl(const token_pos_t& pos, sp::Atom* name, const typeinfo_t& type, int vclass,
+                 bool is_public, bool is_static, bool is_stock, Expr* initializer)
+ : Decl(AstKind::VarDecl, pos, name),
+   type_(type),
+   vclass_(vclass),
+   is_public_(is_public),
+   is_static_(is_static),
+   is_stock_(is_stock),
+   autozero_(true)
+{
+    // Having a BinaryExpr allows us to re-use assignment logic.
+    if (initializer)
+        set_init(initializer);
+}
+
+void
+VarDecl::set_init(Expr* expr)
+{
+    init_ = new BinaryExpr(pos(), '=', new SymbolExpr(pos(), name()), expr);
+    init_->set_initializer();
+}
+
+Expr*
+VarDecl::init_rhs() const
+{
+    if (!init_)
+        return nullptr;
+    return init_->right();
+}
+
+void
+ParseNode::error(const token_pos_t& pos, int number, ...)
+{
+    va_list ap;
+    va_start(ap, number);
+    error_va(pos, number, ap);
+    va_end(ap);
+}
+
+void
+Expr::FlattenLogical(int token, std::vector<Expr*>* out)
+{
+    out->push_back(this);
+}
+
+void
+LogicalExpr::FlattenLogical(int token, std::vector<Expr*>* out)
+{
+    if (token_ == token) {
+        left_->FlattenLogical(token, out);
+        right_->FlattenLogical(token, out);
+    } else {
+        Expr::FlattenLogical(token, out);
+    }
+}
+
+BlockStmt*
+BlockStmt::WrapStmt(Stmt* stmt)
+{
+    if (BlockStmt* block = stmt->as<BlockStmt>())
+        return block;
+    BlockStmt* block = new BlockStmt(stmt->pos());
+    block->stmts().emplace_back(stmt);
+    return block;
+}
+
+BinaryExprBase::BinaryExprBase(AstKind kind, const token_pos_t& pos, int token, Expr* left, Expr* right)
+  : Expr(kind, pos),
+    token_(token),
+    left_(left),
+    right_(right)
+{
+    assert(right_ != this);
+}


### PR DESCRIPTION
Following the refactoring of CodeGenerator, this moves semantic analysis
into its own class and moves analysis out of ParseNode. This gives us a
lot more flexibility and means we have a consistent semantic object
across checks.

This patch is also the start of moving away from Mozilla syntax.
Function signatures of the style:

    ReturnType
    Name(Args)
    {
    }

Will now be styled as:

    ReturnType Name(Args) {

As always, if the signature is multi-line, the brace will be on the
following line.