### PR TITLE
Build a big ol' binary.

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -1,18 +1,18 @@
-# vim: set ts=2 sw=2 tw=99 et ft=python:
-# 
+# vim: set ts=4 sw=4 tw=99 et ft=python:
+#
 # Copyright (C) 2004-2012 David Anderson
-# 
+#
 # This file is part of SourcePawn.
-# 
+#
 # SourcePawn is free software: you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free
 # Software Foundation, either version 3 of the License, or (at your option)
 # any later version.
-# 
+#
 # SourcePawn is distributed in the hope that it will be useful, but WITHOUT ANY
 # WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License along with
 # SourcePawn. If not, see http://www.gnu.org/licenses/.
 #
@@ -21,462 +21,471 @@ import os
 import subprocess
 import sys
 
+
 def Normalize(path):
-  return os.path.abspath(os.path.normpath(path))
+    return os.path.abspath(os.path.normpath(path))
+
 
 def SetArchFlags(compiler):
-  if compiler.like('gcc'):
-    if compiler.target.arch == 'x86':
-      if not compiler.like('emscripten'):
-        compiler.cflags += ['-msse']
-    else:
-      compiler.cflags += ['-fPIC']
+    if compiler.like('gcc'):
+        if compiler.target.arch == 'x86':
+            if not compiler.like('emscripten'):
+                compiler.cflags += ['-msse']
+        else:
+            compiler.cflags += ['-fPIC']
+
 
 class Config(object):
-  def __init__(self):
-    super(Config, self).__init__()
-    self.enable_coverage = getattr(builder.options, 'enable_coverage', False)
-    self.enable_asan = getattr(builder.options, 'enable_asan', False)
-    self.targets = []
-    self.asan_libs = {}
+    def __init__(self):
+        super(Config, self).__init__()
+        self.enable_coverage = getattr(builder.options, 'enable_coverage', False)
+        self.enable_asan = getattr(builder.options, 'enable_asan', False)
+        self.targets = []
+        self.asan_libs = {}
 
-  def configure(self):
-    if builder.options.targets:
-        targets = builder.options.targets.split(',')
+    def configure(self):
+        if builder.options.targets:
+            targets = builder.options.targets.split(',')
 
-        dupes = set()
-        for target in targets:
-            if target in dupes:
-                continue
-            dupes.add(target)
+            dupes = set()
+            for target in targets:
+                if target in dupes:
+                    continue
+                dupes.add(target)
 
-            cxx = builder.DetectCxx(target = target)
+                cxx = builder.DetectCxx(target=target)
+                self.configure_cxx(cxx)
+                self.targets.append(cxx)
+        else:
+            cxx = builder.DetectCxx()
             self.configure_cxx(cxx)
             self.targets.append(cxx)
-    else:
-        cxx = builder.DetectCxx()
-        self.configure_cxx(cxx)
-        self.targets.append(cxx)
 
-  def configure_cxx(self, cxx):
-    if cxx.like('gcc'):
-      self.configure_gcc(cxx)
-    elif cxx.like('msvc'):
-      self.configure_msvc(cxx)
+    def configure_cxx(self, cxx):
+        if cxx.like('gcc'):
+            self.configure_gcc(cxx)
+        elif cxx.like('msvc'):
+            self.configure_msvc(cxx)
 
-    # Optimization
-    if builder.options.opt == '1':
-      cxx.defines += ['NDEBUG']
-      if cxx.like('gcc'):
-        if self.enable_asan:
-          cxx.cflags += ['-O1']
+        # Optimization
+        if builder.options.opt == '1':
+            cxx.defines += ['NDEBUG']
+            if cxx.like('gcc'):
+                if self.enable_asan:
+                    cxx.cflags += ['-O1']
+                else:
+                    cxx.cflags += ['-O3']
+                if cxx.like('emscripten'):
+                    emflags = ['--closure', '1', '-flto', '--llvm-lto', '1']
+                    cxx.cflags += emflags
+                    cxx.linkflags += ['-O3'] + emflags
+            elif cxx.like('msvc'):
+                cxx.cflags += ['/Ox']
+                cxx.linkflags += ['/OPT:ICF', '/OPT:REF']
+
+        # Debugging
+        if builder.options.debug == '1':
+            cxx.defines += ['DEBUG', '_DEBUG']
+            if cxx.like('msvc'):
+                cxx.cflags += ['/Od', '/RTC1']
+            elif cxx.like('emscripten'):
+                emflags = [
+                    '-s', 'ASSERTIONS=2', '-s', 'SAFE_HEAP=1', '-s', 'STACK_OVERFLOW_CHECK=2', '-s',
+                    'DEMANGLE_SUPPORT=1'
+                ]
+                cxx.cflags += emflags
+                cxx.linkflags += emflags
+
+        # This needs to be after our optimization flags which could otherwise disable it.
+        if cxx.like('msvc'):
+            # Don't omit the frame pointer.
+            cxx.cflags += ['/Oy-']
+
+        # Platform-specifics
+        if not cxx.like('emscripten'):
+            if cxx.target.platform == 'linux':
+                cxx.postlink += ['-lpthread', '-lrt']
+            elif cxx.target.platform == 'mac':
+                cxx.linkflags.remove('-lstdc++')
+                cxx.cflags += ['-mmacosx-version-min=10.7']
+                cxx.cflags += ['-stdlib=libc++']
+                cxx.linkflags += ['-stdlib=libc++']
+                cxx.linkflags += ['-mmacosx-version-min=10.7']
+            elif cxx.target.platform == 'windows':
+                cxx.defines += ['WIN32', '_WINDOWS']
+                cxx.cxxdefines += ['NOMINMAX']
+
+        cxx.defines += ['KE_THREADSAFE']
+        cxx.defines += ['SOURCEPAWN_VERSION="1.11"']
+
+        if getattr(builder.options, 'enable_spew', False):
+            cxx.defines += ['JIT_SPEW']
+
+        if builder.options.amtl:
+            amtl_path = builder.options.amtl
         else:
-          cxx.cflags += ['-O3']
-        if cxx.like('emscripten'):
-          emflags = ['--closure', '1', '-flto', '--llvm-lto', '1']
-          cxx.cflags += emflags
-          cxx.linkflags += ['-O3'] + emflags
-      elif cxx.like('msvc'):
-        cxx.cflags += ['/Ox']
-        cxx.linkflags += ['/OPT:ICF', '/OPT:REF']
+            amtl_path = os.path.join(builder.sourcePath, 'third_party', 'amtl')
 
-    # Debugging
-    if builder.options.debug == '1':
-      cxx.defines += ['DEBUG', '_DEBUG']
-      if cxx.like('msvc'):
-        cxx.cflags += ['/Od', '/RTC1']
-      elif cxx.like('emscripten'):
-        emflags = ['-s', 'ASSERTIONS=2', '-s', 'SAFE_HEAP=1', '-s', 'STACK_OVERFLOW_CHECK=2', '-s', 'DEMANGLE_SUPPORT=1']
-        cxx.cflags += emflags
-        cxx.linkflags += emflags
+        amtl_path = Normalize(amtl_path)
+        if not os.path.isdir(amtl_path):
+            raise Exception('Could not find AMTL at: {0}'.format(amtl_path))
+        self.amtl = amtl_path
 
