### PR TITLE
Properly implement liveness analysis

### DIFF
--- a/compiler/assembler.cpp
+++ b/compiler/assembler.cpp
@@ -400,7 +400,7 @@ RttiBuilder::add_debug_var(SmxRttiTable<smx_rtti_debug_var>* table, DebugString&
 void
 RttiBuilder::add_method(symbol* sym)
 {
-    assert(!sym->skipped);
+    assert(!sym->unused());
 
     uint32_t index = methods_->count();
     smx_rtti_method& method = methods_->add();
@@ -849,22 +849,19 @@ Assembler::Assemble(SmxByteBuffer* buffer)
 
             if (!sym->defined)
                 continue;
-            if (sym->skipped)
+            if (sym->unused())
                 continue;
 
-            if (sym->is_public || (sym->usage & uREAD)) {
-                function_entry entry;
-                entry.sym = sym;
-                if (sym->is_public) {
-                    entry.name = sym->name();
-                } else {
-                    // Create a private name.
-                    entry.name = ke::StringPrintf(".%d.%s", sym->addr(), sym->name());
-                }
-
-                functions.emplace_back(std::move(entry));
-                continue;
+            function_entry entry;
+            entry.sym = sym;
+            if (sym->is_public) {
+                entry.name = sym->name();
+            } else {
+                // Create a private name.
+                entry.name = ke::StringPrintf(".%d.%s", sym->addr(), sym->name());
             }
+
+            functions.emplace_back(std::move(entry));
         } else if (sym->ident == iVARIABLE || sym->ident == iARRAY || sym->ident == iREFARRAY) {
             if (sym->is_public || (sym->usage & (uREAD | uWRITTEN)) != 0) {
                 sp_file_pubvars_t& pubvar = pubvars->add();

--- a/compiler/compile-context.h
+++ b/compiler/compile-context.h
@@ -49,6 +49,7 @@ class CompileContext final
 
     SymbolScope* globals() const { return globals_; }
     std::unordered_set<symbol*>& functions() { return functions_; }
+    std::unordered_set<symbol*>& publics() { return publics_; }
     const std::shared_ptr<Lexer>& lexer() const { return lexer_; }
     ReportManager* reports() const { return reports_.get(); }
     CompileOptions* options() const { return options_.get(); }
@@ -81,6 +82,7 @@ class CompileContext final
     SymbolScope* globals_;
     std::string default_include_;
     std::unordered_set<symbol*> functions_;
+    std::unordered_set<symbol*> publics_;
     std::unique_ptr<CompileOptions> options_;
     std::vector<std::string> input_files_;
     std::vector<std::string> included_files_;

--- a/compiler/errors.cpp
+++ b/compiler/errors.cpp
@@ -215,7 +215,7 @@ MessageBuilder::~MessageBuilder()
     report.number = number_;
     report.fileno = where_.file;
     report.lineno = std::max(where_.line, 1);
-    if (report.fileno >= 0) {
+    if (report.fileno >= 0 && (size_t)report.fileno < cc.input_files().size()) {
         report.filename = cc.input_files().at(report.fileno);
     } else {
         report.fileno = 0;

--- a/compiler/main.cpp
+++ b/compiler/main.cpp
@@ -216,11 +216,9 @@ pc_compile(int argc, char* argv[]) {
     setconfig(argv[0]); /* the path to the include files */
     sc_ctrlchar_org = sc_ctrlchar;
 
-    /* optionally create a temporary input file that is a collection of all
-     * input files
-     */
     assert(options->source_files.size() == 1);
     inpf_org = std::make_shared<SourceFile>();
+    inpf = inpf_org;
     if (!inpf_org->Open(options->source_files[0]))
         report(FATAL_ERROR_READ) << options->source_files[0];
     skip_utf8_bom(inpf_org.get());
@@ -302,7 +300,7 @@ cleanup:
         if (pc_stksize_override)
             pc_stksize = pc_stksize_override;
 
-        if (verbosity >= 1) {
+        if (verbosity >= 1 && compile_ok && jmpcode == 0) {
             printf("Code size:         %" PRIu32 " bytes\n", cg.code_size());
             printf("Data size:         %" PRIu32 " bytes\n", cg.data_size());
             printf("Stack/heap size:   %8ld bytes\n", (long)pc_stksize * sizeof(cell));

--- a/compiler/parse-node.h
+++ b/compiler/parse-node.h
@@ -490,7 +490,8 @@ class Expr : public ParseNode
 {
   public:
     explicit Expr(AstKind kind, const token_pos_t& pos)
-      : ParseNode(kind, pos)
+      : ParseNode(kind, pos),
+        lvalue_(false)
     {}
 
     // Flatten a series of binary expressions into a single list.
@@ -529,7 +530,7 @@ class Expr : public ParseNode
 
   protected:
     value val_ = {};
-    bool lvalue_ = 0;
+    bool lvalue_ : 1;
 };
 
 class IsDefinedExpr final : public Expr
@@ -1344,9 +1345,7 @@ class DeleteStmt : public Stmt
 
     bool Bind(SemaContext& sc) override { return expr_->Bind(sc); }
 
-    void ProcessUses(SemaContext& sc) override {
-        expr_->MarkAndProcessUses(sc);
-    }
+    void ProcessUses(SemaContext& sc) override;
 
     static bool is_a(ParseNode* node) { return node->kind() == AstKind::DeleteStmt; }
 

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -140,6 +140,7 @@ struct symbol;
 // Values for symbol::usage.
 #define uREAD       0x1     // Used/accessed.
 #define uWRITTEN    0x2     // Altered/written (variables only).
+#define uLIVE       0x4     // Marked during liveness analysis.
 
 #define uMAINFUNC "main"
 

--- a/compiler/symbols.h
+++ b/compiler/symbols.h
@@ -354,7 +354,6 @@ symbol* NewVariable(sp::Atom* name, cell addr, int ident, int vclass, int tag, i
                     int numdim, int semantic_tag);
 int findnamedarg(arginfo* arg, sp::Atom* name);
 symbol* FindEnumStructField(Type* type, sp::Atom* name);
-void reduce_referrers(CompileContext& cc);
 void deduce_liveness(CompileContext& cc);
 void declare_handle_intrinsics();
 symbol* declare_methodmap_symbol(CompileContext& cc, methodmap_t* map);

--- a/compiler/symbols.h
+++ b/compiler/symbols.h
@@ -101,7 +101,7 @@ struct symbol : public PoolObject
     int tag;       /* tagname id */
 
     // See uREAD/uWRITTEN above.
-    uint8_t usage : 2;
+    uint8_t usage : 3;
 
     // Variable: the variable is defined in the source file.
     // Function: the function is defined ("implemented") in the source file
@@ -120,7 +120,6 @@ struct symbol : public PoolObject
     // Functions only.
     bool missing : 1;       // the function is not implemented in this source file
     bool callback : 1;      // used as a callback
-    bool skipped : 1;       // skipped in codegen
     bool native : 1;        // the function is native
     bool returns_value : 1; // whether any path returns a value
     bool always_returns: 1; // whether all paths have an explicit return statement
@@ -218,6 +217,13 @@ struct symbol : public PoolObject
     }
     bool is_variadic() const;
     bool must_return_value() const;
+    bool used() const {
+        assert(ident == iFUNCTN);
+        return (usage & uLIVE) == uLIVE;
+    }
+    bool unused() const {
+        return !used();
+    }
 
   private:
     cell addr_; /* address or offset (or value for constant, index for native function) */


### PR DESCRIPTION
This was always a hack in the multi-parse compiler, but now, we can do
it properly. The live set is "all public functions" and from there we
calculate a reachability graph and mark what's live.

Unlike the old system, we do not bother changing read/written flags. We
use a new bit since that's easier to do when statics are split into
their own scope.

Now that liveness works correctly, the new compiler will no longer emit
code for unused functions. This should even function better than 1.10/1.11.