### PR TITLE
Remove preprocessor level limits.

### DIFF
--- a/compiler/lexer.h
+++ b/compiler/lexer.h
@@ -369,10 +369,10 @@ class Lexer
     ke::HashMap<sp::CharsAndLength, int, KeywordTablePolicy> keywords_;
     short icomment_; /* currently in multiline comment? */
     std::vector<short> comment_stack_;
-    std::vector<short> preproc_if_stack_;
-    char ifstack_[sCOMP_STACK]; /* "#if" stack */
-    short iflevel_;             /* nesting level if #if/#else/#endif */
-    short skiplevel_; /* level at which we started skipping (including nested #if .. #endif) */
+    std::vector<size_t> preproc_if_stack_;
+    std::vector<char> ifstack_;
+    size_t iflevel_;             /* nesting level if #if/#else/#endif */
+    size_t skiplevel_; /* level at which we started skipping (including nested #if .. #endif) */
     int listline_ = -1; /* "current line" for the list file */
     int lexnewline_;
     std::string deprecate_;

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -57,7 +57,6 @@ typedef uint32_t ucell;
 #define PUBLIC_CHAR '@' /* character that defines a function "public" */
 #define sCHARBITS 8     /* size of a packed character */
 
-#define sCOMP_STACK 32     /* maximum nesting of #if .. #endif sections */
 #define sLINEMAX 4095
 #define PREPROC_TERM \
     '\x7f' /* termination character for preprocessor expressions (the "DEL" code) */


### PR DESCRIPTION
We can remove an arbitrary hardcoded limit, a fatal error path, and
simplify some data structures at the same time.