### PR TITLE
Don't mark lvalue initializers as read.

### DIFF
--- a/compiler/name-resolution.cpp
+++ b/compiler/name-resolution.cpp
@@ -491,7 +491,7 @@ VarDecl::Bind(SemaContext& sc)
 
     // LHS bind should now succeed.
     if (init_)
-        init_->left()->Bind(sc);
+        init_->left()->BindLval(sc);
     return true;
 }
 

--- a/tests/compile-only/fail-initialized-var-is-unused.sp
+++ b/tests/compile-only/fail-initialized-var-is-unused.sp
@@ -1,0 +1,6 @@
+// warnings_are_errors: true
+float spawnTime[64+1] = {-1.0,...};
+
+public void OnPluginStart()
+{
+}

--- a/tests/compile-only/fail-initialized-var-is-unused.txt
+++ b/tests/compile-only/fail-initialized-var-is-unused.txt
@@ -1,0 +1,1 @@
+(2) : error 203: symbol is never used: "spawnTime"


### PR DESCRIPTION
Bug: issue #713
Test: fail-initialized-var-is-unused