### PR TITLE
Rewrite heap tracking.

### DIFF
--- a/compiler/assembler.cpp
+++ b/compiler/assembler.cpp
@@ -919,7 +919,8 @@ Assembler::Assemble(SmxByteBuffer* buffer)
     code->header().flags = CODEFLAG_DEBUG;
     code->header().main = 0;
     code->header().code = sizeof(sp_file_code_t);
-    code->header().features = SmxConsts::kCodeFeatureDirectArrays;
+    code->header().features = SmxConsts::kCodeFeatureDirectArrays |
+                              SmxConsts::kCodeFeatureHeapScopes;
     code->setBlob(cg_.code_ptr(), cg_.code_size());
 
     // Set up the data section. Note pre-SourceMod 1.7, the |memsize| was

--- a/compiler/code-generator.cpp
+++ b/compiler/code-generator.cpp
@@ -1979,7 +1979,7 @@ CodeGenerator::EnterMemoryScope(std::vector<MemoryScope>& frame, AllocScopeKind 
 }
 
 void
-CodeGenerator::AllocInScope(MemoryScope& scope, int type, int size)
+CodeGenerator::AllocInScope(MemoryScope& scope, MemuseType type, int size)
 {
     if (type == MEMUSE_STATIC && !scope.usage.empty() && scope.usage.back().type == MEMUSE_STATIC) {
         scope.usage.back().size += size;
@@ -2032,7 +2032,7 @@ CodeGenerator::pop_static_heaplist()
 }
 
 int
-CodeGenerator::markheap(int type, int size, AllocScopeKind kind)
+CodeGenerator::markheap(MemuseType type, int size, AllocScopeKind kind)
 {
     MemoryScope* scope = nullptr;
     if (kind == AllocScopeKind::Temp) {
@@ -2069,7 +2069,7 @@ CodeGenerator::pushstacklist()
 }
 
 int
-CodeGenerator::markstack(int type, int size)
+CodeGenerator::markstack(MemuseType type, int size)
 {
     current_stack_ += size;
     AllocInScope(stack_scopes_.back(), type, size);

--- a/compiler/code-generator.h
+++ b/compiler/code-generator.h
@@ -122,12 +122,17 @@ class CodeGenerator final
       Temp
     };
 
+    enum MemuseType {
+        MEMUSE_STATIC = 0,
+        MEMUSE_DYNAMIC = 1
+    };
+
     struct MemoryUse {
-        MemoryUse(int type, int size)
+        MemoryUse(MemuseType type, int size)
          : type(type),
            size(size)
         {}
-        int type; /* MEMUSE_STATIC or MEMUSE_DYNAMIC */
+        MemuseType type;
         int size; /* size of array for static (0 for dynamic) */
     };
 
@@ -163,7 +168,7 @@ class CodeGenerator final
     // Heap functions
     void pushheaplist(AllocScopeKind kind = AllocScopeKind::Normal);
     void popheaplist(bool codegen);
-    int markheap(int type, int size, AllocScopeKind kind);
+    int markheap(MemuseType type, int size, AllocScopeKind kind);
 
     // Remove the current heap scope, requiring that all alocations within be
     // static. Then return that static size.
@@ -172,7 +177,7 @@ class CodeGenerator final
     // Stack functions
     void pushstacklist();
     void popstacklist(bool codegen);
-    int markstack(int type, int size);
+    int markstack(MemuseType type, int size);
     void modheap_for_scope(const MemoryScope& scope);
     void modstk_for_scope(const MemoryScope& scope);
 
@@ -189,7 +194,7 @@ class CodeGenerator final
     }
 
     void EnterMemoryScope(std::vector<MemoryScope>& frame, AllocScopeKind kind);
-    void AllocInScope(MemoryScope& scope, int type, int size);
+    void AllocInScope(MemoryScope& scope, MemuseType type, int size);
     int PopScope(std::vector<MemoryScope>& scope_list);
 
   private:

--- a/compiler/parse-node.h
+++ b/compiler/parse-node.h
@@ -59,7 +59,8 @@ class ParseNode : public PoolObject
   public:
     explicit ParseNode(AstKind kind, const token_pos_t& pos)
       : kind_(kind),
-        pos_(pos)
+        pos_(pos),
+        tree_has_heap_allocs_(false)
     {}
 
     virtual bool Bind(SemaContext& sc) {
@@ -78,6 +79,9 @@ class ParseNode : public PoolObject
 
     AstKind kind() const { return kind_; }
     bool is(AstKind k) const { return kind() == k; }
+
+    bool tree_has_heap_allocs() const { return tree_has_heap_allocs_; }
+    void set_tree_has_heap_allocs(bool b) { tree_has_heap_allocs_ = b; }
 
     template <class T> T* as() {
         if (T::is_a(this))
@@ -100,6 +104,7 @@ class ParseNode : public PoolObject
   protected:
     AstKind kind_;
     token_pos_t pos_;
+    bool tree_has_heap_allocs_ : 1;
 };
 
 enum FlowType {
@@ -491,7 +496,8 @@ class Expr : public ParseNode
   public:
     explicit Expr(AstKind kind, const token_pos_t& pos)
       : ParseNode(kind, pos),
-        lvalue_(false)
+        lvalue_(false),
+        can_alloc_heap_(false)
     {}
 
     // Flatten a series of binary expressions into a single list.
@@ -522,6 +528,8 @@ class Expr : public ParseNode
     const value& val() const { return val_; }
     bool lvalue() const { return lvalue_; }
     void set_lvalue(bool lvalue) { lvalue_ = lvalue; }
+    bool can_alloc_heap() const { return can_alloc_heap_; }
+    void set_can_alloc_heap(bool b) { can_alloc_heap_ = b; }
 
     void MarkAndProcessUses(SemaContext& sc) {
         MarkUsed(sc);
@@ -531,6 +539,7 @@ class Expr : public ParseNode
   protected:
     value val_ = {};
     bool lvalue_ : 1;
+    bool can_alloc_heap_ : 1;
 };
 
 class IsDefinedExpr final : public Expr

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -1040,15 +1040,23 @@ Parser::primary()
         /* allow tagnames to be used in parenthesized expressions */
         ke::SaveAndSet<bool> allowtags(&lexer_->allow_tags(), true);
 
-        CommaExpr* expr = new CommaExpr(lexer_->pos());
+        auto pos = lexer_->pos();
+        CommaExpr* comma = nullptr;
+        Expr* expr = nullptr;
         do {
             Expr* child = hier14();
-            expr->exprs().push_back(child);
+            if (expr) {
+                if (!comma)
+                    comma = new CommaExpr(pos);
+                comma->exprs().push_back(child);
+            } else {
+                expr = child;
+            }
         } while (lexer_->match(','));
         lexer_->need(')');
         lexer_->lexclr(FALSE); /* clear lexer_->lex() push-back, it should have been
                         * cleared already by lexer_->need() */
-        return expr;
+        return comma ? comma : expr;
     }
 
     int tok = lexer_->lex();

--- a/compiler/sctracker.h
+++ b/compiler/sctracker.h
@@ -10,9 +10,6 @@
 
 class SemaContext;
 
-#define MEMUSE_STATIC 0
-#define MEMUSE_DYNAMIC 1
-
 struct funcenum_t {
     funcenum_t()
      : tag(0),

--- a/compiler/semantics.h
+++ b/compiler/semantics.h
@@ -144,7 +144,12 @@ class Semantics final
     void set_context(SemaContext* sc) { sc_ = sc; }
 
   private:
-    bool CheckStmt(Stmt* stmt);
+    enum StmtFlags {
+        STMT_DEFAULT = 0x0,
+        STMT_OWNS_HEAP = 0x1
+    };
+
+    bool CheckStmt(Stmt* stmt, StmtFlags = STMT_DEFAULT);
     bool CheckStmtList(StmtList* list);
     bool CheckBlockStmt(BlockStmt* stmt);
     bool CheckChangeScopeNode(ChangeScopeNode* node);
@@ -209,6 +214,9 @@ class Semantics final
     symbol* BindNewTarget(Expr* target);
     symbol* BindCallTarget(CallExpr* call, Expr* target);
 
+    void NeedsHeapAlloc(Expr* expr);
+    void AssignHeapOwnership(ParseNode* node);
+
     Expr* AnalyzeForTest(Expr* expr);
 
     bool TestSymbol(symbol* sym, bool testconst);
@@ -219,6 +227,7 @@ class Semantics final
     ParseTree* tree_;
     std::unordered_set<SymbolScope*> static_scopes_;
     SemaContext* sc_ = nullptr;
+    bool pending_heap_allocation_ = false;
 };
 
 class AutoEnterScope final

--- a/include/smx/smx-headers.h
+++ b/include/smx/smx-headers.h
@@ -75,6 +75,9 @@ struct SmxConsts {
     // This feature adds the INIT_ARRAY opcode, and requires that multi-dimensional
     // arrays use direct internal addressing.
     static const uint32_t kCodeFeatureDirectArrays = (1 << 1);
+
+    // This feature adds the HEAP_SAVE and HEAP_RESTORE opcodes.
+    static const uint32_t kCodeFeatureHeapScopes = (1 << 2);
 };
 
 // These structures are byte-packed.

--- a/include/smx/smx-v1-opcodes.h
+++ b/include/smx/smx-v1-opcodes.h
@@ -240,6 +240,8 @@ namespace sp {
     _U(REBASE, "rebase")                                                    \
     _G(INITARRAY_PRI, "initarray.pri", 6)                                   \
     _G(INITARRAY_ALT, "initarray.alt", 6)                                   \
+    _G(HEAP_SAVE, "heap.save", 1)                                           \
+    _G(HEAP_RESTORE, "heap.restore", 1)                                     \
     /* Opcodes below this are pseudo-opcodes and are not part of the ABI */ \
     _U(FIRST_FAKE, "firstfake")                                             \
     _G(FABS, "fabs", 1)                                                     \

--- a/tests/compile-only/ok-heap-and-ternary-operator.sp
+++ b/tests/compile-only/ok-heap-and-ternary-operator.sp
@@ -1,0 +1,17 @@
+#include <shell>
+
+public void main()
+{
+	{
+		int b;
+		printnums(0, (b
+			      ? (((b > 0)
+				  ? 1
+				  : GetTime()) + 1)
+			      : 0));
+	}
+}
+
+int GetTime(int x[2] = {}) {
+	return 100;
+}

--- a/vm/control-flow.cpp
+++ b/vm/control-flow.cpp
@@ -395,4 +395,16 @@ Block::unlink()
   immediately_dominated_.clear();
 }
 
+uint32_t
+Block::startPc() const
+{
+  return start_ - graph_.rt()->code().bytes;
+}
+
+uint32_t
+Block::endPc() const
+{
+  return end_ - graph_.rt()->code().bytes;
+}
+
 } // namespace sp

--- a/vm/control-flow.h
+++ b/vm/control-flow.h
@@ -151,6 +151,10 @@ class Block :
     has_compiler_break_bug_ = true;
   }
 