-    # This needs to be after our optimization flags which could otherwise disable it.
-    if cxx.like('msvc'):
-      # Don't omit the frame pointer.
-      cxx.cflags += ['/Oy-']
-
-    # Platform-specifics
-    if not cxx.like('emscripten'):
-      if cxx.target.platform == 'linux':
-        cxx.postlink += ['-lpthread', '-lrt']
-      elif cxx.target.platform == 'mac':
-        cxx.linkflags.remove('-lstdc++')
-        cxx.cflags += ['-mmacosx-version-min=10.7']
-        cxx.cflags += ['-stdlib=libc++']
-        cxx.linkflags += ['-stdlib=libc++']
-        cxx.linkflags += ['-mmacosx-version-min=10.7']
-      elif cxx.target.platform == 'windows':
-        cxx.defines += ['WIN32', '_WINDOWS']
-        cxx.cxxdefines += ['NOMINMAX']
-
-    cxx.defines += ['KE_THREADSAFE']
-    cxx.defines += ['SOURCEPAWN_VERSION="1.11"']
-
-    if getattr(builder.options, 'enable_spew', False):
-      cxx.defines += ['JIT_SPEW']
-
-    if builder.options.amtl:
-      amtl_path = builder.options.amtl
-    else:
-      amtl_path = os.path.join(builder.sourcePath, 'third_party', 'amtl')
-
-    amtl_path = Normalize(amtl_path)
-    if not os.path.isdir(amtl_path):
-      raise Exception('Could not find AMTL at: {0}'.format(amtl_path))
-    self.amtl = amtl_path
-
-    cxx.cxxincludes += [
-      self.amtl,
-      os.path.join(builder.sourcePath, 'include'),
-    ]
-
-    if cxx.target.platform == 'linux':
-      cxx.defines += ['_GNU_SOURCE']
-    elif cxx.target.platform == 'mac':
-      cxx.defines += ['DARWIN']
-
-  def configure_gcc(self, cxx):
-    cxx.cflags += [
-      '-pipe',
-      '-Wall',
-      '-Werror',
-      '-Wno-switch',
-    ]
-    cxx.cxxflags += ['-std=c++17']
-    cxx.linkflags += ['-lstdc++']
-
-    if builder.options.debug == '1':
-      cxx.cflags += ['-g3']
-      cxx.cxxflags += ['-D_GLIBCXX_DEBUG']
-
-    have_gcc = cxx.family == 'gcc'
-    have_clang = cxx.family == 'clang' or cxx.family == 'emscripten'
-    if have_clang or have_gcc:
-      cxx.cflags += ['-fvisibility=hidden']
-      cxx.cxxflags += ['-fvisibility-inlines-hidden']
-      if have_clang or (have_gcc and cxx.version >= '4.7'):
-        cxx.cxxflags += ['-Wno-delete-non-virtual-dtor']
-      if not (have_gcc and cxx.version <= 6.3):
-        cxx.cxxflags += ['-Wno-unused-private-field']
-
-    if self.enable_coverage:
-      if cxx.family == 'clang':
-        coverage_argv = [
-          '-fprofile-instr-generate',
-          '-fcoverage-mapping',
+        cxx.cxxincludes += [
+            self.amtl,
+            os.path.join(builder.sourcePath, 'include'),
         ]
-        cxx.cflags += coverage_argv
-        cxx.linkflags += coverage_argv
-      else:
-        raise Exception('Code coverage support is not implemented for {0}.'.format(cxx.family))
 
-    # Disable some stuff we don't use, that gives us better binary
-    # compatibility on Linux.
-    cxx.cxxflags += [
-      '-fno-rtti',
-      '-Wno-non-virtual-dtor',
-      '-Wno-overloaded-virtual',
-      '-Wno-invalid-offsetof',
-    ]
+        if cxx.target.platform == 'linux':
+            cxx.defines += ['_GNU_SOURCE']
+        elif cxx.target.platform == 'mac':
+            cxx.defines += ['DARWIN']
 
-    if have_gcc:
-      if cxx.target.arch in ['x86', 'x86_64']:
-        cxx.cflags += ['-mfpmath=sse']
-      cxx.cxxflags += ['-Wformat-truncation=0']
+    def configure_gcc(self, cxx):
+        cxx.cflags += [
+            '-pipe',
+            '-Wall',
+            '-Werror',
+            '-Wno-switch',
+        ]
+        cxx.cxxflags += ['-std=c++17']
+        cxx.linkflags += ['-lstdc++']
 
-    cxx.postlink += ['-lm']
+        if builder.options.debug == '1':
+            cxx.cflags += ['-g3']
+            cxx.cxxflags += ['-D_GLIBCXX_DEBUG']
 
-    is_wsl = False
-    if os.path.exists('/proc/sys/kernel/osrelease'):
-      with open('/proc/sys/kernel/osrelease', 'rb') as fp:
-        contents = fp.read().decode("utf-8")
-        is_wsl = 'Microsoft' in contents
+        have_gcc = cxx.family == 'gcc'
+        have_clang = cxx.family == 'clang' or cxx.family == 'emscripten'
+        if have_clang or have_gcc:
+            cxx.cflags += ['-fvisibility=hidden']
+            cxx.cxxflags += ['-fvisibility-inlines-hidden']
+            if have_clang or (have_gcc and cxx.version >= '4.7'):
+                cxx.cxxflags += ['-Wno-delete-non-virtual-dtor']
+            if not (have_gcc and cxx.version <= 6.3):
+                cxx.cxxflags += ['-Wno-unused-private-field']
 
-    if cxx.like('emscripten'):
-      emflags = ['-s', 'PRECISE_F32=1']
-      cxx.cflags += emflags
-      cxx.linkflags += emflags
-      cxx.defines += ['__linux__']
+        if self.enable_coverage:
+            if cxx.family == 'clang':
+                coverage_argv = [
+                    '-fprofile-instr-generate',
+                    '-fcoverage-mapping',
+                ]
+                cxx.cflags += coverage_argv
+                cxx.linkflags += coverage_argv
+            else:
+                raise Exception('Code coverage support is not implemented for {0}.'.format(
+                    cxx.family))
 
-    if self.enable_asan:
-      if not have_clang:
-        raise Exception('--enable-asan only supported when using Clang')
-      self.configure_asan(cxx)
+        # Disable some stuff we don't use, that gives us better binary
+        # compatibility on Linux.
+        cxx.cxxflags += [
+            '-fno-rtti',
+            '-Wno-non-virtual-dtor',
+            '-Wno-overloaded-virtual',
+            '-Wno-invalid-offsetof',
+        ]
 
-  def configure_msvc(self, cxx):
-    if builder.options.debug == '1':
-      cxx.cflags += ['/MTd']
-      cxx.linkflags += ['/NODEFAULTLIB:libcmt']
-    else:
-      cxx.cflags += ['/MT']
-    cxx.defines += [
-      '_CRT_SECURE_NO_DEPRECATE',
-      '_CRT_SECURE_NO_WARNINGS',
-      '_CRT_NONSTDC_NO_DEPRECATE',
-      '_ITERATOR_DEBUG_LEVEL=0',
-    ]
-    cxx.cflags += [
-      '/W3',
-      '/wd4351',
-    ]
-    cxx.cxxflags += [
-      '/EHsc',
-      '/GR-',
-      '/TP',
-    ]
-    cxx.linkflags += [
-      'kernel32.lib',
-      'user32.lib',
-      'gdi32.lib',
-      'winspool.lib',
-      'comdlg32.lib',
-      'advapi32.lib',
-      'shell32.lib',
-      'ole32.lib',
-      'oleaut32.lib',
-      'uuid.lib',
-      'odbc32.lib',
-      'odbccp32.lib',
-    ]
+        if have_gcc:
+            if cxx.target.arch in ['x86', 'x86_64']:
+                cxx.cflags += ['-mfpmath=sse']
+            cxx.cxxflags += ['-Wformat-truncation=0']
 
-    if self.enable_asan:
-      raise Exception('--enable-asan only supported when using Clang')
+        cxx.postlink += ['-lm']
 
-  def configure_asan(self, cxx):
-    if cxx.target.platform != 'linux':
-      raise Exception('--enable-asan only supported on Linux')
-    cxx.cflags += ['-fsanitize=address']
-    cxx.linkflags += ['-fsanitize=address']
-    if cxx.target.arch == 'x86':
-      libclang_rt = 'libclang_rt.asan-i386.so'
-    else:
-      libclang_rt = 'libclang_rt.asan-x86_64.so'
+        is_wsl = False
+        if os.path.exists('/proc/sys/kernel/osrelease'):
+            with open('/proc/sys/kernel/osrelease', 'rb') as fp:
+                contents = fp.read().decode("utf-8")
+                is_wsl = 'Microsoft' in contents
 
-    try:
-      argv = cxx.cxx_argv + ['--print-file-name', libclang_rt]
-      output = subprocess.check_output(argv)
-      output = output.decode('utf-8')
-      output = output.strip()
-    except:
-      raise
-      raise Exception('Could not find {}'.format(libclang_rt))
+        if cxx.like('emscripten'):
+            emflags = ['-s', 'PRECISE_F32=1']
+            cxx.cflags += emflags
+            cxx.linkflags += emflags
+            cxx.defines += ['__linux__']
 
-    self.asan_libs[cxx.target.arch] = os.path.dirname(output)
+        if self.enable_asan:
+            if not have_clang:
+                raise Exception('--enable-asan only supported when using Clang')
+            self.configure_asan(cxx)
 
-  def ProgramBuilder(self, compiler, name):
-    binary = compiler.Program(name)
-    if binary.compiler.like('msvc'):
-      binary.compiler.linkflags.append('/SUBSYSTEM:CONSOLE')
-    return binary
+    def configure_msvc(self, cxx):
+        if builder.options.debug == '1':
+            cxx.cflags += ['/MTd']
+            cxx.linkflags += ['/NODEFAULTLIB:libcmt']
+        else:
+            cxx.cflags += ['/MT']
+        cxx.defines += [
+            '_CRT_SECURE_NO_DEPRECATE',
+            '_CRT_SECURE_NO_WARNINGS',
+            '_CRT_NONSTDC_NO_DEPRECATE',
+            '_ITERATOR_DEBUG_LEVEL=0',
+        ]
+        cxx.cflags += [
+            '/W3',
+            '/wd4351',
+        ]
+        cxx.cxxflags += [
+            '/EHsc',
+            '/GR-',
+            '/TP',
+        ]
+        cxx.linkflags += [
+            'kernel32.lib',
+            'user32.lib',
+            'gdi32.lib',
+            'winspool.lib',
+            'comdlg32.lib',
+            'advapi32.lib',
+            'shell32.lib',
+            'ole32.lib',
+            'oleaut32.lib',
+            'uuid.lib',
+            'odbc32.lib',
+            'odbccp32.lib',
+        ]
 
-  def LibraryBuilder(self, compiler, name):
-    binary = compiler.Library(name)
-    if binary.compiler.like('msvc'):
-      binary.compiler.linkflags.append('/SUBSYSTEM:WINDOWS')
+        if self.enable_asan:
+            raise Exception('--enable-asan only supported when using Clang')
 
-    # Dumb clang behavior means we have to manually find libclang_rt.
-    if self.enable_asan:
-      binary.compiler.linkflags += [
-        '-shared-libsan',
-        '-Wl,-rpath={}'.format(self.asan_libs[binary.compiler.target.arch]),
-      ]
-    return binary
+    def configure_asan(self, cxx):
+        if cxx.target.platform != 'linux':
+            raise Exception('--enable-asan only supported on Linux')
+        cxx.cflags += ['-fsanitize=address']
+        cxx.linkflags += ['-fsanitize=address']
+        if cxx.target.arch == 'x86':
+            libclang_rt = 'libclang_rt.asan-i386.so'
+        else:
+            libclang_rt = 'libclang_rt.asan-x86_64.so'
 
-  def StaticLibraryBuilder(self, compiler, name):
-    return compiler.StaticLibrary(name)
+        try:
+            argv = cxx.cxx_argv + ['--print-file-name', libclang_rt]
+            output = subprocess.check_output(argv)
+            output = output.decode('utf-8')
+            output = output.strip()
+        except:
+            raise
+            raise Exception('Could not find {}'.format(libclang_rt))
 
-  def Program(self, context, name):
-    compiler = context.cxx.clone()
-    SetArchFlags(compiler)
-    return self.ProgramBuilder(compiler, name)
+        self.asan_libs[cxx.target.arch] = os.path.dirname(output)
 
-  def Library(self, context, name):
-    compiler = context.cxx.clone()
-    SetArchFlags(compiler)
-    return self.LibraryBuilder(compiler, name)
+    def ProgramBuilder(self, compiler, name):
+        binary = compiler.Program(name)
+        if binary.compiler.like('msvc'):
+            binary.compiler.linkflags.append('/SUBSYSTEM:CONSOLE')
+        return binary
 
-  def StaticLibrary(self, context, name):
-    compiler = context.cxx.clone()
-    SetArchFlags(compiler)
-    return self.StaticLibraryBuilder(compiler, name)
+    def LibraryBuilder(self, compiler, name):
+        binary = compiler.Library(name)
+        if binary.compiler.like('msvc'):
+            binary.compiler.linkflags.append('/SUBSYSTEM:WINDOWS')
+
+        # Dumb clang behavior means we have to manually find libclang_rt.
+        if self.enable_asan:
+            binary.compiler.linkflags += [
+                '-shared-libsan',
+                '-Wl,-rpath={}'.format(self.asan_libs[binary.compiler.target.arch]),
+            ]
+        return binary
+
+    def StaticLibraryBuilder(self, compiler, name):
+        return compiler.StaticLibrary(name)
+
+    def Program(self, context, name):
+        compiler = context.cxx.clone()
+        SetArchFlags(compiler)
+        return self.ProgramBuilder(compiler, name)
+
+    def Library(self, context, name):
+        compiler = context.cxx.clone()
+        SetArchFlags(compiler)
+        return self.LibraryBuilder(compiler, name)
+
+    def StaticLibrary(self, context, name):
+        compiler = context.cxx.clone()
+        SetArchFlags(compiler)
+        return self.StaticLibraryBuilder(compiler, name)
+
 
 class SourcePawn(object):
-  def __init__(self, root, amtl):
-    super(SourcePawn, self).__init__()
-    self.root = root
-    self.amtl = amtl
-    self.vars = {
-      'Root': self.root,
-      'SP': self,
-    }
-    self.spshell = {}
-    self.spcomp = {}
-    self.zlib = None
-    self.libamtl = None
-    self.static_libsp = {}
-    self.dynamic_libsp = {}
+    def __init__(self, root, amtl):
+        super(SourcePawn, self).__init__()
+        self.root = root
+        self.amtl = amtl
+        self.vars = {
+            'Root': self.root,
+            'SP': self,
+        }
+        self.spshell = {}
+        self.spcomp = {}
+        self.zlib = None
+        self.libamtl = None
+        self.static_libsp = {}
+        self.dynamic_libsp = {}
 
-  def BuildCore(self):
-    self.EnsureZlib()
-    self.EnsureAmtl()
+    def BuildCore(self):
+        self.EnsureZlib()
+        self.EnsureAmtl()
 
-    for cxx in self.root.targets:
-      builder.CallBuilder(lambda builder: self.BuildCoreForArch(cxx, builder))
+        for cxx in self.root.targets:
+            builder.CallBuilder(lambda builder: self.BuildCoreForArch(cxx, builder))
 
-  def BuildCoreForArch(self, cxx, builder):
-    builder.cxx = cxx
+    def BuildCoreForArch(self, cxx, builder):
+        builder.cxx = cxx
 
-    cxx.cxxincludes += [
-      os.path.join(builder.currentSourcePath),
-      os.path.join(builder.currentSourcePath, 'third_party'),
-      os.path.join(builder.currentSourcePath, 'third_party', 'amtl'),
-    ]
+        cxx.cxxincludes += [
+            os.path.join(builder.currentSourcePath),
+            os.path.join(builder.currentSourcePath, 'third_party'),
+            os.path.join(builder.currentSourcePath, 'third_party', 'amtl'),
+        ]
 
-    self.BuildStaticCoreLib(builder)
-    self.BuildDynamicCoreLib(builder)
-    self.BuildSpcomp(builder)
-    self.BuildSpshell(builder)
-    self.BuildVerifier(builder)
+        self.BuildStaticCoreLib(builder)
+        self.BuildDynamicCoreLib(builder)
+        self.BuildSpcomp(builder)
+        self.BuildSpshell(builder)
+        self.BuildVerifier(builder)
 
-  def BuildStaticCoreLib(self, builder):
-    cxx = builder.cxx
-    binary = self.root.StaticLibrary(builder, 'libsourcepawn_static')
+    def BuildStaticCoreLib(self, builder):
+        cxx = builder.cxx
+        binary = self.root.StaticLibrary(builder, 'libsourcepawn_static')
 
-    vars = self.vars.copy()
-    vars['binary'] = binary
+        vars = self.vars.copy()
+        vars['binary'] = binary
 
-    binary.compiler.cxxincludes += [
-        os.path.join(builder.currentSourcePath),
-        os.path.join(builder.currentSourcePath, 'third_party'),
-        self.amtl,
-    ]
+        binary.compiler.cxxincludes += [
+            os.path.join(builder.currentSourcePath),
+            os.path.join(builder.currentSourcePath, 'third_party'),
+            self.amtl,
+        ]
 
-    builder.Build('compiler/AMBuilder', vars)
-    builder.Build('libsmx/AMBuilder', vars)
-    builder.Build('vm/AMBuilder', vars)
+        builder.Build('compiler/AMBuilder', vars)
+        builder.Build('libsmx/AMBuilder', vars)
+        builder.Build('vm/AMBuilder', vars)
 
-    binary.compiler.linkflags += [
-      self.zlib[cxx.target.arch],
-      self.libamtl[cxx.target.arch],
-    ]
-    cppnode = builder.Add(binary)
-    self.static_libsp[cxx.target.arch] = cppnode.binary
+        binary.compiler.linkflags += [
+            self.zlib[cxx.target.arch],
+            self.libamtl[cxx.target.arch],
+        ]
+        cppnode = builder.Add(binary)
+        self.static_libsp[cxx.target.arch] = cppnode.binary
 
-  def BuildDynamicCoreLib(self, builder):
-    cxx = builder.cxx
-    binary = self.root.Library(builder, 'libsourcepawn')
+    def BuildDynamicCoreLib(self, builder):
+        cxx = builder.cxx
+        binary = self.root.Library(builder, 'libsourcepawn')
 
-    vars = self.vars.copy()
-    vars['binary'] = binary
+        vars = self.vars.copy()
+        vars['binary'] = binary
 
-    if binary.compiler.like('gcc') and binary.compiler.target.platform == 'mac':
-      binary.compiler.cxxflags += [
-        '-Wno-implicit-exception-spec-mismatch',
-      ]
-    binary.sources += [
-      'vm/dll_exports.cpp',
-    ]
+        if binary.compiler.like('gcc') and binary.compiler.target.platform == 'mac':
+            binary.compiler.cxxflags += [
+                '-Wno-implicit-exception-spec-mismatch',
+            ]
+        binary.sources += [
+            'vm/dll_exports.cpp',
+        ]
 
-    self.AddStaticLibraries(binary)
+        self.AddStaticLibraries(binary)
 
-    cppnode = builder.Add(binary)
-    self.dynamic_libsp[cxx.target.arch] = cppnode.binary
+        cppnode = builder.Add(binary)
+        self.dynamic_libsp[cxx.target.arch] = cppnode.binary
 
-  def BuildSpcomp(self, builder):
-    binary = self.root.Program(builder, 'spcomp')
-    binary.sources += [
-      'compiler/main.cpp',
-    ]
+    def BuildSpcomp(self, builder):
+        binary = self.root.Program(builder, 'spcomp')
+        binary.sources += [
+            'compiler/main.cpp',
+        ]
 
-    self.AddStaticLibraries(binary)
+        self.AddStaticLibraries(binary)
 
-    cppnodes = builder.Add(binary)
-    self.spcomp[builder.cxx.target.arch] = cppnodes.binary
+        cppnodes = builder.Add(binary)
+        self.spcomp[builder.cxx.target.arch] = cppnodes.binary
 
-  def BuildSpshell(self, builder):
-    binary = self.root.Program(builder, 'spshell')
-    binary.sources += [
-      'vm/shell.cpp',
-    ]
+    def BuildSpshell(self, builder):
+        binary = self.root.Program(builder, 'spshell')
+        binary.sources += [
+            'vm/shell.cpp',
+        ]
 
-    self.AddStaticLibraries(binary)
+        self.AddStaticLibraries(binary)
 
-    cppnodes = builder.Add(binary)
-    self.spshell[builder.cxx.target.arch] = cppnodes.binary
+        cppnodes = builder.Add(binary)
+        self.spshell[builder.cxx.target.arch] = cppnodes.binary
 
-  def BuildVerifier(self, builder):
-    binary = self.root.Program(builder, 'verifier')
-    binary.sources += [
-      'tools/verifier/verifier.cpp',
-    ]
+    def BuildVerifier(self, builder):
+        binary = self.root.Program(builder, 'verifier')
+        binary.sources += [
+            'tools/verifier/verifier.cpp',
+        ]
 
-    self.AddStaticLibraries(binary)
+        self.AddStaticLibraries(binary)
 
-    builder.Add(binary)
+        builder.Add(binary)
 
-  def AddStaticLibraries(self, binary):
-    if binary.compiler.linker.like('gcc') and binary.compiler.target.platform == 'linux':
-      binary.compiler.linkflags += ['-Wl,--start-group']
+    def AddStaticLibraries(self, binary):
+        if binary.compiler.linker.like('gcc') and binary.compiler.target.platform == 'linux':
+            binary.compiler.linkflags += ['-Wl,--start-group']
 
-    arch = binary.compiler.target.arch
-    binary.compiler.linkflags += [
-      self.zlib[arch],
-      self.libamtl[arch],
-      self.static_libsp[arch],
-    ]
+        arch = binary.compiler.target.arch
+        binary.compiler.linkflags += [
+            self.zlib[arch],
+            self.libamtl[arch],
+            self.static_libsp[arch],
+        ]
 
-    if binary.compiler.linker.like('gcc') and binary.compiler.target.platform == 'linux':
-      binary.compiler.linkflags += ['-Wl,--end-group']
+        if binary.compiler.linker.like('gcc') and binary.compiler.target.platform == 'linux':
+            binary.compiler.linkflags += ['-Wl,--end-group']
 
-  def BuildSuite(self):
-    self.BuildCore()
+    def BuildSuite(self):
+        self.BuildCore()
 
-  def EnsureAmtl(self):
-    if self.libamtl is not None:
-      return
+    def EnsureAmtl(self):
+        if self.libamtl is not None:
+            return
 
-    self.libamtl = getattr(self.root, 'libamtl', None)
-    if self.libamtl:
-      return
+        self.libamtl = getattr(self.root, 'libamtl', None)
+        if self.libamtl:
+            return
 
-    self.libamtl = {}
-    for cxx in self.root.targets:
-      def do_config(builder, name):
-          return self.root.StaticLibrary(builder, name)
-      extra_vars = {'Configure': do_config}
-      libamtl = self.BuildForArch("third_party/amtl/amtl/AMBuilder", cxx, extra_vars)
-      self.libamtl[cxx.target.arch] = libamtl.binary
+        self.libamtl = {}
+        for cxx in self.root.targets:
 
-  def EnsureZlib(self):
-    if self.zlib is not None:
-      return
-    self.zlib = {}
-    for cxx in self.root.targets:
-      self.zlib[cxx.target.arch] = self.BuildForArch("third_party/zlib/AMBuilder", cxx)
-    self.included_zlib = True
+            def do_config(builder, name):
+                return self.root.StaticLibrary(builder, name)
 
-  def BuildForArch(self, scripts, cxx, extra_vars = {}):
-    new_vars = copy.copy(self.vars)
-    for key in extra_vars:
-        new_vars[key] = extra_vars[key]
+            extra_vars = {'Configure': do_config}
+            libamtl = self.BuildForArch("third_party/amtl/amtl/AMBuilder", cxx, extra_vars)
+            self.libamtl[cxx.target.arch] = libamtl.binary
 
-    builder.cxx = cxx
-    try:
-        rvalue = builder.Build(scripts, new_vars)
-    finally:
-        builder.cxx = None
-    return rvalue
+    def EnsureZlib(self):
+        if self.zlib is not None:
+            return
+        self.zlib = {}
+        for cxx in self.root.targets:
+            self.zlib[cxx.target.arch] = self.BuildForArch("third_party/zlib/AMBuilder", cxx)
+        self.included_zlib = True
+
+    def BuildForArch(self, scripts, cxx, extra_vars={}):
+        new_vars = copy.copy(self.vars)
+        for key in extra_vars:
+            new_vars[key] = extra_vars[key]
+
+        builder.cxx = cxx
+        try:
+            rvalue = builder.Build(scripts, new_vars)
+        finally:
+            builder.cxx = None
+        return rvalue
+
 
 if builder.parent is None:
-  root = Config()
-  root.configure()
-  sp = SourcePawn(root, root.amtl)
-  build = getattr(builder.options, 'build', 'all').split(',')
+    root = Config()
+    root.configure()
+    sp = SourcePawn(root, root.amtl)
 else:
-  sp = SourcePawn(external_root, external_amtl)
-  build = external_build
+    sp = SourcePawn(external_root, external_amtl)
 
 sp.BuildCore()
 
 if builder.parent is not None:
-  rvalue = sp
+    rvalue = sp

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -183,7 +183,6 @@ class Config(object):
             '-fno-rtti',
             '-Wno-non-virtual-dtor',
             '-Wno-overloaded-virtual',
-            '-Wno-invalid-offsetof',
         ]
 
         if have_gcc:
