### PR TITLE
Remove setjmp/longjmp.

### DIFF
--- a/compiler/assembler.h
+++ b/compiler/assembler.h
@@ -30,7 +30,7 @@
 #include "shared/byte-buffer.h"
 #include "shared/string-pool.h"
 
-void assemble(CompileContext& cc, CodeGenerator& cg, const char* outname,
+bool assemble(CompileContext& cc, CodeGenerator& cg, const char* outname,
               int compression_level);
 
 class Assembler

--- a/compiler/compile-context.h
+++ b/compiler/compile-context.h
@@ -20,8 +20,6 @@
 //  3.  This notice may not be removed or altered from any source distribution.
 #pragma once
 
-#include <setjmp.h>
-
 #include <memory>
 #include <string>
 #include <unordered_set>
@@ -88,7 +86,9 @@ class CompileContext final
     std::shared_ptr<SourceFile> inpf_org() const { return inpf_org_; }
     void set_inpf_org(std::shared_ptr<SourceFile> sf) { inpf_org_ = sf; }
 
-    jmp_buf* errbuf() { return &errbuf_; }
+    bool must_abort() const { return must_abort_; }
+    void set_must_abort() { must_abort_ = true; }
+
     PoolAllocator& allocator() { return allocator_; }
 
     // No copy construction.
@@ -119,10 +119,12 @@ class CompileContext final
     bool shutting_down_ = false;
     bool one_error_per_stmt_ = false;
     std::unique_ptr<ReportManager> reports_;
-    jmp_buf errbuf_;
 
     // Skip the verify step.
     bool verify_output_ = true;
+
+    // Indicates that compilation must abort immediately.
+    bool must_abort_ = false;
 
     SemaContext* sc_ = nullptr;
 };

--- a/compiler/errors.h
+++ b/compiler/errors.h
@@ -38,8 +38,7 @@ class ParseNode;
 enum class ErrorType {
     Suppressed,
     Warning,
-    Error,
-    Fatal
+    Error
 };
 
 struct ErrorReport {
@@ -52,27 +51,6 @@ struct ErrorReport {
     std::string filename;
     std::string message;
     ErrorType type;
-};
-
-enum FatalError {
-    FIRST_FATAL_ERROR = 300,
-
-    FATAL_ERROR_READ = FIRST_FATAL_ERROR,
-    FATAL_ERROR_WRITE,
-    FATAL_ERROR_ALLOC_OVERFLOW,
-    FATAL_ERROR_OOM,
-    FATAL_ERROR_INVALID_INSN,
-    FATAL_ERROR_INT_OVERFLOW,
-    FATAL_ERROR_SCRIPT_OVERFLOW,
-    FATAL_ERROR_OVERWHELMED_BY_BAD,
-    FATAL_ERROR_NO_CODEPAGE,
-    FATAL_ERROR_INVALID_PATH,
-    FATAL_ERROR_ASSERTION_FAILED,
-    FATAL_ERROR_USER_ERROR,
-    FATAL_ERROR_NO_GENERATED_CODE,
-    FATAL_ERROR_FUNCENUM,
-
-    FATAL_ERRORS_TOTAL
 };
 
 class ReportManager;
@@ -200,6 +178,9 @@ class ReportManager
     // suppress generating a report if there are too many errors on one
     // line.
     unsigned int total_errors_ = 0;
+
+    // This is the actual # of reported errors.
+    size_t total_reported_errors_ = 0;
 };
 
 class AutoCountErrors

--- a/compiler/messages.h
+++ b/compiler/messages.h
@@ -224,32 +224,6 @@ static const char* errmsg[] = {
     /*185*/ "invalid default array initializer\n",
 };
 