+  // For debugging.
+  uint32_t startPc() const;
+  uint32_t endPc() const;
+
  private:
   ControlFlowGraph& graph_;
   std::vector<ke::RefPtr<Block>> predecessors_;
@@ -236,6 +240,8 @@ class ControlFlowGraph : public ke::Refcounted<ControlFlowGraph>
   void dump(FILE* fp);
   void dumpDot(FILE* fp);
   void dumpDomTreeDot(FILE* fp);
+
+  PluginRuntime* rt() const { return rt_; }
 
  private:
   PluginRuntime* rt_;

--- a/vm/interpreter.cpp
+++ b/vm/interpreter.cpp
@@ -1061,6 +1061,18 @@ Interpreter::visitHALT(cell_t value)
 }
 
 bool
+Interpreter::visitHEAP_SAVE()
+{
+  return cx_->enterHeapScope();
+}
+
+bool
+Interpreter::visitHEAP_RESTORE()
+{
+  return cx_->leaveHeapScope();
+}
+
+bool
 Interpreter::visitINITARRAY(PawnReg reg, cell_t addr, cell_t iv_size, cell_t data_copy_size,
                             cell_t data_fill_size, cell_t fill_value)
 {

--- a/vm/interpreter.h
+++ b/vm/interpreter.h
@@ -152,6 +152,8 @@ class Interpreter final : public PcodeVisitor
   bool visitHALT(cell_t value) override;
   bool visitINITARRAY(PawnReg reg, cell_t addr, cell_t iv_size, cell_t data_copy_size,
                       cell_t data_fill_size, cell_t fill_value) override;
+  bool visitHEAP_SAVE() override;
+  bool visitHEAP_RESTORE() override;
 
  private:
   Interpreter(PluginContext* cx, RefPtr<MethodInfo> method);

--- a/vm/method-verifier.h
+++ b/vm/method-verifier.h
@@ -62,24 +62,28 @@ class MethodVerifier final
 
   struct VerifyData : public IBlockData {
     VerifyData()
-     : stack_balance(0)
+     : stack_balance(0),
+       heap_scope_depth(0)
     {}
     VerifyData(const VerifyData& other)
      : stack_balance(other.stack_balance),
        heap_balance(other.heap_balance),
-       tracker_balance(other.tracker_balance)
+       tracker_balance(other.tracker_balance),
+       heap_scope_depth(other.heap_scope_depth)
     {}
 
     VerifyData& operator =(const VerifyData& other) {
       stack_balance = other.stack_balance;
       heap_balance = other.heap_balance;
       tracker_balance = other.tracker_balance;
+      heap_scope_depth = other.heap_scope_depth;
       return *this;
     }
 
     uint32_t stack_balance;
     std::vector<int32_t> heap_balance;
     std::vector<int32_t> tracker_balance;
+    uint32_t heap_scope_depth;
 
     std::unique_ptr<VerifyData> entry;
   };

--- a/vm/pcode-reader.h
+++ b/vm/pcode-reader.h
@@ -658,6 +658,11 @@ class PcodeReader
                                       fill_value);
     }
 