@@ -324,6 +323,9 @@ class SourcePawn(object):
         self.static_libsp = {}
         self.dynamic_libsp = {}
 
+        # Embedders (aka SourceMod) use this.
+        self.libsourcepawn = {}
+
     def BuildCore(self):
         self.EnsureZlib()
         self.EnsureAmtl()
@@ -334,10 +336,16 @@ class SourcePawn(object):
     def BuildCoreForArch(self, cxx, builder):
         builder.cxx = cxx
 
+        if cxx.like('gcc'):
+            cxx.cflags += [
+                '-Wno-invalid-offsetof',
+            ]
+
         cxx.cxxincludes += [
             os.path.join(builder.currentSourcePath),
+            os.path.join(builder.currentSourcePath, 'include'),
             os.path.join(builder.currentSourcePath, 'third_party'),
-            os.path.join(builder.currentSourcePath, 'third_party', 'amtl'),
+            self.amtl,
         ]
 
         self.BuildStaticCoreLib(builder)
@@ -353,20 +361,10 @@ class SourcePawn(object):
         vars = self.vars.copy()
         vars['binary'] = binary
 
-        binary.compiler.cxxincludes += [
-            os.path.join(builder.currentSourcePath),
-            os.path.join(builder.currentSourcePath, 'third_party'),
-            self.amtl,
-        ]
-
         builder.Build('compiler/AMBuilder', vars)
         builder.Build('libsmx/AMBuilder', vars)
         builder.Build('vm/AMBuilder', vars)
 
