### PR TITLE
Revert "Exact match check for #pragma newdecls values"

### DIFF
--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -926,12 +926,9 @@ Lexer::DoCommand(bool allow_synthesized_tokens)
                     } else if (current_token()->atom->str() == "newdecls") {
                         while (*lptr <= ' ' && *lptr != '\0')
                             lptr++;
-                        std::string word(((char*) lptr));
-                        word.erase(std::remove(word.begin(), word.end(), '\r'), word.end());
-                        word.erase(std::remove(word.begin(), word.end(), '\n'), word.end());
-                        if (word == "required")
+                        if (strncmp((char*)lptr, "required", 8) == 0)
                             require_newdecls_stack_.back() = true;
-                        else if (word == "optional")
+                        else if (strncmp((char*)lptr, "optional", 8) == 0)
                             require_newdecls_stack_.back() = false;
                         else
                             error(146);


### PR DESCRIPTION
Reverts alliedmodders/sourcepawn#730

Breakage on corpus, with patterns like:

    #pragma newdecls required;