+    case OP_HEAP_SAVE:
+      return visitor_->visitHEAP_SAVE();
+    case OP_HEAP_RESTORE:
+      return visitor_->visitHEAP_RESTORE();
+
     default:
       assert(false);
       return false;

--- a/vm/pcode-visitor.h
+++ b/vm/pcode-visitor.h
@@ -136,6 +136,8 @@ class PcodeVisitor
   virtual bool visitSWITCH(cell_t defaultOffset, const CaseTableEntry* cases, size_t ncases) = 0;
   virtual bool visitINITARRAY(PawnReg reg, cell_t addr, cell_t iv_size, cell_t data_copy_size,
                               cell_t data_fill_size, cell_t fill_value) = 0;
+  virtual bool visitHEAP_SAVE() = 0;
+  virtual bool visitHEAP_RESTORE() = 0;
 };
 
 class IncompletePcodeVisitor : public PcodeVisitor
@@ -495,6 +497,14 @@ class IncompletePcodeVisitor : public PcodeVisitor
   }
   virtual bool visitINITARRAY(PawnReg reg, cell_t addr, cell_t iv_size, cell_t data_copy_size,
                               cell_t data_fill_size, cell_t fill_value) override {
+    assert(false);
+    return false;
+  }
+  virtual bool visitHEAP_SAVE() override {
+    assert(false);
+    return false;
+  }
+  virtual bool visitHEAP_RESTORE() override {
     assert(false);
     return false;
   }