-        binary.compiler.linkflags += [
-            self.zlib[cxx.target.arch],
-            self.libamtl[cxx.target.arch],
-        ]
         cppnode = builder.Add(binary)
         self.static_libsp[cxx.target.arch] = cppnode.binary
 
@@ -388,6 +386,7 @@ class SourcePawn(object):
         self.AddStaticLibraries(binary)
 
         cppnode = builder.Add(binary)
+        self.libsourcepawn[cxx.target.arch] = cppnode
         self.dynamic_libsp[cxx.target.arch] = cppnode.binary
 
     def BuildSpcomp(self, builder):
@@ -399,7 +398,7 @@ class SourcePawn(object):
         self.AddStaticLibraries(binary)
 
         cppnodes = builder.Add(binary)
-        self.spcomp[builder.cxx.target.arch] = cppnodes.binary
+        self.spcomp[builder.cxx.target.arch] = cppnodes
 
     def BuildSpshell(self, builder):
         binary = self.root.Program(builder, 'spshell')
@@ -410,7 +409,7 @@ class SourcePawn(object):
         self.AddStaticLibraries(binary)
 
         cppnodes = builder.Add(binary)
-        self.spshell[builder.cxx.target.arch] = cppnodes.binary
+        self.spshell[builder.cxx.target.arch] = cppnodes
 
     def BuildVerifier(self, builder):
         binary = self.root.Program(builder, 'verifier')
