### PR TITLE
Implement RTTI parsing and validation in the VM

### DIFF
--- a/compiler/assembler.cpp
+++ b/compiler/assembler.cpp
@@ -486,6 +486,7 @@ RttiBuilder::add_enumstruct(Type* type)
         info.type_id = to_typeid(encoding);
         info.offset = field->addr();
         es_fields_->at(es.first_field + index) = info;
+        index++;
     }
 
     return es_index;

--- a/include/smx/smx-typeinfo.h
+++ b/include/smx/smx-typeinfo.h
@@ -316,6 +316,7 @@ static const uint8_t kVarClass_Global = 0x0;
 static const uint8_t kVarClass_Local = 0x1;
 static const uint8_t kVarClass_Static = 0x2;
 static const uint8_t kVarClass_Arg = 0x3;
+static const uint8_t kVarClass_Max = kVarClass_Arg;
 
 #pragma pack(pop)
 

--- a/tools/verifier/verify.py
+++ b/tools/verifier/verify.py
@@ -7,6 +7,8 @@ def main():
   parser = argparse.ArgumentParser()
   parser.add_argument('-v', '--verbose', action='store_true', default=False,
                       help="Enable verbose mode")
+  parser.add_argument('-d', '--validate_debug_sections', action='store_true', default=False,
+                      help="Validate debug sections as well")
   parser.add_argument('verifier', type=str, help="Verifier path")
   parser.add_argument('folder', type=str, help="Folder with files to verify")
   args = parser.parse_args()
@@ -15,7 +17,13 @@ def main():
   if args.verbose:
     env = os.environ.copy()
     env['VERBOSE'] = '1'
+  if args.validate_debug_sections:
+    if env == None:
+      env = os.environ.copy()
+    env['VALIDATE_DEBUG_SECTIONS'] = '1'
 
