### PR TITLE
Treat assigned outparams as read.

### DIFF
--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -646,6 +646,10 @@ bool Semantics::CheckBinaryExpr(BinaryExpr* expr) {
         if (symbol* sym = left->val().sym) {
             markusage(sym, uWRITTEN);
 
+            // If it's an outparam, also mark it as read.
+            if (sym->vclass == sARGUMENT && (sym->ident == iREFERENCE || sym->ident == iREFARRAY))
+                markusage(sym, uREAD);
+
             // Update the line number as a hack so we can warn that it was never
             // used.
             sym->lnumber = expr->pos().line;

--- a/tests/compile-only/ok-array-base-is-used.sp
+++ b/tests/compile-only/ok-array-base-is-used.sp
@@ -1,0 +1,14 @@
+// warnings_are_errors: true
+native void PrintToServer(const char[] fmt, any:...);
+
+public void OnPluginStart()
+{
+	int stuff[4];
+	FillArray(stuff);
+	PrintToServer("{%d, %d, %d, %d}", stuff[0], stuff[1], stuff[2], stuff[3]);
+}
+
+void FillArray(int stuff[4])
+{
+	stuff = { 5, 2, 8, 1 };	// warning 204: symbol is assigned a value that is never used: "stuff"
+}


### PR DESCRIPTION
Bug: issue #682
Test: ok-array-base-is-used