@@ -454,7 +453,10 @@ class SourcePawn(object):
                 return self.root.StaticLibrary(builder, name)
 
             extra_vars = {'Configure': do_config}
-            libamtl = self.BuildForArch("third_party/amtl/amtl/AMBuilder", cxx, extra_vars)
+
+            amtl = os.path.relpath(self.amtl, builder.currentSourcePath)
+            amtl_builder = os.path.join(amtl, 'amtl', 'AMBuilder')
+            libamtl = self.BuildForArch(amtl_builder, cxx, extra_vars)
             self.libamtl[cxx.target.arch] = libamtl.binary
 
     def EnsureZlib(self):

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -95,9 +95,6 @@ class Config(object):
       # Don't omit the frame pointer.
       cxx.cflags += ['/Oy-']
 
-    if cxx.like('gcc'):
-      cxx.linkflags += ['-lstdc++']
-
     # Platform-specifics
     if not cxx.like('emscripten'):
       if cxx.target.platform == 'linux':
@@ -133,6 +130,11 @@ class Config(object):
       os.path.join(builder.sourcePath, 'include'),
     ]
 
+    if cxx.target.platform == 'linux':
+      cxx.defines += ['_GNU_SOURCE']
+    elif cxx.target.platform == 'mac':
+      cxx.defines += ['DARWIN']
+
   def configure_gcc(self, cxx):
     cxx.cflags += [
       '-pipe',
@@ -141,10 +143,11 @@ class Config(object):
       '-Wno-switch',
     ]
     cxx.cxxflags += ['-std=c++17']
+    cxx.linkflags += ['-lstdc++']
 
     if builder.options.debug == '1':
-        cxx.cflags += ['-g3']
-        cxx.cxxflags += ['-D_GLIBCXX_DEBUG']
+      cxx.cflags += ['-g3']
+      cxx.cxxflags += ['-D_GLIBCXX_DEBUG']
 
     have_gcc = cxx.family == 'gcc'
     have_clang = cxx.family == 'clang' or cxx.family == 'emscripten'
@@ -173,6 +176,7 @@ class Config(object):
       '-fno-rtti',
       '-Wno-non-virtual-dtor',
       '-Wno-overloaded-virtual',
+      '-Wno-invalid-offsetof',
     ]
 
     if have_gcc:
@@ -301,55 +305,131 @@ class SourcePawn(object):
     super(SourcePawn, self).__init__()
     self.root = root
     self.amtl = amtl
-    self.spcomp_scripts = [
-      os.path.join('compiler', 'AMBuilder'),
-    ]
     self.vars = {
       'Root': self.root,
       'SP': self,
     }
     self.spshell = {}
     self.spcomp = {}
-    self.libspcomp2 = {}
-    self.libsourcepawn = {}
-    self.libsourcepawn_a = {}
     self.zlib = None
-    self.libsmx = None
     self.libamtl = None
+    self.static_libsp = {}
+    self.dynamic_libsp = {}
 
-  def BuildSpcomp(self):
-    self.EnsureZlib()
-    self.EnsureLibSmx()
-    self.EnsureAmtl()
-    self.BuildVM()
-    for cxx in self.root.targets:
-      spcomp = self.BuildForArch('compiler/AMBuilder', cxx)
-      self.spcomp[cxx.target.arch] = spcomp
-
-  def BuildVM(self):
-    if self.spshell:
-        return
-
+  def BuildCore(self):
     self.EnsureZlib()
     self.EnsureAmtl()