-static const char* fatalmsg[] = {
-    /*300*/ "cannot read from file: \"%s\"\n",
-    /*301*/ "cannot write to file: \"%s\"\n",
-    /*302*/ "table overflow: \"%s\"\n",
-    /* table can be: loop table
-           *               literal table
-           *               staging buffer
-           *               option table (response file)
-           *               peephole optimizer table
-           */
-    /*303*/ "insufficient memory\n",
-    /*304*/ "invalid assembler instruction \"%s\"\n",
-    /*305*/ "numeric overflow, exceeding capacity\n",
-    /*306*/ "compiled script exceeds the maximum memory size (%ld bytes)\n",
-    /*307*/ "too many error messages on one line\n",
-    /*308*/ "codepage mapping file not found\n",
-    /*309*/ "invalid path: \"%s\"\n",
-    /*310*/ "assertion failed: %s\n",
-    /*311*/ "user error: %s\n",
-    /*312*/ "compiler bug: calling stock \"%s\" that has no generated code\n",
-    /*313*/
-    "deprecated syntax; see https://wiki.alliedmods.net/SourcePawn_Transitional_Syntax#Typedefs\n",
-    /*314*/ "only one source file can be specified at a time\n",
-    /*315*/ "unhandled AST type: %d\n",
-};
-
 static const char* warnmsg[] = {
     /*200*/ "symbol \"%s\" is truncated to %d characters\n",
     /*201*/ "redefinition of constant/macro (symbol \"%s\")\n",
@@ -318,4 +292,9 @@ static const char* errmsg_ex[] = {
     /*412*/ "function %s implements a forward but is not marked as public\n",
     /*413*/ "returned array does not have the same dimension count as return type\n",
     /*414*/ "include statements are only allowed at the top-level scope\n",
+    /*415*/ "assertion failed: %s\n",
+    /*416*/ "user error: %s\n",
+    /*417*/ "cannot read from file: \"%s\"\n",
+    /*418*/ "deprecated syntax; see https://wiki.alliedmods.net/SourcePawn_Transitional_Syntax#Typedefs\n",
+    /*419*/ "cannot write to file: \"%s\"\n",
 };

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -68,7 +68,7 @@ Parser::Parse()
     lexer_->Start();
 
     std::deque<Stmt*> add_to_end;
-    while (lexer_->freading()) {
+    while (lexer_->freading() && !cc_.must_abort()) {
         Stmt* decl = nullptr;
 
         int tok = lexer_->lex();
@@ -117,7 +117,7 @@ Parser::Parse()
                 break;
             case tFUNCENUM:
             case tFUNCTAG:
-                error(FATAL_ERROR_FUNCENUM);
+                report(418);
                 break;
             case tTYPEDEF:
                 decl = parse_typedef();
@@ -155,7 +155,7 @@ Parser::Parse()
                 auto name = lexer_->current_token()->data;
                 auto result = lexer_->PlungeFile(name.c_str() + 1, (name[0] != '<'), TRUE);
                 if (!result && tok != tpTRYINCLUDE)
-                    report(FATAL_ERROR_READ) << name.substr(1);
+                    report(417) << name.substr(1);
 
                 int fcurrent = lexer_->fcurrent();
                 static_scopes_.emplace_back(new SymbolScope(cc_.globals(), sFILE_STATIC, fcurrent));
@@ -1547,7 +1547,9 @@ Parser::parse_compound(bool sameline)
     }
 
     int indent = -1;
-    while (lexer_->match('}') == 0) { /* repeat until compound statement is closed */
+
+    /* repeat until compound statement is closed */
+    while (lexer_->match('}') == 0 && !cc_.must_abort()) {
         if (!lexer_->freading()) {
             error(30, block_start); /* compound block not closed at end of file */
             break;

--- a/tests/compile-only/fail-funcenum.txt
+++ b/tests/compile-only/fail-funcenum.txt
@@ -1,1 +1,1 @@
-(1) : fatal error 313: deprecated syntax; see https://wiki.alliedmods.net/SourcePawn_Transitional_Syntax#Typedefs
+(1) : error 418: deprecated syntax; see https://wiki.alliedmods.net/SourcePawn_Transitional_Syntax#Typedefs

--- a/tests/compile-only/fail-functag.txt
+++ b/tests/compile-only/fail-functag.txt
@@ -1,1 +1,1 @@
-(1) : fatal error 313: deprecated syntax; see https://wiki.alliedmods.net/SourcePawn_Transitional_Syntax#Typedefs
+(1) : error 418: deprecated syntax; see https://wiki.alliedmods.net/SourcePawn_Transitional_Syntax#Typedefs


### PR DESCRIPTION
setjmp and longjmp can be used as an old-school exception handling
method in C programs. In C++ they're rarely used since they do not
trigger destructors.

Removing these calls makes spcomp more embeddable. We can also take the
opportunity to clean up one of the weirder paths still remaining in the
compiler: fatal errors. These abort the compiler immediately. It's a
little tricky to mimic this without longjmp, and we cannot use C++
exceptions in our code. It's also tricky to propagate fatal errors out
of the lexer, since it can be called from pretty much anywhere.

Instead, we just remove the concept of a fatal error. The only scenario
it really helps with is when we're overwhelmed with errors, and we can
sort of retain this by periodically checking if we should stop parsing.