### PR TITLE
Don't allow defining the same public function twice.

### DIFF
--- a/compiler/name-resolution.cpp
+++ b/compiler/name-resolution.cpp
@@ -802,8 +802,12 @@ FunctionDecl::CanRedefine(symbol* sym)
     }
 
     if (data->node) {
-        if (!data->node->is_public()) {
+        if (info_->is_forward() && !data->node->is_public()) {
             report(pos_, 412) << name_;
+            return false;
+        }
+        if (info_->body() && !data->forward) {
+            report(pos_, 21) << name_;
             return false;
         }
         return true;

--- a/tests/compile-only/fail-define-public-twice.sp
+++ b/tests/compile-only/fail-define-public-twice.sp
@@ -1,0 +1,10 @@
+public int TestHandler(int param1, int param2)
+{
+    return 0;
+}
+
+public int TestHandler(int param1, int param2)
+{
+    delete menu;
+    return 0;
+}

--- a/tests/compile-only/fail-define-public-twice.txt
+++ b/tests/compile-only/fail-define-public-twice.txt
@@ -1,0 +1,1 @@
+(6) : error 021: symbol already defined: "TestHandler"


### PR DESCRIPTION
Bug: issue #694
Test: fail-define-public-twice