-    for cxx in self.root.targets:
-      spshell, libsourcepawn, libsourcepawn_a = self.BuildForArch('vm/AMBuilder', cxx)
-      self.spshell[cxx.target.arch] = spshell
-      self.libsourcepawn[cxx.target.arch] = libsourcepawn
-      self.libsourcepawn_a[cxx.target.arch] = libsourcepawn_a
 
-  def BuildExperimental(self):
-    self.EnsureAmtl()
     for cxx in self.root.targets:
-      libspcomp2 = self.BuildForArch('exp/compiler/AMBuilder', cxx)
-      self.libspcomp2[cxx.target.arch] = libspcomp2
+      builder.CallBuilder(lambda builder: self.BuildCoreForArch(cxx, builder))
 
-      self.BuildForArch('exp/tools/docparse/AMBuilder', cxx)
+  def BuildCoreForArch(self, cxx, builder):
+    builder.cxx = cxx
+
+    cxx.cxxincludes += [
+      os.path.join(builder.currentSourcePath),
+      os.path.join(builder.currentSourcePath, 'third_party'),
+      os.path.join(builder.currentSourcePath, 'third_party', 'amtl'),
+    ]
+
+    self.BuildStaticCoreLib(builder)
+    self.BuildDynamicCoreLib(builder)
+    self.BuildSpcomp(builder)
+    self.BuildSpshell(builder)
+    self.BuildVerifier(builder)
+
+  def BuildStaticCoreLib(self, builder):
+    cxx = builder.cxx
+    binary = self.root.StaticLibrary(builder, 'libsourcepawn_static')
+
+    vars = self.vars.copy()
+    vars['binary'] = binary
+
+    binary.compiler.cxxincludes += [
+        os.path.join(builder.currentSourcePath),
+        os.path.join(builder.currentSourcePath, 'third_party'),
+        self.amtl,
+    ]
+
+    builder.Build('compiler/AMBuilder', vars)
+    builder.Build('libsmx/AMBuilder', vars)
+    builder.Build('vm/AMBuilder', vars)
+
+    binary.compiler.linkflags += [
+      self.zlib[cxx.target.arch],
+      self.libamtl[cxx.target.arch],
+    ]
+    cppnode = builder.Add(binary)
+    self.static_libsp[cxx.target.arch] = cppnode.binary
+
+  def BuildDynamicCoreLib(self, builder):
+    cxx = builder.cxx
+    binary = self.root.Library(builder, 'libsourcepawn')
+
+    vars = self.vars.copy()
+    vars['binary'] = binary
+
+    if binary.compiler.like('gcc') and binary.compiler.target.platform == 'mac':
+      binary.compiler.cxxflags += [
+        '-Wno-implicit-exception-spec-mismatch',
+      ]
+    binary.sources += [
+      'vm/dll_exports.cpp',
+    ]
+
+    self.AddStaticLibraries(binary)
+
+    cppnode = builder.Add(binary)
+    self.dynamic_libsp[cxx.target.arch] = cppnode.binary
+
+  def BuildSpcomp(self, builder):
+    binary = self.root.Program(builder, 'spcomp')
+    binary.sources += [
+      'compiler/main.cpp',
+    ]
+
+    self.AddStaticLibraries(binary)
+
+    cppnodes = builder.Add(binary)
+    self.spcomp[builder.cxx.target.arch] = cppnodes.binary
+
+  def BuildSpshell(self, builder):
+    binary = self.root.Program(builder, 'spshell')
+    binary.sources += [
+      'vm/shell.cpp',
+    ]
+
+    self.AddStaticLibraries(binary)
+
+    cppnodes = builder.Add(binary)
+    self.spshell[builder.cxx.target.arch] = cppnodes.binary
+
+  def BuildVerifier(self, builder):
+    binary = self.root.Program(builder, 'verifier')
+    binary.sources += [
+      'tools/verifier/verifier.cpp',
+    ]
+
+    self.AddStaticLibraries(binary)
+
+    builder.Add(binary)
+
+  def AddStaticLibraries(self, binary):
+    if binary.compiler.linker.like('gcc') and binary.compiler.target.platform == 'linux':
+      binary.compiler.linkflags += ['-Wl,--start-group']
+
+    arch = binary.compiler.target.arch
+    binary.compiler.linkflags += [
+      self.zlib[arch],
+      self.libamtl[arch],
+      self.static_libsp[arch],
+    ]
+
+    if binary.compiler.linker.like('gcc') and binary.compiler.target.platform == 'linux':
+      binary.compiler.linkflags += ['-Wl,--end-group']
 
   def BuildSuite(self):
-    self.BuildVM()
-    self.BuildSpcomp()
-    self.BuildExperimental()
+    self.BuildCore()
 
   def EnsureAmtl(self):
     if self.libamtl is not None:
@@ -375,14 +455,6 @@ class SourcePawn(object):
       self.zlib[cxx.target.arch] = self.BuildForArch("third_party/zlib/AMBuilder", cxx)
     self.included_zlib = True
 
-  def EnsureLibSmx(self):
-    if self.libsmx is not None:
-      return
-    self.libsmx = {}
-    for cxx in self.root.targets:
-      lib = self.BuildForArch('libsmx/AMBuilder', cxx)
-      self.libsmx[cxx.target.arch] = lib
-
   def BuildForArch(self, scripts, cxx, extra_vars = {}):
     new_vars = copy.copy(self.vars)
     for key in extra_vars:
@@ -404,18 +476,7 @@ else:
   sp = SourcePawn(external_root, external_amtl)
   build = external_build
 
-if 'all' in build:
-  sp.BuildSuite()
-else:
-  if 'core' in build:
-    build += ['spcomp', 'vm']
-  if 'spcomp' in build:
-    sp.BuildSpcomp()
-  if 'vm' in build:
-    sp.BuildVM()
-  if 'exp' in build:
-    sp.EnsureLibSmx()
-    sp.BuildExperimental()
+sp.BuildCore()
 
 if builder.parent is not None:
   rvalue = sp

--- a/compiler/AMBuilder
+++ b/compiler/AMBuilder
@@ -1,49 +1,9 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python: 
 import os
 
-binary = Root.Program(builder, 'spcomp')
-compiler = binary.compiler
-compiler.includes += [
-  os.path.join(SP.amtl, 'amtl'),
-  os.path.join(SP.amtl),
-  os.path.join(builder.currentSourcePath, '..', 'include'),
-  os.path.join(builder.currentSourcePath, '..', 'third_party'),
-  os.path.join(builder.buildPath, 'includes'),
-  os.path.join(builder.buildPath, builder.buildFolder),
-  os.path.join(builder.currentSourcePath, '..'),
-]
+module = binary.Module(builder, 'compiler')
 