--- a/vm/plugin-context.h
+++ b/vm/plugin-context.h
@@ -95,6 +95,9 @@ class PluginContext : public BasePluginContext
   cell_t* addressOfHp() {
     return &hp_;
   }
+  cell_t* addressOfHpScope() {
+    return &hp_scope_;
+  }
 
   cell_t frm() const {
     return frm_;
@@ -108,6 +111,8 @@ class PluginContext : public BasePluginContext
 
   int popTrackerAndSetHeap();
   int pushTracker(uint32_t amount);
+  bool enterHeapScope();
+  bool leaveHeapScope();
 
   int generateArray(cell_t dims, cell_t* stk, bool autozero);
   int generateFullArray(uint32_t argc, cell_t* argv, int autozero);
@@ -134,6 +139,7 @@ class PluginContext : public BasePluginContext
                  cell_t fill_value);
 
   cell_t* throwIfBadAddress(cell_t addr);
+  bool usesHeapTracker() const;
 
  private:
   PluginRuntime* m_pRuntime;
@@ -151,6 +157,7 @@ class PluginContext : public BasePluginContext
   cell_t sp_;
   cell_t hp_;
   cell_t frm_;
+  cell_t hp_scope_;
 };
 
 } // namespace sp

--- a/vm/smx-v1-image.cpp
+++ b/vm/smx-v1-image.cpp
@@ -277,7 +277,9 @@ SmxV1Image::validateCode()
   if (code->codeversion >= SmxConsts::CODE_VERSION_FEATURE_MASK)
     features = code->features;
 
