### PR TITLE
Fix parsing of bad arguments (issue #701)

### DIFF
--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -1882,7 +1882,8 @@ Parser::parse_args(FunctionInfo* info)
         auto pos = lexer_->pos();
 
         declinfo_t decl = {};
-        parse_decl(&decl, DECLFLAG_ARGUMENT | DECLFLAG_ENUMROOT);
+        if (!parse_decl(&decl, DECLFLAG_ARGUMENT | DECLFLAG_ENUMROOT))
+            continue;
 
         if (decl.type.ident == iVARARGS) {
             if (info->IsVariadic())

--- a/tests/compile-only/fail-issue701.sp
+++ b/tests/compile-only/fail-issue701.sp
@@ -1,0 +1,4 @@
+public void Test(const[] char test) // Expected compiler error, instead compiler freezes.
+{
+// Same happens with "const[] int test"
+}

--- a/tests/compile-only/fail-issue701.txt
+++ b/tests/compile-only/fail-issue701.txt
@@ -1,0 +1,1 @@
+(1) : error 122: expected type expression


### PR DESCRIPTION
Not sure if this should `continue` or `return` or if it makes a difference.