-if compiler.like('gcc'):
-  compiler.cflags += [
-    '-Wno-format',
-  ]
-  compiler.c_only_flags += ['-std=c99']
-
-  if compiler.like('emscripten'):
-    compiler.postlink += ['-lnodefs.js']
-  else:
-    compiler.postlink += ['-lstdc++']
-if compiler.family == 'clang':
-  compiler.cxxflags += [
-    '-Wno-implicit-exception-spec-mismatch',
-  ]
-if compiler.family == 'gcc':
-  compiler.cflags += [
-    '-Wno-maybe-uninitialized',
-  ]
-  if compiler.version >= '4.6':
-    compiler.cxxflags += ['-Wno-unused-but-set-variable']
-
-if compiler.target.platform == 'linux':
-  compiler.defines += [
-    '_GNU_SOURCE'
-  ]
-elif compiler.target.platform == 'mac':
-  compiler.defines += [
-    'DARWIN',
-  ]
-
-binary.sources += [
+module.sources += [
   'assembler.cpp',
   'array-helpers.cpp',
   'compile-context.cpp',
@@ -52,7 +12,6 @@ binary.sources += [
   'errors.cpp',
   'expressions.cpp',
   'lexer.cpp',
-  'main.cpp',
   'name-resolution.cpp',
   'parse-node.cpp',
   'parser.cpp',
@@ -68,16 +27,3 @@ binary.sources += [
   'type-checker.cpp',
   'types.cpp',
 ]
-
-if compiler.target.platform == 'linux' and not compiler.like('emscripten'):
-  compiler.defines += ['ENABLE_BINRELOC']
-  binary.sources.append('binreloc.c')
-
-binary.compiler.linkflags[0:0] = [
-  SP.libsmx[compiler.target.arch].binary,
-  SP.libsourcepawn_a[compiler.target.arch].binary,
-  SP.zlib[compiler.target.arch],
-  SP.libamtl[compiler.target.arch],
-]
-
-rvalue = builder.Add(binary)

--- a/configure.py
+++ b/configure.py
@@ -28,11 +28,12 @@ except:
 		sys.stderr.write('AMBuild must be installed to build this project.\n')
 		sys.stderr.write('http://www.alliedmods.net/ambuild\n')
 	sys.exit(1)
+from pkg_resources import parse_version
 
 # Hack to show a decent upgrade message, which wasn't done until 2.2.
 ambuild_version = getattr(run, 'CURRENT_API', '2.1')
-if ambuild_version.startswith('2.1'):
-	sys.stderr.write("AMBuild 2.2 or higher is required; please update\n")
+if parse_version(ambuild_version) < parse_version("2.2.3"):
+	sys.stderr.write("AMBuild 2.2.3 or higher is required; please update\n")
 	sys.exit(1)
 
 parser = run.BuildParser(sourcePath=sys.path[0], api='2.2')
@@ -44,7 +45,7 @@ parser.options.add_argument('--enable-optimize', action='store_const', const='1'
                             help='Enable optimization')
 parser.options.add_argument('--amtl', type=str, dest='amtl', default=None, help='Custom AMTL path')
 parser.options.add_argument('--build', type=str, dest='build', default='all', 
-                            help='Build which components (all, spcomp, vm, exp, test, core)')
+                            help='Deprecated; no effect.')
 parser.options.add_argument('--enable-spew', action='store_true', default=False, dest='enable_spew',
                             help='Enable debug spew')
 parser.options.add_argument("--enable-coverage", action='store_true', default=False,

--- a/libsmx/AMBuilder
+++ b/libsmx/AMBuilder
@@ -18,15 +18,8 @@
 #
 import os
 
-binary = Root.StaticLibrary(builder, 'smx')
-binary.compiler.cxxincludes += [
-  os.path.join(builder.currentSourcePath, '..'),
-  os.path.join(builder.currentSourcePath, '..', 'include'),
-  os.path.join(SP.amtl),
-]
-binary.sources += [
+module = binary.Module(builder, 'smx')
+module.sources += [
   'data-pool.cpp',
   'smx-builder.cpp',
 ]
-
-rvalue = builder.Add(binary)

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -115,7 +115,7 @@ class TestPlan(object):
     return found
 
   def find_shells(self):
-    search_in = os.path.join(self.args.objdir, 'vm', 'spshell')
+    search_in = os.path.join(self.args.objdir, 'spshell')
     found = self.find_executables_in(search_in, 'spshell')
 
     for arch, path in found:
@@ -147,7 +147,7 @@ class TestPlan(object):
       self.find_spcomp()
 
   def find_spcomp(self):
-    search_in = os.path.join(self.args.objdir, 'compiler', 'spcomp')
+    search_in = os.path.join(self.args.objdir, 'spcomp')
     found = self.find_executables_in(search_in, 'spcomp')
 
     for arch, path in found:

--- a/tools/verifier/verifier.cpp
+++ b/tools/verifier/verifier.cpp
@@ -10,8 +10,8 @@
 // You should have received a copy of the GNU General Public License along with
 // SourcePawn. If not, see http://www.gnu.org/licenses/.
 //
-#include "environment.h"
-#include "method-verifier.h"
+#include "vm/environment.h"
+#include "vm/method-verifier.h"
 #include <amtl/experimental/am-argparser.h>
 #include <set>
 #include <deque>

--- a/tools/yapf-style
+++ b/tools/yapf-style
@@ -1,0 +1,3 @@
+[style]
+based_on_style = pep8
+column_limit = 100

--- a/vm/AMBuilder
+++ b/vm/AMBuilder
@@ -1,51 +1,22 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os
 
-libsourcepawn_a = None
-
-def configure_like_shell(name):
-  prog = Root.Program(builder, name)
-  prog.compiler.includes += Includes
-  prog.compiler.linkflags[0:0] = [
-    libsourcepawn_a.binary,
-    SP.zlib[builder.cxx.target.arch],
-  ]
-  if prog.compiler.like('emscripten'):
-    prog.compiler.postlink += ['-lnodefs.js']
-  elif prog.compiler.like('gcc'):
-    prog.compiler.postlink += ['-lstdc++']
-  return prog
-
-Includes = [
-  os.path.join(SP.amtl, 'amtl'),
-  os.path.join(SP.amtl),
-  os.path.join(builder.currentSourcePath),
-  os.path.join(builder.currentSourcePath, '..', 'third_party'),
-
-  # The include path for SP v2 stuff.
-  os.path.join(builder.sourcePath, 'sourcepawn', 'include'),
+module = binary.Module(builder, 'vm')
+module.compiler.cxxincludes += [
+    os.path.join(builder.currentSourcePath),
 ]
 
-if builder.cxx.like('gcc'):
-  builder.cxx.cflags += [
-    '-Wno-invalid-offsetof',
-  ]
-  builder.cxx.cxxflags += ['-fno-rtti']
-if builder.cxx.like('clang'):
-  builder.cxx.cxxflags += [
+if module.compiler.like('clang'):
+  module.compiler.cxxflags += [
     '-Wno-implicit-exception-spec-mismatch',
   ]
-if builder.cxx.family == 'gcc':
+if module.compiler.family == 'gcc':
   # ABI restrictions...
-  builder.cxx.cxxflags += [
+  module.compiler.cxxflags += [
     '-Wno-delete-non-virtual-dtor',
   ]
 
-# Build the static library.
-library = Root.StaticLibrary(builder, 'sourcepawn')
-library.compiler.includes += Includes
-
-library.sources += [
+module.sources += [
   'api.cpp',
   'base-context.cpp',
   'builtins.cpp',
@@ -74,69 +45,29 @@ library.sources += [
   'watchdog_timer.cpp',
 ]
 
-is_emscripten = builder.cxx.family == 'emscripten'
-has_jit = builder.cxx.target.arch in ['x86'] and not is_emscripten
+is_emscripten = module.compiler.family == 'emscripten'
+has_jit = module.compiler.target.arch in ['x86'] and not is_emscripten
 
 if has_jit:
-  library.sources += [
+  module.sources += [
     'jit.cpp',
+    'linking.cpp',
   ]
-  library.compiler.defines += ['SP_HAS_JIT']
+  module.compiler.defines += ['SP_HAS_JIT']
 
 if is_emscripten:
-  library.sources += [
+  module.sources += [
     'code-stubs-null.cpp',
   ]
-elif builder.cxx.target.arch == 'x86':
-  library.sources += [
-    'linking.cpp',
+elif module.compiler.target.arch == 'x86':
+  module.sources += [
     'x86/assembler-x86.cpp',
     'x86/code-stubs-x86.cpp',
     'x86/jit_x86.cpp',
   ]
-elif builder.cxx.target.arch == 'x86_64':
-  library.sources += [
-    'linking.cpp',
+elif module.compiler.target.arch == 'x86_64':
+  module.sources += [
     'x64/assembler-x64.cpp',
     'x64/code-stubs-x64.cpp',
     'x64/macro-assembler-x64.cpp',
   ]
-
-libsourcepawn_a = builder.Add(library)
-
-# Build the dynamically-linked library.
-dll = Root.Library(builder, 'sourcepawn.vm')
-dll.compiler.includes += Includes
-dll.compiler.linkflags[0:0] = [
-  libsourcepawn_a.binary,
-  SP.zlib[builder.cxx.target.arch],
-]
-dll.sources += [
-  'dll_exports.cpp'
-]
-
-libsourcepawn = builder.Add(dll)
-
-# Build the debug shell.
-shell = configure_like_shell('spshell')
-if has_jit:
-  shell.compiler.defines += ['SP_HAS_JIT']
-shell.sources += [
-  'shell.cpp'
-]
-shell.compiler.linkflags[0:0] = [
-  SP.libamtl[builder.cxx.target.arch],
-]
-spshell = builder.Add(shell)
-
-# Build the verifier.
-verifier = configure_like_shell('verifier')
-verifier.sources += [
-  '../tools/verifier/verifier.cpp',
-]
-verifier.compiler.linkflags[0:0] = [
-  SP.libamtl[builder.cxx.target.arch],
-]
-builder.Add(verifier)
-
-rvalue = spshell, libsourcepawn, libsourcepawn_a

--- a/vm/api.h
+++ b/vm/api.h
@@ -14,7 +14,7 @@
 #define _include_sourcepawn_vm_api_h_
 
 #include <sp_vm_api.h>
-#include <am-cxx.h> // Replace with am-cxx later.
+#include <amtl/am-cxx.h>
 
 namespace sp {
 

--- a/vm/builtins.cpp
+++ b/vm/builtins.cpp
@@ -11,7 +11,7 @@
 // SourcePawn. If not, see http://www.gnu.org/licenses/.
 //
 #include "builtins.h"
-#include <am-float.h>
+#include <amtl/am-float.h>
 #include <math.h>
 
 namespace sp {

--- a/vm/code-allocator.h
+++ b/vm/code-allocator.h
@@ -15,8 +15,8 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include <am-refcounting.h>
-#include <am-vector.h>
+#include <amtl/am-refcounting.h>
+#include <amtl/am-vector.h>
 
 namespace sp {
 

--- a/vm/debug-metadata.cpp
+++ b/vm/debug-metadata.cpp
@@ -12,7 +12,7 @@
 //
 #include "debug-metadata.h"
 
-#include <am-string.h>
+#include <amtl/am-string.h>
 
 using namespace sp;
 

--- a/vm/debug-metadata.h
+++ b/vm/debug-metadata.h
@@ -16,7 +16,7 @@
 #include <vector>
 
 #include <stdint.h>
-#include <am-platform.h>
+#include <amtl/am-platform.h>
 
 #if defined(KE_LINUX)
 #include <stdio.h>

--- a/vm/dll_exports.cpp
+++ b/vm/dll_exports.cpp
@@ -13,7 +13,7 @@
 #include <sp_vm_api.h>
 #include <stdlib.h>
 #include <stdarg.h>
-#include <am-cxx.h>
+#include <amtl/am-cxx.h>
 #include "dll_exports.h"
 #include "environment.h"
 #include "stack-frames.h"

--- a/vm/jit.h
+++ b/vm/jit.h
@@ -19,7 +19,7 @@
 
 #include <sp_vm_types.h>
 #include <sp_vm_api.h>
-#include <am-vector.h>
+#include <amtl/am-vector.h>
 #include "macro-assembler.h"
 #include "opcodes.h"
 #include "pool-allocator.h"

--- a/vm/plugin-runtime.h
+++ b/vm/plugin-runtime.h
@@ -14,10 +14,10 @@
 #define _INCLUDE_SOURCEPAWN_JIT_RUNTIME_H_
 
 #include <sp_vm_api.h>
-#include <am-vector.h>
-#include <am-string.h>
-#include <am-inlinelist.h>
-#include <am-hashmap.h>
+#include <amtl/am-vector.h>
+#include <amtl/am-string.h>
+#include <amtl/am-inlinelist.h>
+#include <amtl/am-hashmap.h>
 #include <amtl/am-refcounting.h>
 #include "scripted-invoker.h"
 #include "legacy-image.h"

--- a/vm/pool-allocator.h
+++ b/vm/pool-allocator.h
@@ -24,9 +24,9 @@
 
 #include <new>
 
-#include <am-bits.h>
-#include <am-fixedarray.h>
-#include <am-vector.h>
+#include <amtl/am-bits.h>
+#include <amtl/am-fixedarray.h>
+#include <amtl/am-vector.h>
 
 namespace sp {
 

--- a/vm/smx-v1-image.cpp
+++ b/vm/smx-v1-image.cpp
@@ -11,7 +11,7 @@
 
 #include <amtl/am-string.h>
 #include "smx-v1-image.h"
-#include "zlib/zlib.h"
+#include <zlib/zlib.h>
 #include "environment.h"
 
 using namespace ke;

--- a/vm/smx-v1-image.h
+++ b/vm/smx-v1-image.h
@@ -15,8 +15,8 @@
 #include <smx/smx-legacy-debuginfo.h>
 #include <smx/smx-typeinfo.h>
 #include <smx/smx-v1.h>
-#include <am-string.h>
-#include <am-vector.h>
+#include <amtl/am-string.h>
+#include <amtl/am-vector.h>
 #include <sp_vm_types.h>
 #include "file-utils.h"
 #include "legacy-image.h"

--- a/vm/stack-frames.h
+++ b/vm/stack-frames.h
@@ -18,7 +18,7 @@
 #include <memory>
 
 #include <sp_vm_api.h>
-#include <am-cxx.h>
+#include <amtl/am-cxx.h>
 #include <amtl/am-platform.h>
 #include <amtl/am-refcounting.h>
 #include <amtl/am-enum.h>

--- a/vm/x64/macro-assembler-x64.h
+++ b/vm/x64/macro-assembler-x64.h
@@ -13,7 +13,7 @@
 #ifndef _include_sourcepawn_macro_assembler_x64_h__
 #define _include_sourcepawn_macro_assembler_x64_h__
 
-#include <assembler.h>
+#include "assembler.h"
 #include "assembler-x64.h"
 #include "stack-frames.h"
 #include "constants-x64.h"

--- a/vm/x86/assembler-x86.h
+++ b/vm/x86/assembler-x86.h
@@ -32,7 +32,7 @@
 #define _include_sourcepawn_assembler_x86_h__
 
 #include <assembler.h>
-#include <am-vector.h>
+#include <amtl/am-vector.h>
 #include <string.h>
 
 namespace sp {

--- a/vm/x86/jit_x86.h
+++ b/vm/x86/jit_x86.h
@@ -19,7 +19,7 @@
 
 #include <sp_vm_types.h>
 #include <sp_vm_api.h>
-#include <am-vector.h>
+#include <amtl/am-vector.h>
 #include "jit.h"
 #include "plugin-runtime.h"
 #include "plugin-context.h"

--- a/vm/x86/macro-assembler-x86.h
+++ b/vm/x86/macro-assembler-x86.h
@@ -32,7 +32,7 @@
 #define _include_sourcepawn_macroassembler_x86h__
 
 #include <assembler.h>
-#include <am-vector.h>
+#include <amtl/am-vector.h>
 #include <string.h>
 #include "assembler-x86.h"
 #include "stack-frames.h"


### PR DESCRIPTION
It's time to start treating the SourcePawn tree as one homogenous
component, rather than separate mini-libraries. This step of the
refactoring process applies only to the build scripts.

The compiler and VM are now built as one component. They stay in
separate folders for organization, although, we will begin refactoring
that organization in the not too distant future.

Together with zlib and amtl, we produce a libsourcepawn archive. This is
used to create libsourcepawn.so (which is used by SourceMod).

Local tools (spcomp, spshell, and verifier) build using the archive.

This has the nice side effect of generally simplifying our build
scripts.

Support for building exp/* is now removed. Docgen will be re-added via
spcomp in a later patch.