-  uint32_t supported_features = SmxConsts::kCodeFeatureDirectArrays;
+  uint32_t supported_features =
+    SmxConsts::kCodeFeatureDirectArrays |
+    SmxConsts::kCodeFeatureHeapScopes;
   if (features & ~supported_features)
     return error("unsupported feature set; code is too new");
 

--- a/vm/x86/jit_x86.cpp
+++ b/vm/x86/jit_x86.cpp
@@ -1543,6 +1543,34 @@ Compiler::visitSWITCH(cell_t defaultOffset,
   return true;
 }
 
+bool
+Compiler::visitHEAP_SAVE()
+{
+  // Allocate one cell on the heap.
+  visitHEAP(sizeof(cell_t));
+  // Get the addres of the old heap scope in pri.
+  __ movl(pri, Operand(hpScopeAddr()));
+  // Store the old heap scope address into the new heap scope.
+  __ movl(Operand(dat, alt, NoScale), pri);
+  // Update the context's current heap scope.
+  __ movl(Operand(hpScopeAddr()), alt);
+  return true;
+}
+
+bool
+Compiler::visitHEAP_RESTORE()
+{
+  // Get the current heap scope address.
+  __ movl(ecx, Operand(hpScopeAddr()));
+  // Get the previous heap scope address.
+  __ movl(alt, Operand(dat, ecx, NoScale));
+  // Update the heap pointer.
+  __ movl(Operand(hpAddr()), alt);
+  // Update the heap scope.
+  __ movl(Operand(hpScopeAddr()), ecx);
+  return true;
+}
+
 void
 Compiler::emitFloatCmp(ConditionCode cc)
 {

--- a/vm/x86/jit_x86.h
+++ b/vm/x86/jit_x86.h
@@ -137,6 +137,8 @@ class Compiler : public CompilerBase
     size_t ncases) override;
   bool visitINITARRAY(PawnReg reg, cell_t addr, cell_t iv_size, cell_t data_copy_size,
                       cell_t data_fill_size, cell_t fill_value) override;
+  bool visitHEAP_SAVE() override;
+  bool visitHEAP_RESTORE() override;
 
  private:
   bool setup(cell_t pcode_offs);
@@ -163,6 +165,9 @@ class Compiler : public CompilerBase
   }
   ExternalAddress spAddr() {
     return ExternalAddress(context_->addressOfSp());
+  }
+  ExternalAddress hpScopeAddr() {
+    return ExternalAddress(context_->addressOfHpScope());
   }
 };
 


### PR DESCRIPTION
Since the AMX Mod X days we've dealt with heap allocations by trying to
precisely free them, similar to stack opcodes. This gets complicated by
the ternary operator which could have different allocations on each
side. It's further complicated by the method verifier, not to mention
nuances in evaluation ordering.

This patch throws away the entire concept of the "heap tracker". Heap
allocations are no longer precisely tracked, and the TRACKER opcodes are
banished from new binaries.

The new scheme is to save and restore the heap pointer via two new
codes: OP_HEAP_SAVE and OP_HEAP_RESTORE. These opcodes are emitted with
a much simpler granularity than the old tracker logic.

If a node requires heap allocations, we mark the node, and then set a
"pending allocation" bit. The nearest block statement then grabs this
bit and assumes responsibility for emitting SAVE/RESTORE opcodes. This
is called a heap scope. Control-flow statements can have their body
create a heap scope (to avoid memory explosion in loops). The "advance"
expression of a "for" statement also creates a heap scope.

It is never necessary to create a heap scope, but the more granular they
are, the less risk there is of running out of memory. We've struck a
balance here that roughly matches how stack allocations work.

We do not create a heap scope for the function body. Instead,
PluginContext::Invoke always restores the heap pointer. It now also
restores the stack pointer as well, making it unnecessary to do any
extra code generation on return paths.

The unfortunate aspect of this patch is that the Semantics pass needs to
precisely mimic when CodeGeneration will allocate on the heap, so we can
build the heap scope boundaries. To future proof this, the code
generator asserts that heap allocations are tied to a node that was
properly marked in the Semantics phase.

The upsides of this patch are many. It is much easier to understand the
generated code and the compiler logic now. The ternary operator is much
simpler. The entire (very complex) "mergeTracker" function in the
verifier is no longer needed, and other simplifications to the verifier
were made as well.