+  verified_files = 0
+  failed_files = 0
   for file in os.listdir(args.folder):
     path = os.path.join(args.folder, file)
     argv = [
@@ -36,8 +44,12 @@ def main():
     sys.stdout.write(stdout)
     sys.stderr.write(stderr)
 
+    verified_files += 1
+
     if p.returncode != 0:
-      raise Exception('failed to verify')
+      print('failed to verify {}'.format(file))
+      failed_files += 1
+  print('Done. {}/{} plugins passed verification. {} ({:.02f}%) failed.'.format(verified_files-failed_files, verified_files, failed_files, failed_files/verified_files*100.0))
 
 def DecodeConsoleText(origin, text):
   try:

--- a/vm/AMBuilder
+++ b/vm/AMBuilder
@@ -134,6 +134,9 @@ verifier = configure_like_shell('verifier')
 verifier.sources += [
   '../tools/verifier/verifier.cpp',
 ]
+verifier.compiler.linkflags[0:0] = [
+  SP.libamtl[builder.cxx.target.arch],
+]
 builder.Add(verifier)
 
 rvalue = spshell, libsourcepawn, libsourcepawn_a

--- a/vm/AMBuilder
+++ b/vm/AMBuilder
@@ -66,6 +66,7 @@ library.sources += [
   'plugin-context.cpp',
   'plugin-runtime.cpp',
   'pool-allocator.cpp',
+  'rtti.cpp',
   'runtime-helpers.cpp',
   'scripted-invoker.cpp',
   'smx-v1-image.cpp',

--- a/vm/legacy-image.h
+++ b/vm/legacy-image.h
@@ -52,15 +52,15 @@ class LegacyImage
   virtual bool FindPubvar(const char* name, size_t* indexp) const = 0;
   virtual size_t HeapSize() const = 0;
   virtual size_t ImageSize() const = 0;
-  virtual const char* LookupFile(uint32_t code_offset) = 0;
-  virtual const char* LookupFunction(uint32_t code_offset) = 0;
-  virtual bool LookupLine(uint32_t code_offset, uint32_t* line) = 0;
-  virtual bool LookupFunctionAddress(const char* function, const char* file, ucell_t *addr) = 0;
-  virtual bool LookupLineAddress(const uint32_t line, const char* file, ucell_t* addr) = 0;
+  virtual const char* LookupFile(uint32_t code_offset) const = 0;
+  virtual const char* LookupFunction(uint32_t code_offset) const = 0;
+  virtual bool LookupLine(uint32_t code_offset, uint32_t* line) const = 0;
+  virtual bool LookupFunctionAddress(const char* function, const char* file, ucell_t *addr) const = 0;
+  virtual bool LookupLineAddress(const uint32_t line, const char* file, ucell_t* addr) const = 0;
   virtual size_t NumFiles() const = 0;
   virtual const char* GetFileName(size_t index) const = 0;
   virtual bool HasRtti() const = 0;
-  virtual const smx_rtti_method* GetMethodRttiByOffset(uint32_t pcode_offset) = 0;
+  virtual const smx_rtti_method* GetMethodRttiByOffset(uint32_t pcode_offset) const = 0;
 };
 
 class EmptyImage : public LegacyImage
@@ -120,19 +120,19 @@ class EmptyImage : public LegacyImage
   size_t ImageSize() const override {
     return 0;
   }
-  const char* LookupFile(uint32_t code_offset) override {
+  const char* LookupFile(uint32_t code_offset) const override {
     return nullptr;
   }
-  const char* LookupFunction(uint32_t code_offset) override {
+  const char* LookupFunction(uint32_t code_offset) const override {
     return nullptr;
   }
-  bool LookupLine(uint32_t code_offset, uint32_t* line) override {
+  bool LookupLine(uint32_t code_offset, uint32_t* line) const override {
     return false;
   }
-  bool LookupFunctionAddress(const char* function, const char* file, ucell_t* addr) override {
+  bool LookupFunctionAddress(const char* function, const char* file, ucell_t* addr) const override {
     return false;
   }
-  bool LookupLineAddress(const uint32_t line, const char* file, ucell_t* addr) override {
+  bool LookupLineAddress(const uint32_t line, const char* file, ucell_t* addr) const override {
     return false;
   }
   size_t NumFiles() const override {
@@ -141,7 +141,7 @@ class EmptyImage : public LegacyImage
   const char* GetFileName(size_t index) const override {
     return nullptr;
   }
-  const smx_rtti_method* GetMethodRttiByOffset(uint32_t pcode_offset) override {
+  const smx_rtti_method* GetMethodRttiByOffset(uint32_t pcode_offset) const override {
     return nullptr;
   }
   bool HasRtti() const override {

--- a/vm/rtti.cpp
+++ b/vm/rtti.cpp
@@ -1,0 +1,436 @@
+// vim: set sts=2 ts=8 sw=2 tw=99 et:
+//
+// Copyright (C) 2004-2021 AlliedModers LLC
+//
+// This file is part of SourcePawn. SourcePawn is licensed under the GNU
+// General Public License, version 3.0 (GPL). If a copy of the GPL was not
+// provided with this file, you can obtain it here:
+//   http://www.gnu.org/licenses/gpl.html
+//
+#include "rtti.h"
+#include <smx/smx-typeinfo.h>
+
+using namespace ke;
+using namespace sp::debug;
+
+RttiData::RttiData()
+ : rtti_data_(nullptr),
+   rtti_data_size_(0)
+{
+}
+
+RttiData::RttiData(const uint8_t* blob, uint32_t size)
+ : rtti_data_(blob),
+   rtti_data_size_(size)
+{
+}
+
+const Rtti*
+RttiData::typeFromTypeId(uint32_t type_id) const
+{
+  if (!rtti_data_)
+    return nullptr;
+
+  uint8_t kind = type_id & kMaxTypeIdKind;
+  uint32_t payload = (type_id >> 4) & kMaxTypeIdPayload;
+
+  if (kind == kTypeId_Inline) {
+    uint8_t bytes[4];
+    bytes[0] = (payload >> 0) & 0xff;
+    bytes[1] = (payload >> 8) & 0xff;
+    bytes[2] = (payload >> 16) & 0xff;
+    bytes[3] = (payload >> 24) & 0xff;
+
+    RttiParser parser(bytes, 4, 0);
+    return parser.decodeNew();
+  } else if (kind == kTypeId_Complex) {
+    RttiParser parser(rtti_data_, rtti_data_size_, payload);
+    return parser.decodeNew();
+  }
+  return nullptr;
+}
+
+const Rtti*
+RttiData::functionTypeFromOffset(uint32_t offset) const
+{
+  if (!rtti_data_)
+    return nullptr;
+
+  RttiParser parser(rtti_data_, rtti_data_size_, offset);
+  return parser.decodeFunction();
+}
+
+const Rtti*
+RttiData::typesetTypeFromOffset(uint32_t offset) const
+{
+  if (!rtti_data_)
+    return nullptr;
+
+  RttiParser parser(rtti_data_, rtti_data_size_, offset);
+  return parser.decodeTypeset();
+}
+
+const uint8_t*
+RttiData::blob() const
+{
+  return rtti_data_;
+}
+
+size_t
+RttiData::size() const
+{
+  return rtti_data_size_;
+}
+
+bool
+RttiData::validateType(uint32_t type_id) const
+{
+  uint8_t kind = type_id & kMaxTypeIdKind;
+  uint32_t payload = (type_id >> 4) & kMaxTypeIdPayload;
+  if (kind == kTypeId_Inline) {
+    uint8_t bytes[4];
+    bytes[0] = (payload >> 0) & 0xff;
+    bytes[1] = (payload >> 8) & 0xff;
+    bytes[2] = (payload >> 16) & 0xff;
+    bytes[3] = (payload >> 24) & 0xff;
+
+    RttiParser parser(bytes, 4, 0);
+    return parser.validate();
+  }
+  else if (kind == kTypeId_Complex) {
+    if (payload >= rtti_data_size_)
+      return false;
+
+    RttiParser parser(rtti_data_, rtti_data_size_, payload);
+    return parser.validate();
+  }
+  else
+    return false;
+}
+
+bool
+RttiData::validateFunctionOffset(uint32_t offset) const
+{
+  RttiParser parser(rtti_data_, rtti_data_size_, offset);
+  return parser.validateFunction();
+}
+
+bool
+RttiData::validateTypesetOffset(uint32_t offset) const
+{
+  RttiParser parser(rtti_data_, rtti_data_size_, offset);
+  return parser.validateTypeset();
+}
+
+RttiParser::RttiParser(const uint8_t* bytes, uint32_t length, uint32_t offset)
+ : bytes_(bytes),
+   length_(length),
+   offset_(offset),
+   is_const_(false)
+{
+}
+
+// Decode a type, but reset the |is_const| indicator for non-
+// dependent type.
+Rtti*
+RttiParser::decodeNew()
+{
+  bool was_const = is_const_;
+  is_const_ = false;
+  
+  Rtti* result = decode();
+  if (is_const_)
+    result->setConst();
+
+  is_const_ = was_const;
+  return result;
+}
+
+Rtti*
+RttiParser::decode()
+{
+  is_const_ = match(cb::kConst) || is_const_;
+
+  uint8_t type = bytes_[offset_++];
+  switch (type) {
+  case cb::kBool:
+  case cb::kInt32:
+  case cb::kFloat32:
+  case cb::kChar8:
+  case cb::kAny:
+  case cb::kTopFunction:
+    return new Rtti(type);
+
+  case cb::kFixedArray:
+  {
+    uint32_t size = decodeUint32();
+    Rtti* inner = decode();
+    return new Rtti(type, size, inner);
+  }
+  case cb::kArray:
+  {
+    Rtti* inner = decode();
+    return new Rtti(type, inner);
+  }
+  case cb::kEnum:
+  case cb::kTypedef:
+  case cb::kTypeset:
+  case cb::kClassdef:
+  case cb::kEnumStruct:
+  {
+    uint32_t index = decodeUint32();
+    return new Rtti(type, index);
+  }
+  case cb::kFunction:
+    return decodeFunction();
+  }
+  return nullptr;
+}
+
+Rtti*
+RttiParser::decodeFunction()
+{
+  uint8_t argc = bytes_[offset_++];
+
+  bool variadic = false;
+  if (bytes_[offset_] == cb::kVariadic) {
+    variadic = true;
+    offset_++;
+  }
+
+  Rtti* returnType;
+  if (bytes_[offset_] == cb::kVoid) {
+    returnType = new Rtti(cb::kVoid);
+    offset_++;
+  } else {
+    returnType = decodeNew();
+  }
+
+  Rtti* functionType = new Rtti(returnType, variadic);
+  for (uint8_t i = 0; i < argc; i++) {
+    bool is_by_ref = match(cb::kByRef);
+    Rtti* arg_type = decodeNew();
+    if (is_by_ref)
+      arg_type->setByRef();
+    functionType->addArgument(arg_type);
+  }
+  return functionType;
+}
+
+Rtti*
+RttiParser::decodeTypeset()
+{
+  uint32_t count = decodeUint32();
+  Rtti* typeset = new Rtti(cb::kTypeset);
+
+  for (uint32_t i = 0; i < count; i++) {
+    typeset->addSignature(decodeNew());
+  }
+  return typeset;
+}
+
+bool
+RttiParser::validate()
+{
+  if (offset_ >= length_)
+    return false;
+  // A type can start with a |const| indicator.
+  match(cb::kConst);
+  if (offset_ >= length_)
+    return false;
+  uint8_t type = bytes_[offset_++];
+  switch (type) {
+  case cb::kBool:
+  case cb::kInt32:
+  case cb::kFloat32:
+  case cb::kChar8:
+  case cb::kAny:
+  case cb::kTopFunction:
+    return true;
+
+  case cb::kFixedArray:
+  {
+    // Skip the size.
+    if (!tryDecodeUint32())
+      return false;
+    return validate();
+  }
+  case cb::kArray:
+    return validate();
+
+  case cb::kEnum:
+  case cb::kTypedef:
+  case cb::kTypeset:
+  case cb::kClassdef:
+  case cb::kEnumStruct:
+    // Skip the index.
+    return tryDecodeUint32();
+
+  case cb::kFunction:
+    return validateFunction();
+  }
+  return false;
+}
+
+bool
+RttiParser::validateFunction()
+{
+  // argc available?
+  if (offset_ >= length_)
+    return false;
+
+  uint8_t argc = bytes_[offset_++];
+  if (offset_ >= length_)
+    return false;
+
+  if (bytes_[offset_] == cb::kVariadic)
+    offset_++;
+  if (offset_ >= length_)
+    return false;
+
+  // Validate return type.
+  if (bytes_[offset_] == cb::kVoid)
+    offset_++;
+  else if (!validate())
+    return false;
+
+  for (uint8_t i = 0; i < argc; i++) {
+    if (offset_ >= length_)
+      return false;
+    // A by_ref indicator is allowed here.
+    match(cb::kByRef);
+    if (!validate())
+      return false;
+  }
+  return true;
+}
+
+bool
+RttiParser::validateTypeset()
+{
+  // See if we can decode the count of signatures in this typset.
+  uint32_t old_offset = offset_;
+  if (!tryDecodeUint32())
+    return false;
+
+  // Decode the count now.
+  offset_ = old_offset;
+  uint32_t count = decodeUint32();
+  for (uint32_t i = 0; i < count; i++) {
+    if (!validate())
+      return false;
+  }
+  return true;
+}
+
+bool
+RttiParser::match(uint8_t b)
+{
+  if (bytes_[offset_] != b)
+    return false;
+
+  offset_++;
+  return true;
+}
+
+uint32_t
+RttiParser::decodeUint32()
+{
+  uint32_t value = 0;
+  uint32_t shift = 0;
+  while (true) {
+    uint8_t b = bytes_[offset_++];
+    value |= (b & 0x7f) << shift;
+    if ((b & 0x80) == 0)
+      break;
+    shift += 7;
+  }
+  return value;
+}
+
+bool
+RttiParser::tryDecodeUint32()
+{
+  while (offset_ < length_) {
+    uint8_t b = bytes_[offset_++];
+    if ((b & 0x80) == 0)
+      return true;
+  }
+  return false;
+}
+
+Rtti::Rtti(uint8_t type)
+ : type_(type),
+   index_(0),
+   inner_(nullptr),
+   is_const_(false),
+   is_by_ref_(false),
+   is_variadic_(false)
+{
+}
+
+Rtti::Rtti(uint8_t type, uint32_t size)
+ : type_(type),
+   index_(size),
+   inner_(nullptr),
+   is_const_(false),
+   is_by_ref_(false),
+   is_variadic_(false)
+{
+}
+
+Rtti::Rtti(uint8_t type, Rtti* inner)
+ : type_(type),
+   index_(0),
+   inner_(inner),
+   is_const_(false),
+   is_by_ref_(false),
+   is_variadic_(false)
+{
+}
+
+Rtti::Rtti(uint8_t type, uint32_t size, Rtti* inner)
+ : type_(type),
+   index_(size),
+   inner_(inner),
+   is_const_(false),
+   is_by_ref_(false),
+   is_variadic_(false)
+{
+}
+
+Rtti::Rtti(Rtti* return_type, bool is_variadic)
+ : type_(cb::kFunction),
+   index_(0),
+   inner_(return_type),
+   is_const_(false),
+   is_by_ref_(false),
+   is_variadic_(is_variadic)
+{
+}
+
+void
+Rtti::setConst()
+{
+  is_const_ = true;
+}
+
+void
+Rtti::setByRef()
+{
+  is_by_ref_ = true;
+}
+
+void
+Rtti::addArgument(Rtti* arg)
+{
+  assert(type_ == cb::kFunction);
+  args_.push_back(std::unique_ptr<const Rtti>(arg));
+}
+
+void
+Rtti::addSignature(Rtti* arg)
+{
+  assert(type_ == cb::kTypeset);
+  args_.push_back(std::unique_ptr<const Rtti>(arg));
+}

--- a/vm/rtti.h
+++ b/vm/rtti.h
@@ -1,0 +1,120 @@
+// vim: set sts=2 ts=8 sw=2 tw=99 et:
+//
+// Copyright (C) 2004-2021 AlliedModers LLC
+//
+// This file is part of SourcePawn. SourcePawn is licensed under the GNU
+// General Public License, version 3.0 (GPL). If a copy of the GPL was not
+// provided with this file, you can obtain it here:
+//   http://www.gnu.org/licenses/gpl.html
+//
+#ifndef _include_sourcepawn_rtti_h_
+#define _include_sourcepawn_rtti_h_
+
+#include <memory>
+#include <vector>
+
+#include <sp_vm_types.h>
+#include <amtl/am-hashmap.h>
+
+namespace sp {
+namespace debug {
+
+class Rtti;
+
+class RttiData {
+public:
+  RttiData();
+  RttiData(const uint8_t* blob, uint32_t size);
+
+  const Rtti* typeFromTypeId(uint32_t type_id) const;
+  const Rtti* functionTypeFromOffset(uint32_t offset) const;
+  const Rtti* typesetTypeFromOffset(uint32_t offset) const;
+
+  const uint8_t* blob() const;
+  size_t size() const;
+
+  bool validateType(uint32_t type_id) const;
+  bool validateFunctionOffset(uint32_t offset) const;
+  bool validateTypesetOffset(uint32_t offset) const;
+
+private:
+  const uint8_t* rtti_data_;
+  uint32_t rtti_data_size_;
+};
+
+class RttiParser {
+public:
+  RttiParser(const uint8_t* bytes, uint32_t length, uint32_t offset);
+
+  Rtti* decodeNew();
+  Rtti* decodeFunction();
+  Rtti* decodeTypeset();
+
+  bool validate();
+  bool validateFunction();
+  bool validateTypeset();
+
+private:
+  Rtti* decode();
+  bool match(uint8_t b);
+  uint32_t decodeUint32();
+  bool tryDecodeUint32();
+
+private:
+  const uint8_t* bytes_;
+  uint32_t length_;
+  uint32_t offset_;
+  bool is_const_;
+};
+
+class Rtti {
+public:
+  Rtti(uint8_t type);
+  Rtti(uint8_t type, uint32_t index);
+  Rtti(uint8_t type, Rtti* inner);
+  Rtti(uint8_t type, uint32_t index, Rtti* inner);
+  Rtti(Rtti* return_type, bool variadic);
+
+  void setConst();
+  void setByRef();
+  void addArgument(Rtti* arg);
+  void addSignature(Rtti* signature);
+
+public:
+  bool isConst() const {
+    return is_const_;
+  }
+  bool isByRef() const {
+    return is_by_ref_;
+  }
+  uint8_t type() const {
+    return type_;
+  }
+  const uint32_t index() const {
+    return index_;
+  }
+  const Rtti* inner() const {
+    return inner_.get();
+  }
+  bool isVariadic() const {
+    return is_variadic_;
+  }
+
+private:
+  uint8_t type_;
+  uint32_t index_;
+  std::unique_ptr<const Rtti> inner_;
+  bool is_const_;
+
+  // Arguments
+  bool is_by_ref_;
+
+  // Function type only
+  std::vector<std::unique_ptr<const Rtti>> args_;
+  bool is_variadic_;
+};
+
+} // namespace debug
+} // namespace sp
+
+#endif // _include_sourcepawn_rtti_h_

--- a/vm/shell.cpp
+++ b/vm/shell.cpp
@@ -316,6 +316,10 @@ int main(int argc, char** argv)
     "p", "jitdump",
     Some(false),
     "Enable perf metadata recording for profiling.");
+  ToggleOption validate_debug_sections(parser,
+    "d", "validate-debug-sections",
+    Some(false),
+    "Validate debug sections before loading the plugin. Enables line debugging in the runtime, which might slow down execution.");
   StringOption filename(parser,
     "file",
     "SMX file to execute.");
@@ -345,6 +349,9 @@ int main(int argc, char** argv)
 
   if (getenv("DISABLE_JIT") || disable_jit.value())
     sEnv->SetJitEnabled(false);
+
+  if (getenv("VALIDATE_DEBUG_SECTIONS") || validate_debug_sections.value())
+    sEnv->EnableDebugBreak();
 
   ShellDebugListener debug;
   sEnv->SetDebugger(&debug);

--- a/vm/smx-v1-image.cpp
+++ b/vm/smx-v1-image.cpp
@@ -184,7 +184,7 @@ SmxV1Image::validate()
 }
 
 const SmxV1Image::Section*
-SmxV1Image::findSection(const char* name)
+SmxV1Image::findSection(const char* name) const
 {
   for (size_t i = 0; i < sections_.size(); i++) {
     if (strcmp(sections_[i].name, name) == 0)
@@ -194,7 +194,7 @@ SmxV1Image::findSection(const char* name)
 }
 
 bool
-SmxV1Image::validateSection(const Section* section)
+SmxV1Image::validateSection(const Section* section) const
 {
   if (section->dataoffs >= length_)
     return false;
@@ -204,7 +204,7 @@ SmxV1Image::validateSection(const Section* section)
 }
 
 bool
-SmxV1Image::validateRttiHeader(const Section* section)
+SmxV1Image::validateRttiHeader(const Section* section) const
 {
   if (!validateSection(section))
     return false;
@@ -363,7 +363,7 @@ SmxV1Image::validateNatives()
 }
 
 bool
-SmxV1Image::validateName(size_t offset)
+SmxV1Image::validateName(size_t offset) const
 {
   return offset < names_section_->size;
 }
@@ -925,7 +925,7 @@ SmxV1Image::ImageSize() const
 }
 
 const char*
-SmxV1Image::LookupFile(uint32_t addr)
+SmxV1Image::LookupFile(uint32_t addr) const
 {
   int high = debug_files_.length();
   int low = -1;
@@ -948,7 +948,7 @@ SmxV1Image::LookupFile(uint32_t addr)
 
 template <typename SymbolType, typename DimType>
 const char*
-SmxV1Image::lookupFunction(const SymbolType* syms, uint32_t addr)
+SmxV1Image::lookupFunction(const SymbolType* syms, uint32_t addr) const
 {
   const uint8_t* cursor = reinterpret_cast<const uint8_t*>(syms);
   const uint8_t* cursor_end = cursor + debug_symbols_section_->size;
@@ -974,7 +974,7 @@ SmxV1Image::lookupFunction(const SymbolType* syms, uint32_t addr)
 }
 
 const char*
-SmxV1Image::LookupFunction(uint32_t code_offset)
+SmxV1Image::LookupFunction(uint32_t code_offset) const
 {
   if (auto method = GetMethodRttiByOffset(code_offset))
     return names_ + method->name;
@@ -1006,7 +1006,7 @@ SmxV1Image::HasRtti() const
 }
 
 const smx_rtti_method*
-SmxV1Image::GetMethodRttiByOffset(uint32_t pcode_offset)
+SmxV1Image::GetMethodRttiByOffset(uint32_t pcode_offset) const
 {
   if (!rtti_methods_)
     return nullptr;
@@ -1020,7 +1020,7 @@ SmxV1Image::GetMethodRttiByOffset(uint32_t pcode_offset)
 }
 
 bool
-SmxV1Image::LookupLine(uint32_t addr, uint32_t* line)
+SmxV1Image::LookupLine(uint32_t addr, uint32_t* line) const
 {
   int high = debug_lines_.length();
   int low = -1;
@@ -1061,7 +1061,7 @@ SmxV1Image::GetFileName(size_t index) const
 
 template <typename SymbolType, typename DimType>
 bool
-SmxV1Image::getFunctionAddress(const SymbolType* syms, const char* function, ucell_t* funcaddr, uint32_t& index)
+SmxV1Image::getFunctionAddress(const SymbolType* syms, const char* function, ucell_t* funcaddr, uint32_t& index) const
 {
   const uint8_t* cursor = reinterpret_cast<const uint8_t *>(syms);
   const uint8_t* cursor_end = cursor + debug_symbols_section_->size;
@@ -1086,7 +1086,7 @@ SmxV1Image::getFunctionAddress(const SymbolType* syms, const char* function, uce
 }
 
 bool
-SmxV1Image::LookupFunctionAddress(const char* function, const char* file, ucell_t* funcaddr)
+SmxV1Image::LookupFunctionAddress(const char* function, const char* file, ucell_t* funcaddr) const
 {
   *funcaddr = 0;
   if (rtti_methods_) {
@@ -1137,7 +1137,7 @@ SmxV1Image::LookupFunctionAddress(const char* function, const char* file, ucell_
 }
 
 bool
-SmxV1Image::LookupLineAddress(const uint32_t line, const char* filename, uint32_t* addr)
+SmxV1Image::LookupLineAddress(const uint32_t line, const char* filename, uint32_t* addr) const
 {
   // Find a suitable "breakpoint address" close to the indicated line (and in
   // the specified file). The address is moved up to the next "breakable" line

--- a/vm/smx-v1-image.h
+++ b/vm/smx-v1-image.h
@@ -200,7 +200,15 @@ class SmxV1Image
   bool validatePubvars();
   bool validateNatives();
   bool validateRtti();
+  bool validateRttiClassdefs();
+  bool validateRttiEnums();
+  bool validateRttiEnumStructs();
+  bool validateRttiEnumStructField(const smx_rtti_enumstruct* enumstruct, uint32_t index);
+  bool validateRttiField(uint32_t index);
   bool validateRttiMethods();
+  bool validateRttiNatives();
+  bool validateRttiTypedefs();
+  bool validateRttiTypesets();
   bool validateDebugInfo();
   bool validateTags();
 
@@ -250,7 +258,15 @@ class SmxV1Image
   const sp_u_fdbg_symbol_t* debug_syms_unpacked_ = nullptr;
 
   std::unique_ptr<const RttiData> rtti_data_ = nullptr;
+  const smx_rtti_table_header* rtti_classdefs_ = nullptr;
+  const smx_rtti_table_header* rtti_enums_ = nullptr;
+  const smx_rtti_table_header* rtti_enumstructs_ = nullptr;
+  const smx_rtti_table_header* rtti_enumstruct_fields_ = nullptr;
+  const smx_rtti_table_header* rtti_fields_ = nullptr;
   const smx_rtti_table_header* rtti_methods_ = nullptr;
+  const smx_rtti_table_header* rtti_natives_ = nullptr;
+  const smx_rtti_table_header* rtti_typedefs_ = nullptr;
+  const smx_rtti_table_header* rtti_typesets_ = nullptr;
 };
 
 } // namespace sp

--- a/vm/smx-v1-image.h
+++ b/vm/smx-v1-image.h
@@ -62,15 +62,15 @@ class SmxV1Image
   bool FindPubvar(const char* name, size_t* indexp) const override;
   size_t HeapSize() const override;
   size_t ImageSize() const override;
-  const char* LookupFile(uint32_t code_offset) override;
-  const char* LookupFunction(uint32_t code_offset) override;
-  bool LookupLine(uint32_t code_offset, uint32_t* line) override;
-  bool LookupFunctionAddress(const char* function, const char* file, ucell_t* addr) override;
-  bool LookupLineAddress(const uint32_t line, const char* file, ucell_t* addr) override;
+  const char* LookupFile(uint32_t code_offset) const override;
+  const char* LookupFunction(uint32_t code_offset) const override;
+  bool LookupLine(uint32_t code_offset, uint32_t* line) const override;
+  bool LookupFunctionAddress(const char* function, const char* file, ucell_t* addr) const override;
+  bool LookupLineAddress(const uint32_t line, const char* file, ucell_t* addr) const override;
   size_t NumFiles() const override;
   const char* GetFileName(size_t index) const override;
   bool HasRtti() const override;
-  const smx_rtti_method* GetMethodRttiByOffset(uint32_t pcode_offset) override;
+  const smx_rtti_method* GetMethodRttiByOffset(uint32_t pcode_offset) const override;
 
  private:
   SmxV1Image();
@@ -81,7 +81,7 @@ class SmxV1Image
     uint32_t dataoffs;
     uint32_t size;
   };
-  const Section* findSection(const char* name);
+  const Section* findSection(const char* name) const;
 
  public:
   template <typename T>
@@ -191,9 +191,9 @@ class SmxV1Image
     error_ = msg;
     return false;
   }
-  bool validateName(size_t offset);
-  bool validateSection(const Section* section);
-  bool validateRttiHeader(const Section* section);
+  bool validateName(size_t offset) const;
+  bool validateSection(const Section* section) const;
+  bool validateRttiHeader(const Section* section) const;
   bool validateCode();
   bool validateData();
   bool validatePublics();
@@ -217,11 +217,11 @@ class SmxV1Image
 
  private:
   template <typename SymbolType, typename DimType>
-  const char* lookupFunction(const SymbolType* syms, uint32_t addr);
+  const char* lookupFunction(const SymbolType* syms, uint32_t addr) const;
   template <typename SymbolType, typename DimType>
-  bool getFunctionAddress(const SymbolType* syms, const char* function, ucell_t* funcaddr, uint32_t& index);
+  bool getFunctionAddress(const SymbolType* syms, const char* function, ucell_t* funcaddr, uint32_t& index) const;
 
-  const smx_rtti_table_header* findRttiSection(const char* name) {
+  const smx_rtti_table_header* findRttiSection(const char* name) const {
     const Section* section = findSection(name);
     if (!section)
       return nullptr;
@@ -233,7 +233,7 @@ class SmxV1Image
   }
 
   template <typename T>
-  const T* getRttiRow(const smx_rtti_table_header* header, size_t index) {
+  const T* getRttiRow(const smx_rtti_table_header* header, size_t index) const {
     assert(index < header->row_count);
     const uint8_t* base = reinterpret_cast<const uint8_t*>(header) + header->header_size;
     return reinterpret_cast<const T*>(base + header->row_size * index);

--- a/vm/smx-v1-image.h
+++ b/vm/smx-v1-image.h
@@ -210,6 +210,9 @@ class SmxV1Image
   bool validateRttiTypedefs();
   bool validateRttiTypesets();
   bool validateDebugInfo();
+  bool validateDebugVariables(const smx_rtti_table_header* rtti_table);
+  bool validateDebugMethods();
+  bool validateSymbolAddress(int32_t address, uint8_t vclass);
   bool validateTags();
 
  private:
@@ -222,6 +225,10 @@ class SmxV1Image
     const Section* section = findSection(name);
     if (!section)
       return nullptr;
+    return reinterpret_cast<const smx_rtti_table_header*>(buffer() + section->dataoffs);
+  }
+
+  const smx_rtti_table_header* toRttiTable(const Section* section) const {
     return reinterpret_cast<const smx_rtti_table_header*>(buffer() + section->dataoffs);
   }
 
@@ -267,6 +274,9 @@ class SmxV1Image
   const smx_rtti_table_header* rtti_natives_ = nullptr;
   const smx_rtti_table_header* rtti_typedefs_ = nullptr;
   const smx_rtti_table_header* rtti_typesets_ = nullptr;
+  const smx_rtti_table_header* rtti_dbg_globals_ = nullptr;
+  const smx_rtti_table_header* rtti_dbg_methods_ = nullptr;
+  const smx_rtti_table_header* rtti_dbg_locals_ = nullptr;
 };
 
 } // namespace sp

--- a/vm/smx-v1-image.h
+++ b/vm/smx-v1-image.h
@@ -20,8 +20,13 @@
 #include <sp_vm_types.h>
 #include "file-utils.h"
 #include "legacy-image.h"
+#include "rtti.h"
+
+#include <memory>
 
 namespace sp {
+
+using namespace debug;
 
 class SmxV1Image
   : public FileReader,
@@ -177,6 +182,9 @@ class SmxV1Image
   const List<sp_file_pubvars_t>& pubvars() const {
     return pubvars_;
   }
+  const RttiData* rttidata() const {
+    return rtti_data_.get();
+  }
 
  protected:
   bool error(const char* msg) {
@@ -241,7 +249,7 @@ class SmxV1Image
   const sp_fdbg_symbol_t* debug_syms_ = nullptr;
   const sp_u_fdbg_symbol_t* debug_syms_unpacked_ = nullptr;
 
-  const Section* rtti_data_ = nullptr;
+  std::unique_ptr<const RttiData> rtti_data_ = nullptr;
   const smx_rtti_table_header* rtti_methods_ = nullptr;
 };
 


### PR DESCRIPTION
This loads and validates all available `rtti.*` sections in the binary.

The new `.dbg.*` sections are only validated if the line debugger was enabled using `ISourcePawnEnvironment::EnableDebugBreak()` which isn't called in SourceMod yet.

The legacy `.dbg.symbols` section isn't parsed (yet?).

It's the first step to expose a symbol access API in the VM to implement an useful plugin debugger (ref #539).