### PR TITLE
Improve memory usage of the compiler.

### DIFF
--- a/compiler/array-data.h
+++ b/compiler/array-data.h
@@ -20,21 +20,23 @@
 //  3.  This notice may not be removed or altered from any source distribution.
 #pragma once
 
-#include "array-data.h"
-#include "parse-node.h"
+#include <stdint.h>
 
-class Semantics;
+#include <vector>
 
-// Determine the static size of an iARRAY based on dimension expressions and
-// array initializers. The array may be converted to an iREFARRAY if it is
-// determined to be dynamic.
-void ResolveArraySize(Semantics* sema, VarDecl* decl);
-void ResolveArraySize(Semantics* sema, const token_pos_t& pos, typeinfo_t* type, int vclass);
+#include <sp_vm_types.h>
 
-// Perform type and size checks of an array and its initializer if present.
-bool CheckArrayInitialization(Semantics* sema, const typeinfo_t& type, Expr* init);
+struct ArrayData {
+    std::vector<cell_t> iv;
+    std::vector<cell_t> data;
+    uint32_t zeroes;
 
-void BuildArrayInitializer(VarDecl* decl, ArrayData* array, cell_t base_addr);
-void BuildArrayInitializer(const typeinfo_t& type, Expr* init, ArrayData* array);
+    size_t total_size() const {
+        return iv.size() + data.size() + zeroes;
+    }
+};
 
-cell_t CalcArraySize(symbol* sym);
+struct DefaultArrayData : public ArrayData {
+    cell_t iv_size;
+    cell_t data_size;
+};

--- a/compiler/array-helpers.cpp
+++ b/compiler/array-helpers.cpp
@@ -614,9 +614,9 @@ FixedArrayValidator::ValidateRank(int rank, Expr* init)
 
         report(init->pos(), 241);
 
-        array = new ArrayExpr(init->pos());
-        array->exprs().push_back(init);
-        array->set_ellipses();
+        std::vector<Expr*> exprs = {init};
+
+        array = new ArrayExpr(init->pos(), exprs, true);
         array->set_synthesized_for_compat();
         decl_->set_init(array);
     }

--- a/compiler/array-helpers.cpp
+++ b/compiler/array-helpers.cpp
@@ -763,15 +763,18 @@ AddImplicitDynamicInitializer(VarDecl* decl)
     // Note that these declarations use old tag-based syntax, and therefore
     // do not work with enum structs, which create implicit dimensions.
     TypenameInfo ti = type->ToTypenameInfo();
-    NewArrayExpr* init = new NewArrayExpr(decl->pos(), ti);
+
+    std::vector<Expr*> exprs;
     for (int i = 0; i < type->numdim(); i++) {
         Expr* expr = type->get_dim_expr(i);
         if (!expr) {
             error(decl->pos(), 184);
             return false;
         }
-        init->exprs().emplace_back(expr);
+        exprs.emplace_back(expr);
     }
+
+    auto init = new NewArrayExpr(decl->pos(), ti, exprs);
     if (!decl->init_rhs())
         decl->set_init(init);
     if (!decl->autozero())

--- a/compiler/array-helpers.cpp
+++ b/compiler/array-helpers.cpp
@@ -950,8 +950,8 @@ ArrayEmitter::Emit(int rank, Expr* init)
     if (!init) {
         assert(type_.dim[rank]);
     } else if (ArrayExpr* array = init->as<ArrayExpr>()) {
-        PoolList<symbol*>* field_list = nullptr;
-        PoolList<symbol*>::iterator field_iter;
+        PoolArray<symbol*>* field_list = nullptr;
+        symbol** field_iter = nullptr;
         if (es_) {
             symbol* esroot = es_->asEnumStruct();
             field_list = &esroot->data()->asEnumStruct()->fields;

--- a/compiler/array-helpers.cpp
+++ b/compiler/array-helpers.cpp
@@ -867,10 +867,10 @@ class ArrayEmitter final
 
     void Emit();
 
-    PoolList<cell>& iv() {
+    std::vector<cell>& iv() {
         return iv_;
     }
-    PoolList<cell>& data() {
+    std::vector<cell>& data() {
         return data_;
     }
     size_t pending_zeroes() const {
@@ -895,8 +895,8 @@ class ArrayEmitter final
     const typeinfo_t& type_;
     Type* es_;
     Expr* init_;
-    PoolList<cell> iv_;
-    PoolList<cell> data_;
+    std::vector<cell> iv_;
+    std::vector<cell> data_;
     size_t pending_zeroes_;
 };
 

--- a/compiler/assembler.cpp
+++ b/compiler/assembler.cpp
@@ -556,8 +556,8 @@ RttiBuilder::encode_signature(symbol* sym)
 
     uint32_t argc = 0;
     bool is_variadic = false;
-    for (arginfo* arg = &sym->function()->args[0]; arg->type.ident; arg++) {
-        if (arg->type.ident == iVARARGS)
+    for (const auto& arg : sym->function()->args) {
+        if (arg.type.ident == iVARARGS)
             is_variadic = true;
         argc++;
     }
@@ -577,11 +577,11 @@ RttiBuilder::encode_signature(symbol* sym)
         encode_tag_into(bytes, sym->tag);
     }
 
-    for (arginfo* arg = &sym->function()->args[0]; arg->type.ident; arg++) {
-        int tag = arg->type.tag();
-        int numdim = arg->type.numdim();
-        if (arg->type.numdim() && arg->type.enum_struct_tag()) {
-            int last_tag = arg->type.enum_struct_tag();
+    for (const auto& arg : sym->function()->args) {
+        int tag = arg.type.tag();
+        int numdim = arg.type.numdim();
+        if (arg.type.numdim() && arg.type.enum_struct_tag()) {
+            int last_tag = arg.type.enum_struct_tag();
             Type* last_type = types_->find(last_tag);
             if (last_type->isEnumStruct()) {
                 tag = last_tag;
@@ -589,11 +589,11 @@ RttiBuilder::encode_signature(symbol* sym)
             }
         }
 
-        if (arg->type.ident == iREFERENCE)
+        if (arg.type.ident == iREFERENCE)
             bytes.push_back(cb::kByRef);
 
-        auto dim = numdim ? &arg->type.dim[0] : nullptr;
-        variable_type_t info = {tag, dim, numdim, arg->type.is_const};
+        auto dim = numdim ? &arg.type.dim[0] : nullptr;
+        variable_type_t info = {tag, dim, numdim, arg.type.is_const};
         encode_var_type(bytes, info);
     }
 

--- a/compiler/assembler.cpp
+++ b/compiler/assembler.cpp
@@ -414,15 +414,15 @@ RttiBuilder::add_method(symbol* sym)
     method.pcode_end = sym->codeaddr;
     method.signature = encode_signature(sym);
 
-    if (sym->function()->dbgstrs.empty())
+    if (!sym->function()->dbgstrs)
         return;
 
     smx_rtti_debug_method debug;
     debug.method_index = index;
     debug.first_local = dbg_locals_->count();
 
-    for (auto& iter : sym->function()->dbgstrs) {
-        const auto& chars = iter.chars();
+    for (auto& iter : *sym->function()->dbgstrs) {
+        const char* chars = iter.c_str();
         if (chars[0] == '\0')
             continue;
 

--- a/compiler/ast-types.h
+++ b/compiler/ast-types.h
@@ -19,55 +19,61 @@
 //  3.  This notice may not be removed or altered from any source distribution.
 #pragma once
 
+#define AST_TYPE_LIST(FOR_EACH) \
+    FOR_EACH(ParseTree) \
+    FOR_EACH(StmtList) \
+    FOR_EACH(BlockStmt) \
+    FOR_EACH(BreakStmt) \
+    FOR_EACH(ContinueStmt) \
+    FOR_EACH(StaticAssertStmt) \
+    FOR_EACH(VarDecl) \
+    FOR_EACH(EnumDecl) \
+    FOR_EACH(PstructDecl) \
+    FOR_EACH(TypedefDecl) \
+    FOR_EACH(TypesetDecl) \
+    FOR_EACH(UsingDecl) \
+    FOR_EACH(IsDefinedExpr) \
+    FOR_EACH(UnaryExpr) \
+    FOR_EACH(BinaryExpr) \
+    FOR_EACH(LogicalExpr) \
+    FOR_EACH(ChainedCompareExpr) \
+    FOR_EACH(TernaryExpr) \
+    FOR_EACH(IncDecExpr) \
+    FOR_EACH(CastExpr) \
+    FOR_EACH(SizeofExpr) \
+    FOR_EACH(SymbolExpr) \
+    FOR_EACH(CallExpr) \
+    FOR_EACH(CallUserOpExpr) \
+    FOR_EACH(DefaultArgExpr) \
+    FOR_EACH(FieldAccessExpr) \
+    FOR_EACH(IndexExpr) \
+    FOR_EACH(RvalueExpr) \
+    FOR_EACH(CommaExpr) \
+    FOR_EACH(ThisExpr) \
+    FOR_EACH(NullExpr) \
+    FOR_EACH(TaggedValueExpr) \
+    FOR_EACH(StringExpr) \
+    FOR_EACH(NewArrayExpr) \
+    FOR_EACH(ArrayExpr) \
+    FOR_EACH(StructExpr) \
+    FOR_EACH(IfStmt) \
+    FOR_EACH(ExprStmt) \
+    FOR_EACH(ReturnStmt) \
+    FOR_EACH(AssertStmt) \
+    FOR_EACH(DeleteStmt) \
+    FOR_EACH(ExitStmt) \
+    FOR_EACH(DoWhileStmt) \
+    FOR_EACH(ForStmt) \
+    FOR_EACH(SwitchStmt) \
+    FOR_EACH(PragmaUnusedStmt) \
+    FOR_EACH(FunctionDecl) \
+    FOR_EACH(EnumStructDecl) \
+    FOR_EACH(MethodmapDecl) \
+    FOR_EACH(ChangeScopeNode)
+
 enum class AstKind : uint8_t
 {
-    ParseTree,
-    StmtList,
-    BlockStmt,
-    LoopControlStmt,
-    StaticAssertStmt,
-    VarDecl,
-    EnumDecl,
-    PstructDecl,
-    TypedefDecl,
-    TypesetDecl,
-    UsingDecl,
-    IsDefinedExpr,
-    UnaryExpr,
-    BinaryExpr,
-    LogicalExpr,
-    ChainedCompareExpr,
-    TernaryExpr,
-    IncDecExpr,
-    CastExpr,
-    SizeofExpr,
-    SymbolExpr,
-    CallExpr,
-    CallUserOpExpr,
-    DefaultArgExpr,
-    FieldAccessExpr,
-    IndexExpr,
-    RvalueExpr,
-    CommaExpr,
-    ThisExpr,
-    NullExpr,
-    TaggedValueExpr,
-    StringExpr,
-    NewArrayExpr,
-    ArrayExpr,
-    StructExpr,
-    IfStmt,
-    ExprStmt,
-    ReturnStmt,
-    AssertStmt,
-    DeleteStmt,
-    ExitStmt,
-    DoWhileStmt,
-    ForStmt,
-    SwitchStmt,
-    PragmaUnusedStmt,
-    FunctionDecl,
-    EnumStructDecl,
-    MethodmapDecl,
-    ChangeScopeNode,
+#define _(Name) Name,
+    AST_TYPE_LIST(_)
+#undef _
 };

--- a/compiler/code-generator.cpp
+++ b/compiler/code-generator.cpp
@@ -77,7 +77,9 @@ CodeGenerator::AddDebugLine(int linenr)
     auto str = ke::StringPrintf("L:%x %x", asm_.position(), linenr);
     if (func_) {
         auto data = func_->function();
-        data->dbgstrs.emplace_back(str.c_str(), str.size());
+        if (!data->dbgstrs)
+            data->dbgstrs = cc_.NewDebugStringList();
+        data->dbgstrs->emplace_back(std::move(str));
     } else {
         debug_strings_.emplace_back(std::move(str));
     }
@@ -108,7 +110,9 @@ CodeGenerator::AddDebugSymbol(symbol* sym)
 
     if (func_) {
         auto data = func_->function();
-        data->dbgstrs.emplace_back(string.c_str(), string.size());
+        if (!data->dbgstrs)
+            data->dbgstrs = cc_.NewDebugStringList();
+        data->dbgstrs->emplace_back(std::move(string));
     } else {
         debug_strings_.emplace_back(std::move(string));
     }

--- a/compiler/code-generator.cpp
+++ b/compiler/code-generator.cpp
@@ -1754,7 +1754,7 @@ CodeGenerator::EmitFunctionInfo(FunctionInfo* info)
         AutoEnterScope arg_scope(this, &local_syms_);
 
         for (const auto& fun_arg : info->args()) {
-            auto sym = fun_arg.decl->sym();
+            auto sym = fun_arg->sym();
             sym->codeaddr = asm_.position();
             EnqueueDebugSymbol(sym);
         }

--- a/compiler/code-generator.cpp
+++ b/compiler/code-generator.cpp
@@ -189,8 +189,11 @@ CodeGenerator::EmitStmt(Stmt* stmt)
         case AstKind::DoWhileStmt:
             EmitDoWhileStmt(stmt->to<DoWhileStmt>());
             break;
-        case AstKind::LoopControlStmt:
-            EmitLoopControlStmt(stmt->to<LoopControlStmt>());
+        case AstKind::BreakStmt:
+            EmitLoopControl(tBREAK);
+            break;
+        case AstKind::ContinueStmt:
+            EmitLoopControl(tCONTINUE);
             break;
         case AstKind::ForStmt:
             EmitForStmt(stmt->to<ForStmt>());
@@ -1572,10 +1575,8 @@ CodeGenerator::EmitDoWhileStmt(DoWhileStmt* stmt)
 }
 
 void
-CodeGenerator::EmitLoopControlStmt(LoopControlStmt* stmt)
+CodeGenerator::EmitLoopControl(int token)
 {
-    int token = stmt->token();
-
     assert(loop_);
     assert(token == tBREAK || token == tCONTINUE);
 

--- a/compiler/code-generator.h
+++ b/compiler/code-generator.h
@@ -65,7 +65,6 @@ class CodeGenerator final
     void EmitIfStmt(IfStmt* stmt);
     void EmitDeleteStmt(DeleteStmt* stmt);
     void EmitDoWhileStmt(DoWhileStmt* stmt);
-    void EmitLoopControlStmt(LoopControlStmt* stmt);
     void EmitForStmt(ForStmt* stmt);
     void EmitSwitchStmt(SwitchStmt* stmt);
     void EmitFunctionInfo(FunctionInfo* info);
@@ -122,6 +121,7 @@ class CodeGenerator final
 
     // Helper that automatically handles heap deallocations.
     void EmitExprForStmt(Expr* expr);
+    void EmitLoopControl(int token);
 
   private:
     enum MemuseType {

--- a/compiler/compile-context.cpp
+++ b/compiler/compile-context.cpp
@@ -67,3 +67,8 @@ std::vector<std::string>* CompileContext::NewDebugStringList() {
     debug_strings_.emplace_front();
     return &debug_strings_.front();
 }
+
+std::unordered_map<sp::Atom*, symbol*>* CompileContext::NewSymbolMap() {
+    symbol_maps_.emplace_front();
+    return &symbol_maps_.front();
+}

--- a/compiler/compile-context.cpp
+++ b/compiler/compile-context.cpp
@@ -57,3 +57,8 @@ CompileContext::InitLexer()
 {
     lexer_ = std::make_shared<Lexer>(*this);
 }
+
+DefaultArrayData* CompileContext::NewDefaultArrayData() {
+    default_array_data_objects_.emplace_front();
+    return &default_array_data_objects_.front();
+}

--- a/compiler/compile-context.cpp
+++ b/compiler/compile-context.cpp
@@ -62,3 +62,8 @@ DefaultArrayData* CompileContext::NewDefaultArrayData() {
     default_array_data_objects_.emplace_front();
     return &default_array_data_objects_.front();
 }
+
+std::vector<std::string>* CompileContext::NewDebugStringList() {
+    debug_strings_.emplace_front();
+    return &debug_strings_.front();
+}

--- a/compiler/compile-context.h
+++ b/compiler/compile-context.h
@@ -20,11 +20,13 @@
 //  3.  This notice may not be removed or altered from any source distribution.
 #pragma once
 
+#include <forward_list>
 #include <memory>
 #include <string>
 #include <unordered_set>
 #include <vector>
 
+#include "array-data.h"
 #include "pool-allocator.h"
 #include "source-file.h"
 
@@ -97,6 +99,8 @@ class CompileContext final
     void operator =(const CompileContext&) = delete;
     void operator =(CompileContext&&) = delete;
 
+    DefaultArrayData* NewDefaultArrayData();
+
   private:
     PoolAllocator allocator_;
     SymbolScope* globals_;
@@ -127,4 +131,7 @@ class CompileContext final
     bool must_abort_ = false;
 
     SemaContext* sc_ = nullptr;
+
+    // AST attachments.
+    std::forward_list<DefaultArrayData> default_array_data_objects_;
 };

--- a/compiler/compile-context.h
+++ b/compiler/compile-context.h
@@ -101,6 +101,7 @@ class CompileContext final
 
     DefaultArrayData* NewDefaultArrayData();
     std::vector<std::string>* NewDebugStringList();
+    std::unordered_map<sp::Atom*, symbol*>* NewSymbolMap();
 
   private:
     PoolAllocator allocator_;
@@ -136,4 +137,5 @@ class CompileContext final
     // AST attachments.
     std::forward_list<DefaultArrayData> default_array_data_objects_;
     std::forward_list<std::vector<std::string>> debug_strings_;
+    std::forward_list<std::unordered_map<sp::Atom*, symbol*>> symbol_maps_;
 };

--- a/compiler/compile-context.h
+++ b/compiler/compile-context.h
@@ -100,6 +100,7 @@ class CompileContext final
     void operator =(CompileContext&&) = delete;
 
     DefaultArrayData* NewDefaultArrayData();
+    std::vector<std::string>* NewDebugStringList();
 
   private:
     PoolAllocator allocator_;
@@ -134,4 +135,5 @@ class CompileContext final
 
     // AST attachments.
     std::forward_list<DefaultArrayData> default_array_data_objects_;
+    std::forward_list<std::vector<std::string>> debug_strings_;
 };

--- a/compiler/data-queue.cpp
+++ b/compiler/data-queue.cpp
@@ -61,7 +61,7 @@ DataQueue::Add(const char* text, size_t length)
 }
 
 void
-DataQueue::Add(PoolList<cell>&& cells)
+DataQueue::Add(std::vector<cell>&& cells)
 {
     if (cells.empty())
         return;

--- a/compiler/data-queue.h
+++ b/compiler/data-queue.h
@@ -28,7 +28,7 @@ class DataQueue final
     DataQueue();
 
     void Add(cell value);
-    void Add(PoolList<cell>&& cells);
+    void Add(std::vector<cell>&& cells);
     void Add(const char* text, size_t length);
     void AddZeroes(cell count);
 

--- a/compiler/expressions.cpp
+++ b/compiler/expressions.cpp
@@ -61,7 +61,7 @@ static inline bool
 MatchOperator(symbol* sym, int tag1, int tag2, int numparam)
 {
     auto fun = sym->function();
-    if (fun->args.size() != size_t(numparam) + 1)
+    if (fun->args.size() != size_t(numparam))
         return false;
 
     assert(numparam == 1 || numparam == 2);
@@ -73,10 +73,6 @@ MatchOperator(symbol* sym, int tag1, int tag2, int numparam)
         if (fun->args[i].type.tag() != tags[i])
             return false;
     }
-
-    if (fun->args[numparam].type.ident != 0)
-        return false;
-
     return true;
 }
 

--- a/compiler/main.cpp
+++ b/compiler/main.cpp
@@ -291,6 +291,7 @@ cleanup:
             printf("Pool allocation:   %8" KE_FMT_SIZET " bytes\n", allocated);
             printf("Pool unused:       %8" KE_FMT_SIZET " bytes\n", reserved - allocated);
             printf("Pool bookkeeping:  %8" KE_FMT_SIZET " bytes\n", bookkeeping);
+            printf("Pool wasted:       %8" KE_FMT_SIZET " bytes\n", cc.allocator().wasted());
         }
     }
 

--- a/compiler/name-resolution.cpp
+++ b/compiler/name-resolution.cpp
@@ -996,7 +996,7 @@ FunctionInfo::BindArgs(SemaContext& sc)
 
         if (typeinfo.ident == iREFARRAY || typeinfo.ident == iARRAY) {
             if (sc.sema()->CheckVarDecl(var) && var->init_rhs())
-                fill_arg_defvalue(var, &arg);
+                fill_arg_defvalue(sc.cc(), var, &arg);
         } else {
             Expr* init = var->init_rhs();
             if (init && sc.sema()->CheckExpr(init)) {

--- a/compiler/name-resolution.cpp
+++ b/compiler/name-resolution.cpp
@@ -85,8 +85,6 @@ SemaContext::BindType(const token_pos_t& pos, typeinfo_t* ti)
         ti->set_tag(0);
         ti->declared_tag = tag;
         ti->dim.emplace_back(enum_type->addr());
-        if (!ti->dim_exprs.empty())
-            ti->dim_exprs.emplace_back(nullptr);
 
         if (ti->ident != iARRAY && ti->ident != iREFARRAY) {
             ti->ident = iARRAY;

--- a/compiler/name-resolution.cpp
+++ b/compiler/name-resolution.cpp
@@ -1134,14 +1134,18 @@ FunctionDecl::Bind(SemaContext& sc)
 bool
 PragmaUnusedStmt::Bind(SemaContext& sc)
 {
+    std::vector<symbol*> symbols;
     for (const auto& name : names_) {
         symbol* sym = FindSymbol(sc, name);
         if (!sym) {
             report(pos_, 17) << name;
             continue;
         }
-        symbols_.emplace_back(sym);
+        symbols.emplace_back(sym);
     }
+
+    new (&symbols_) PoolArray<symbol*>(symbols);
+
     return names_.size() == symbols_.size();
 }
 

--- a/compiler/parse-node.cpp
+++ b/compiler/parse-node.cpp
@@ -82,9 +82,9 @@ BlockStmt::WrapStmt(Stmt* stmt)
 {
     if (BlockStmt* block = stmt->as<BlockStmt>())
         return block;
-    BlockStmt* block = new BlockStmt(stmt->pos());
-    block->stmts().emplace_back(stmt);
-    return block;
+
+    std::vector<Stmt*> stmts = {stmt};
+    return new BlockStmt(stmt->pos(), stmts);
 }
 
 BinaryExprBase::BinaryExprBase(AstKind kind, const token_pos_t& pos, int token, Expr* left, Expr* right)

--- a/compiler/parse-node.h
+++ b/compiler/parse-node.h
@@ -226,24 +226,32 @@ class BlockStmt : public StmtList
     SymbolScope* scope_;
 };
 
-class LoopControlStmt : public Stmt
+class BreakStmt : public Stmt
 {
   public:
-    explicit LoopControlStmt(const token_pos_t& pos, int token)
-      : Stmt(AstKind::LoopControlStmt, pos),
-        token_(token)
+    explicit BreakStmt(const token_pos_t& pos)
+      : Stmt(AstKind::BreakStmt, pos)
     {
-        set_flow_type(token_ == tBREAK ? Flow_Break : Flow_Continue);
+        set_flow_type(Flow_Break);
     }
 
     void ProcessUses(SemaContext& sc) override {}
 
-    static bool is_a(ParseNode* node) { return node->kind() == AstKind::LoopControlStmt; }
+    static bool is_a(ParseNode* node) { return node->kind() == AstKind::BreakStmt; }
+};
 
-    int token() const { return token_; }
+class ContinueStmt : public Stmt
+{
+  public:
+    explicit ContinueStmt(const token_pos_t& pos)
+      : Stmt(AstKind::ContinueStmt, pos)
+    {
+        set_flow_type(Flow_Continue);
+    }
 
-  private:
-    int token_;
+    void ProcessUses(SemaContext& sc) override {}
+
+    static bool is_a(ParseNode* node) { return node->kind() == AstKind::ContinueStmt; }
 };
 
 class StaticAssertStmt : public Stmt

--- a/compiler/parse-node.h
+++ b/compiler/parse-node.h
@@ -900,10 +900,11 @@ struct ComputedArg {
 class CallExpr final : public Expr
 {
   public:
-    CallExpr(const token_pos_t& pos, int token, Expr* target)
+    CallExpr(const token_pos_t& pos, int token, Expr* target, const std::vector<ParsedArg>& args)
       : Expr(AstKind::CallExpr, pos),
         token_(token),
-        target_(target)
+        target_(target),
+        args_(args)
     {}
 
     bool Bind(SemaContext& sc) override;
@@ -915,9 +916,9 @@ class CallExpr final : public Expr
 
     static bool is_a(ParseNode* node) { return node->kind() == AstKind::CallExpr; }
 
-    PoolList<ParsedArg>& args() { return args_; }
-    PoolList<ComputedArg>& argv() { return argv_; }
-    const PoolList<ComputedArg>& argv() const { return argv_; }
+    PoolArray<ParsedArg>& args() { return args_; }
+    PoolArray<ComputedArg>& argv() { return argv_; }
+    const PoolArray<ComputedArg>& argv() const { return argv_; }
     Expr* target() const { return target_; }
     int token() const { return token_; }
     Expr* implicit_this() const { return implicit_this_; }
@@ -930,10 +931,10 @@ class CallExpr final : public Expr
 
     int token_;
     Expr* target_;
-    PoolList<ParsedArg> args_;
+    PoolArray<ParsedArg> args_;
     symbol* sym_ = nullptr;
     Expr* implicit_this_ = nullptr;
-    PoolList<ComputedArg> argv_;
+    PoolArray<ComputedArg> argv_;
 };
 
 class EmitOnlyExpr : public Expr

--- a/compiler/parse-node.h
+++ b/compiler/parse-node.h
@@ -1517,8 +1517,9 @@ class SwitchStmt : public Stmt
 class PragmaUnusedStmt : public Stmt
 {
   public:
-    PragmaUnusedStmt(const token_pos_t& pos)
-      : Stmt(AstKind::PragmaUnusedStmt, pos)
+    PragmaUnusedStmt(const token_pos_t& pos, const std::vector<sp::Atom*>& names)
+      : Stmt(AstKind::PragmaUnusedStmt, pos),
+        names_(names)
     {}
 
     bool Bind(SemaContext& sc) override;
@@ -1526,12 +1527,12 @@ class PragmaUnusedStmt : public Stmt
 
     static bool is_a(ParseNode* node) { return node->kind() == AstKind::PragmaUnusedStmt; }
 
-    PoolList<sp::Atom*>& names() { return names_; }
-    PoolList<symbol*>& symbols() { return symbols_; }
+    PoolArray<sp::Atom*>& names() { return names_; }
+    PoolArray<symbol*>& symbols() { return symbols_; }
 
   private:
-    PoolList<sp::Atom*> names_;
-    PoolList<symbol*> symbols_;
+    PoolArray<sp::Atom*> names_;
+    PoolArray<symbol*> symbols_;
 };
 
 struct FunctionArg {

--- a/compiler/parse-node.h
+++ b/compiler/parse-node.h
@@ -1473,10 +1473,14 @@ class ForStmt : public Stmt
 class SwitchStmt : public Stmt
 {
   public:
-    explicit SwitchStmt(const token_pos_t& pos, Expr* expr)
+    typedef std::pair<PoolArray<Expr*>, Stmt*> Case;
+
+    explicit SwitchStmt(const token_pos_t& pos, Expr* expr, std::vector<Case>&& cases,
+                        Stmt* default_case)
       : Stmt(AstKind::SwitchStmt, pos),
         expr_(expr),
-        default_case_(nullptr)
+        default_case_(default_case),
+        cases_(std::move(cases))
     {}
 
     bool Bind(SemaContext& sc) override;
@@ -1484,23 +1488,16 @@ class SwitchStmt : public Stmt
 
     static bool is_a(ParseNode* node) { return node->kind() == AstKind::SwitchStmt; }
 
-    void AddCase(PoolList<Expr*>&& exprs, Stmt* stmt) {
-        cases_.emplace_back(std::move(exprs), stmt);
-    }
-
-    typedef std::pair<PoolList<Expr*>, Stmt*> Case;
-
     Expr* expr() const { return expr_; }
     Expr* set_expr(Expr* expr) { return expr_ = expr; }
     Stmt* default_case() const { return default_case_; }
-    void set_default_case(Stmt* stmt) { default_case_ = stmt; }
-    const PoolList<Case>& cases() const { return cases_; }
+    const PoolArray<Case>& cases() const { return cases_; }
 
   private:
     Expr* expr_;
     Stmt* default_case_;
 
-    PoolList<Case> cases_;
+    PoolArray<Case> cases_;
 };
 
 class PragmaUnusedStmt : public Stmt

--- a/compiler/parse-node.h
+++ b/compiler/parse-node.h
@@ -369,10 +369,11 @@ class EnumDecl : public Decl
 {
   public:
     explicit EnumDecl(const token_pos_t& pos, int vclass, sp::Atom* label, sp::Atom* name,
-                      int increment, int multiplier)
+                      const std::vector<EnumField>& fields, int increment, int multiplier)
       : Decl(AstKind::EnumDecl, pos, name),
         vclass_(vclass),
         label_(label),
+        fields_(fields),
         increment_(increment),
         multiplier_(multiplier)
     {}
@@ -383,7 +384,7 @@ class EnumDecl : public Decl
 
     static bool is_a(ParseNode* node) { return node->kind() == AstKind::EnumDecl; }
 
-    PoolList<EnumField>& fields() {
+    PoolArray<EnumField>& fields() {
         return fields_;
     }
     int increment() const {
@@ -396,7 +397,7 @@ class EnumDecl : public Decl
   private:
     int vclass_;
     sp::Atom* label_;
-    PoolList<EnumField> fields_;
+    PoolArray<EnumField> fields_;
     int increment_;
     int multiplier_;
 };

--- a/compiler/parse-node.h
+++ b/compiler/parse-node.h
@@ -168,11 +168,13 @@ class ChangeScopeNode : public Stmt
 class StmtList : public Stmt
 {
   public:
-    explicit StmtList(AstKind kind, const token_pos_t& pos)
-      : Stmt(kind, pos)
+    explicit StmtList(AstKind kind, const token_pos_t& pos, const std::vector<Stmt*>& stmts)
+      : Stmt(kind, pos),
+        stmts_(stmts)
     {}
-    explicit StmtList(const token_pos_t& pos)
-      : Stmt(AstKind::StmtList, pos)
+    explicit StmtList(const token_pos_t& pos, const std::vector<Stmt*>& stmts)
+      : Stmt(AstKind::StmtList, pos),
+        stmts_(stmts)
     {}
 
     bool EnterNames(SemaContext& sc) override;
@@ -185,19 +187,19 @@ class StmtList : public Stmt
 
     static bool is_a(ParseNode* node) { return node->kind() == AstKind::StmtList; }
 
-    PoolList<Stmt*>& stmts() {
+    PoolArray<Stmt*>& stmts() {
         return stmts_;
     }
 
   protected:
-    PoolList<Stmt*> stmts_;
+    PoolArray<Stmt*> stmts_;
 };
 
 class ParseTree : public StmtList
 {
   public:
-    explicit ParseTree(const token_pos_t& pos)
-      : StmtList(AstKind::ParseTree, pos)
+    explicit ParseTree(const token_pos_t& pos, const std::vector<Stmt*>& stmts)
+      : StmtList(AstKind::ParseTree, pos, stmts)
     {}
 
     bool ResolveNames(SemaContext& sc);
@@ -208,8 +210,8 @@ class ParseTree : public StmtList
 class BlockStmt : public StmtList
 {
   public:
-    explicit BlockStmt(const token_pos_t& pos)
-      : StmtList(AstKind::BlockStmt, pos),
+    explicit BlockStmt(const token_pos_t& pos, const std::vector<Stmt*>& stmts)
+      : StmtList(AstKind::BlockStmt, pos, stmts),
         scope_(nullptr)
     {}
 

--- a/compiler/parse-node.h
+++ b/compiler/parse-node.h
@@ -1217,8 +1217,10 @@ class NewArrayExpr final : public Expr
 class ArrayExpr final : public Expr
 {
   public:
-    explicit ArrayExpr(const token_pos_t& pos)
-      : Expr(AstKind::ArrayExpr, pos)
+    ArrayExpr(const token_pos_t& pos, const std::vector<Expr*>& exprs, bool ellipses)
+      : Expr(AstKind::ArrayExpr, pos),
+        ellipses_(ellipses),
+        exprs_(exprs)
     {}
 
     bool Bind(SemaContext& sc) override;
@@ -1226,7 +1228,7 @@ class ArrayExpr final : public Expr
 
     static bool is_a(ParseNode* node) { return node->kind() == AstKind::ArrayExpr; }
 
-    PoolList<Expr*>& exprs() { return exprs_; }
+    PoolArray<Expr*>& exprs() { return exprs_; }
     bool ellipses() const { return ellipses_; }
     void set_ellipses() { ellipses_ = true; }
     bool synthesized_for_compat() const { return synthesized_for_compat_; }
@@ -1235,7 +1237,7 @@ class ArrayExpr final : public Expr
   private:
     bool ellipses_ = false;
     bool synthesized_for_compat_ = false;
-    PoolList<Expr*> exprs_;
+    PoolArray<Expr*> exprs_;
 };
 
 struct StructInitField {

--- a/compiler/parse-node.h
+++ b/compiler/parse-node.h
@@ -1536,16 +1536,11 @@ class PragmaUnusedStmt : public Stmt
     PoolArray<symbol*> symbols_;
 };
 
-struct FunctionArg {
-    VarDecl* decl;
-};
-
 class FunctionInfo : public PoolObject
 {
   public:
     explicit FunctionInfo(const token_pos_t& pos, const declinfo_t& decl);
 
-    void AddArg(VarDecl* arg);
     bool IsVariadic() const;
 
     bool Bind(SemaContext& sc);
@@ -1583,7 +1578,7 @@ class FunctionInfo : public PoolObject
     void set_is_static() { is_static_ = true; }
     bool is_static() const { return is_static_; }
 
-    PoolList<FunctionArg>& args() { return args_; }
+    PoolArray<VarDecl*>& args() { return args_; }
     const token_pos_t& pos() const { return pos_; }
 
     declinfo_t& decl() { return decl_; }
@@ -1624,7 +1619,7 @@ class FunctionInfo : public PoolObject
     bool is_forward_ = false;
     bool is_native_ = false;
     Stmt* body_ = nullptr;
-    PoolList<FunctionArg> args_;
+    PoolArray<VarDecl*> args_;
     symbol* sym_ = nullptr;
     SymbolScope* scope_ = nullptr;
     ke::Maybe<int> this_tag_;
@@ -1683,12 +1678,12 @@ class EnumStructDecl : public Decl
 
     static bool is_a(ParseNode* node) { return node->kind() == AstKind::EnumStructDecl; }
 
-    PoolList<FunctionDecl*>& methods() { return methods_; }
-    PoolList<EnumStructField>& fields() { return fields_; }
+    PoolArray<FunctionDecl*>& methods() { return methods_; }
+    PoolArray<EnumStructField>& fields() { return fields_; }
 
   private:
-    PoolList<FunctionDecl*> methods_;
-    PoolList<EnumStructField> fields_;
+    PoolArray<FunctionDecl*> methods_;
+    PoolArray<EnumStructField> fields_;
     symbol* root_ = nullptr;
 };
 
@@ -1722,8 +1717,8 @@ class MethodmapDecl : public Decl
 
     static bool is_a(ParseNode* node) { return node->kind() == AstKind::MethodmapDecl; }
 
-    PoolList<MethodmapProperty*>& properties() { return properties_; }
-    PoolList<MethodmapMethod*>& methods() { return methods_; }
+    PoolArray<MethodmapProperty*>& properties() { return properties_; }
+    PoolArray<MethodmapMethod*>& methods() { return methods_; }
 
   private:
     bool BindGetter(SemaContext& sc, MethodmapProperty* prop);
@@ -1732,8 +1727,8 @@ class MethodmapDecl : public Decl
   private:
     bool nullable_;
     sp::Atom* extends_;
-    PoolList<MethodmapProperty*> properties_;
-    PoolList<MethodmapMethod*> methods_;
+    PoolArray<MethodmapProperty*> properties_;
+    PoolArray<MethodmapMethod*> methods_;
 
     methodmap_t* map_ = nullptr;
     symbol* sym_ = nullptr;

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -589,9 +589,10 @@ Parser::parse_using()
 Stmt*
 Parser::parse_pragma_unused()
 {
-    PragmaUnusedStmt* stmt = new PragmaUnusedStmt(lexer_->pos());
+    auto pos = lexer_->pos();
 
     int tok = lexer_->lex_same_line();
+    std::vector<sp::Atom*> names;
     for (;;) {
         if (tok != tSYMBOL) {
             report(1) << get_token_string(tSYMBOL) << get_token_string(tok);
@@ -600,7 +601,7 @@ Parser::parse_pragma_unused()
         }
 
         sp::Atom* name = lexer_->current_token()->atom;
-        stmt->names().emplace_back(name);
+        names.emplace_back(name);
 
         tok = lexer_->lex_same_line();
         if (tok == ',') {
@@ -610,7 +611,7 @@ Parser::parse_pragma_unused()
         if (tok == tEOL)
             break;
     }
-    return stmt;
+    return new PragmaUnusedStmt(pos, names);
 }
 
 Stmt*

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -391,7 +391,7 @@ Parser::parse_enum(int vclass)
         lexer_->need(')');
     }
 
-    EnumDecl* decl = new EnumDecl(pos, vclass, label, name, increment, multiplier);
+    std::vector<EnumField> fields;
 
     lexer_->need('{');
 
@@ -422,12 +422,12 @@ Parser::parse_enum(int vclass)
             value = hier14();
 
         if (field_name)
-            decl->fields().push_back(EnumField(pos, field_name, value));
+            fields.push_back(EnumField(pos, field_name, value));
     } while (lexer_->match(','));
 
     lexer_->need('}');
     lexer_->match(';');
-    return decl;
+    return new EnumDecl(pos, vclass, label, name, fields, increment, multiplier);
 }
 
 Decl*

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -1425,7 +1425,9 @@ Parser::parse_stmt(int* lastindent, bool allow_decl)
                 error(24);
                 return nullptr;
             }
-            return new LoopControlStmt(pos, tok);
+            if (tok == tBREAK)
+                return new BreakStmt(pos);
+            return new ContinueStmt(pos);
         }
         case tRETURN: {
             auto pos = lexer_->pos();

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -1108,12 +1108,11 @@ Parser::constant()
 CallExpr*
 Parser::parse_call(const token_pos_t& pos, int tok, Expr* target)
 {
-    CallExpr* call = new CallExpr(pos, tok, target);
-
     if (lexer_->match(')'))
-        return call;
+        return new CallExpr(pos, tok, target, {});
 
     bool named_params = false;
+    std::vector<ParsedArg> args;
     do {
         sp::Atom* name = nullptr;
         if (lexer_->match('.')) {
@@ -1131,7 +1130,7 @@ Parser::parse_call(const token_pos_t& pos, int tok, Expr* target)
         if (!lexer_->match('_'))
             expr = hier14();
 
-        call->args().emplace_back(name, expr);
+        args.emplace_back(name, expr);
 
         if (lexer_->match(')'))
             break;
@@ -1139,7 +1138,7 @@ Parser::parse_call(const token_pos_t& pos, int tok, Expr* target)
             break;
     } while (lexer_->freading() && !lexer_->match(tENDEXPR));
 
-    return call;
+    return new CallExpr(pos, tok, target, args);
 }
 
 Expr*

--- a/compiler/parser.h
+++ b/compiler/parser.h
@@ -44,7 +44,7 @@ class Parser
     typedef Expr* (Parser::*NewHierFn)();
 
     static symbol* ParseInlineFunction(int tokid, const declinfo_t& decl, const int* this_tag);
-    void CreateInitialScopes(ParseTree* list);
+    void CreateInitialScopes(std::vector<Stmt*>* list);
 
     Stmt* parse_unknown_decl(const full_token_t* tok);
     Decl* parse_enum(int vclass);

--- a/compiler/parser.h
+++ b/compiler/parser.h
@@ -92,7 +92,7 @@ class Parser
     Stmt* parse_if();
     Stmt* parse_for();
     Stmt* parse_switch();
-    void parse_case(SwitchStmt* sw);
+    Stmt* parse_case(std::vector<Expr*>* exprs);
     Stmt* parse_pragma_unused();
     TypedefInfo* parse_function_type();
 

--- a/compiler/parser.h
+++ b/compiler/parser.h
@@ -57,8 +57,8 @@ class Parser
     Decl* parse_using();
     Decl* parse_enumstruct();
     Decl* parse_methodmap();
-    bool parse_methodmap_method(MethodmapDecl* map);
-    bool parse_methodmap_property(MethodmapDecl* map);
+    MethodmapMethod* parse_methodmap_method(MethodmapDecl* map);
+    MethodmapProperty* parse_methodmap_property(MethodmapDecl* map);
     bool parse_methodmap_property_accessor(MethodmapDecl* map, MethodmapProperty* prop);
 
     struct VarParams {
@@ -73,7 +73,7 @@ class Parser
     Stmt* parse_var(declinfo_t* decl, VarParams& params);
     void parse_post_dims(typeinfo_t* type);
     Expr* var_init(int vclass);
-    Decl* parse_inline_function(int tokid, const declinfo_t& decl, const int* this_tag);
+    Decl* parse_inline_function(int tokid, const declinfo_t& decl);
 
     bool parse_decl(declinfo_t* decl, int flags);
     bool parse_old_decl(declinfo_t* decl, int flags);
@@ -96,8 +96,8 @@ class Parser
     Stmt* parse_pragma_unused();
     TypedefInfo* parse_function_type();
 
-    bool parse_function(FunctionInfo* info, int tokid);
-    void parse_args(FunctionInfo* info);
+    bool parse_function(FunctionInfo* info, int tokid, bool has_this);
+    void parse_args(FunctionInfo* info, std::vector<VarDecl*>* args);
 
     // Wrapper around hier14() that allows comma expressions without a wrapping
     // parens.

--- a/compiler/pool-allocator.cpp
+++ b/compiler/pool-allocator.cpp
@@ -32,34 +32,6 @@ PoolAllocator::PoolAllocator()
 
 PoolAllocator::~PoolAllocator()
 {
-    unwind(nullptr);
-}
-
-char*
-PoolAllocator::enter()
-{
-    if (pools_.empty())
-        return nullptr;
-    return pools_.back()->ptr;
-}
-
-void
-PoolAllocator::leave(char* pos)
-{
-    unwind(pos);
-}
-
-void
-PoolAllocator::unwind(char* pos)
-{
-    while (!pools_.empty()) {
-        Pool* last = pools_.back().get();
-        if (pos && pos >= last->base.get() && pos < last->end) {
-            last->ptr = pos;
-            return;
-        }
-        pools_.pop_back();
-    }
 }
 
 PoolAllocator::Pool*

--- a/compiler/pool-allocator.h
+++ b/compiler/pool-allocator.h
@@ -51,14 +51,14 @@ class PoolAllocator final
         }
     };
 
-    static const size_t kDefaultPoolSize = 8 * 1024;
+    static const size_t kDefaultPoolSize = 64 * 1024;
     static const size_t kMaxReserveSize = 64 * 1024;
 
   private:
     std::vector<std::unique_ptr<Pool>> pools_;
+    size_t wasted_ = 0;
 
   private:
-    void unwind(char* pos);
     Pool* ensurePool(size_t actualBytes);
 
   public:
@@ -87,6 +87,12 @@ class PoolAllocator final
         return ptr;
     }
 
+    void trackFree(size_t bytes) {
+        wasted_ += bytes;
+    }
+
+    size_t wasted() const { return wasted_; }
+
     template <typename T>
     T* alloc(size_t count = 1) {
         if (!ke::IsUintPtrMultiplySafe(count, sizeof(T))) {
@@ -99,9 +105,6 @@ class PoolAllocator final
 
         return reinterpret_cast<T*>(ptr);
     }
-
-    char* enter();
-    void leave(char* position);
 };
 
 #endif // _include_jitcraft_pool_allocator_h_

--- a/compiler/pool-objects.cpp
+++ b/compiler/pool-objects.cpp
@@ -43,6 +43,11 @@ PoolAllocationPolicy::Malloc(size_t bytes)
     return p;
 }
 
+void PoolAllocationPolicy::Free(size_t bytes) {
+    auto& cc = CompileContext::get();
+    cc.allocator().trackFree(bytes);
+}
+
 void*
 PoolAllocationPolicy::am_malloc(size_t bytes)
 {

--- a/compiler/pool-objects.h
+++ b/compiler/pool-objects.h
@@ -79,6 +79,7 @@ class PoolAllocationPolicy
     void am_free(void* ptr);
 
     static void* Malloc(size_t bytes);
+    static void Free(size_t bytes);
 };
 
 template <typename T>
@@ -105,7 +106,9 @@ class StlPoolAllocator
             throw std::bad_alloc{};
         return reinterpret_cast<T*>(PoolAllocationPolicy::Malloc(n * sizeof(T)));
     }
-    void deallocate(T* p, size_t n) {}
+    void deallocate(T* p, size_t n) {
+        PoolAllocationPolicy::Free(sizeof(T) * n);
+    }
 
     bool operator ==(const StlPoolAllocator& other) const { return true; }
     bool operator !=(const StlPoolAllocator& other) const { return false; }

--- a/compiler/pool-objects.h
+++ b/compiler/pool-objects.h
@@ -17,6 +17,8 @@
 // SourcePawn. If not, see http://www.gnu.org/licenses/.
 #pragma once
 
+#include <forward_list>
+
 #include "compile-context.h"
 
 #include <amtl/am-fixedarray.h>
@@ -127,6 +129,9 @@ template <typename Key,
           typename Hash = std::hash<Key>,
           typename KeyEqual = std::equal_to<Key>>
 using PoolMap = std::unordered_map<Key, T, Hash, KeyEqual, StlPoolAllocator<std::pair<const Key, T>>>;
+
+template <typename T>
+using PoolForwardList = std::forward_list<T, StlPoolAllocator<T>>;
 
 struct KeywordTablePolicy {
     static bool matches(const sp::CharsAndLength& a, const sp::CharsAndLength& b) {

--- a/compiler/pool-objects.h
+++ b/compiler/pool-objects.h
@@ -19,6 +19,8 @@
 
 #include "compile-context.h"
 
+#include <amtl/am-fixedarray.h>
+
 class PoolObject
 {
   public:
@@ -117,6 +119,9 @@ class StlPoolAllocator
 template <typename T>
 using PoolList = std::vector<T, StlPoolAllocator<T>>;
 
+template <typename T>
+using PoolArray = ke::FixedArray<T, PoolAllocationPolicy>;
+
 template <typename Key,
           typename T,
           typename Hash = std::hash<Key>,
@@ -133,4 +138,3 @@ struct KeywordTablePolicy {
         return ke::HashCharSequence(key.str(), key.length());
     }
 };
-

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -69,12 +69,12 @@ static constexpr char DIRSEP_CHAR = '\\';
 static constexpr char DIRSEP_CHAR = '/';
 #endif
 
-struct ArrayData;
+struct DefaultArrayData;
 
 struct DefaultArg : public PoolObject {
     int tag = 0;
     ke::Maybe<cell> val;
-    ArrayData* array = nullptr;
+    DefaultArrayData* array = nullptr;
     symbol* sym = nullptr;
 
     ~DefaultArg();

--- a/compiler/sctracker.cpp
+++ b/compiler/sctracker.cpp
@@ -91,8 +91,9 @@ funcenum_t*
 funcenum_for_symbol(symbol* sym)
 {
     functag_t* ft = new functag_t;
-
     ft->ret_tag = sym->tag;
+
+    std::vector<funcarg_t> args;
     for (arginfo& arg : sym->function()->args) {
         funcarg_t dest;
         dest.type = arg.type;
@@ -100,8 +101,9 @@ funcenum_for_symbol(symbol* sym)
         if (dest.type.ident != iARRAY && dest.type.ident != iREFARRAY)
           assert(dest.type.dim.empty());
 
-        ft->args.push_back(dest);
+        args.emplace_back(dest);
     }
+    new (&ft->args) PoolArray<funcarg_t>(args);
 
     auto name = ke::StringPrintf("::ft:%s:%d:%d", sym->name(), sym->addr(), sym->codeaddr);
     funcenum_t* fe = funcenums_add(gAtoms.add(name));

--- a/compiler/sctracker.cpp
+++ b/compiler/sctracker.cpp
@@ -94,9 +94,6 @@ funcenum_for_symbol(symbol* sym)
 
     ft->ret_tag = sym->tag;
     for (arginfo& arg : sym->function()->args) {
-        if (!arg.type.ident)
-            break;
-
         funcarg_t dest;
         dest.type = arg.type;
 
@@ -154,8 +151,7 @@ methodmap_method_t::property_tag() const
     assert(getter || setter);
     if (getter)
         return getter->tag;
-    arginfo* thisp = &setter->function()->args[0];
-    if (thisp->type.ident == 0)
+    if (setter->function()->args.size() != 2)
         return types->tag_void();
     arginfo* valp = &setter->function()->args[1];
     if (valp->type.ident != iVARIABLE)

--- a/compiler/sctracker.cpp
+++ b/compiler/sctracker.cpp
@@ -62,14 +62,6 @@ pstructs_find(sp::Atom* name)
 }
 
 void
-pstructs_addarg(pstruct_t* pstruct, structarg_t* arg)
-{
-    arg->offs = pstruct->args.size() * sizeof(cell);
-    arg->index = pstruct->args.size();
-    pstruct->args.emplace_back(arg);
-}
-
-void
 funcenums_free()
 {
     sFuncEnums.clear();
@@ -107,7 +99,7 @@ funcenum_for_symbol(symbol* sym)
 
     auto name = ke::StringPrintf("::ft:%s:%d:%d", sym->name(), sym->addr(), sym->codeaddr);
     funcenum_t* fe = funcenums_add(gAtoms.add(name));
-    functags_add(fe, ft);
+    new (&fe->entries) PoolArray<functag_t*>({ft});
 
     return fe;
 }
@@ -123,12 +115,6 @@ functag_from_tag(int tag)
     if (fe->entries.empty())
         return nullptr;
     return fe->entries.back();
-}
-
-void
-functags_add(funcenum_t* en, functag_t* src)
-{
-    en->entries.push_back(src);
 }
 
 methodmap_t::methodmap_t(methodmap_t* parent, LayoutSpec spec, sp::Atom* name)

--- a/compiler/sctracker.h
+++ b/compiler/sctracker.h
@@ -17,7 +17,7 @@ struct funcenum_t {
     {}
     int tag;
     sp::Atom* name;
-    std::vector<functag_t*> entries;
+    PoolArray<functag_t*> entries;
 };
 
 struct structarg_t : public PoolObject
@@ -40,7 +40,7 @@ struct pstruct_t : public PoolObject
     explicit pstruct_t(sp::Atom* name);
 
     sp::Atom* name;
-    PoolList<structarg_t*> args;
+    PoolArray<structarg_t*> args;
 };
 
 // The ordering of these definitions should be preserved for
@@ -110,7 +110,6 @@ struct methodmap_t : public SymbolData
 pstruct_t* pstructs_add(sp::Atom* name);
 void pstructs_free();
 pstruct_t* pstructs_find(const char* name);
-void pstructs_addarg(pstruct_t* pstruct, structarg_t* arg);
 const structarg_t* pstructs_getarg(const pstruct_t* pstruct, sp::Atom* name);
 
 /**
@@ -118,7 +117,6 @@ const structarg_t* pstructs_getarg(const pstruct_t* pstruct, sp::Atom* name);
  */
 void funcenums_free();
 funcenum_t* funcenums_add(sp::Atom* name);
-void functags_add(funcenum_t* en, functag_t* src);
 funcenum_t* funcenum_for_symbol(symbol* sym);
 functag_t* functag_from_tag(int tag);
 

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -3127,15 +3127,15 @@ void Semantics::CheckFunctionReturnUsage(FunctionInfo* info) {
     if (sym->must_return_value())
         ReportFunctionReturnError(sym);
 
-    // We should always have a block statement for the body. If no '{' was
-    // detected it would have been an error in the parsing pass.
-    auto block = info->body()->as<BlockStmt>();
-    assert(block);
+        // Synthesize a return statement.
+    std::vector<Stmt*> stmts = {
+        info->body(),
+        new ReturnStmt(info->end_pos(), nullptr),
+    };
 
-    // Synthesize a return statement.
-    auto ret_stmt = new ReturnStmt(info->end_pos(), nullptr);
-    block->stmts().push_back(ret_stmt);
-    block->set_flow_type(Flow_Return);
+    auto new_body = new BlockStmt(info->body()->pos(), stmts);
+    new_body->set_flow_type(Flow_Return);
+    info->set_body(new_body);
 }
 
 void

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -3015,16 +3015,10 @@ FunctionInfo::FunctionInfo(const token_pos_t& pos, const declinfo_t& decl)
 {
 }
 
-void
-FunctionInfo::AddArg(VarDecl* arg)
-{
-    args_.emplace_back(FunctionArg{arg});
-}
-
 bool
 FunctionInfo::IsVariadic() const
 {
-    return !args_.empty() && args_.back().decl->type().ident == iVARARGS;
+    return !args_.empty() && args_.back()->type().ident == iVARARGS;
 }
 
 bool Semantics::CheckFunctionInfo(FunctionInfo* info) {
@@ -3219,7 +3213,7 @@ FunctionInfo::ProcessUses(SemaContext& outer_sc)
     SemaContext sc(outer_sc, sym_, this);
 
     for (const auto& arg : args_)
-        arg.decl->ProcessUses(sc);
+        arg->ProcessUses(sc);
 
     body_->ProcessUses(sc);
 }

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -149,8 +149,10 @@ bool Semantics::CheckStmt(Stmt* stmt, StmtFlags flags) {
             return CheckStmtList(stmt->to<StmtList>());
         case AstKind::StaticAssertStmt:
             return CheckStaticAssertStmt(stmt->to<StaticAssertStmt>());
-        case AstKind::LoopControlStmt:
-            return CheckLoopControlStmt(stmt->to<LoopControlStmt>());
+        case AstKind::BreakStmt:
+            return CheckBreakStmt(stmt->to<BreakStmt>());
+        case AstKind::ContinueStmt:
+            return CheckContinueStmt(stmt->to<ContinueStmt>());
         case AstKind::EnumDecl:
         case AstKind::PstructDecl:
         case AstKind::TypedefDecl:
@@ -2527,13 +2529,13 @@ AutoCollectSemaFlow::~AutoCollectSemaFlow()
     sc_.set_always_returns(old_value_);
 }
 
-bool Semantics::CheckLoopControlStmt(LoopControlStmt* stmt) {
-    int token = stmt->token();
-    if (token == tBREAK)
-        sc_->loop_has_break() = true;
-    else if (token == tCONTINUE)
-        sc_->loop_has_continue() = true;
+bool Semantics::CheckBreakStmt(BreakStmt* stmt) {
+    sc_->loop_has_break() = true;
+    return true;
+}
 
+bool Semantics::CheckContinueStmt(ContinueStmt* stmt) {
+    sc_->loop_has_continue() = true;
     return true;
 }
 

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -34,25 +34,6 @@
 #include "scvars.h"
 #include "symbols.h"
 
-AutoEnterScope::AutoEnterScope(SemaContext& sc, SymbolScope* scope)
-  : sc_(sc),
-    prev_(sc.scope())
-{
-    sc.set_scope(scope);
-}
-
-AutoEnterScope::AutoEnterScope(SemaContext& sc, ScopeKind kind)
-  : sc_(sc),
-    prev_(sc.scope())
-{
-    sc.set_scope(new SymbolScope(sc.scope(), kind));
-}
-
-AutoEnterScope::~AutoEnterScope()
-{
-    sc_.set_scope(prev_);
-}
-
 Semantics::Semantics(CompileContext& cc, ParseTree* tree)
   : cc_(cc),
     tree_(tree)
@@ -305,7 +286,6 @@ bool Semantics::CheckPstructArg(VarDecl* decl, const pstruct_t* ps, const Struct
             error(expr->pos(), 405);
             return false;
         }
-        decl->sym()->add_reference_to(sym);
     } else {
         assert(false);
         return false;

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -3362,7 +3362,7 @@ IsLegacyEnumTag(SymbolScope* scope, int tag)
 }
 
 void
-fill_arg_defvalue(VarDecl* decl, arginfo* arg)
+fill_arg_defvalue(CompileContext& cc, VarDecl* decl, arginfo* arg)
 {
     arg->def = new DefaultArg();
     arg->def->tag = decl->type().tag();
@@ -3378,11 +3378,12 @@ fill_arg_defvalue(VarDecl* decl, arginfo* arg)
         return;
     }
 
-    ArrayData data;
-    BuildArrayInitializer(decl, &data, 0);
+    auto array = cc.NewDefaultArrayData();
+    BuildArrayInitializer(decl, array, 0);
 
-    arg->def->array = new ArrayData;
-    *arg->def->array = std::move(data);
+    arg->def->array = array;
+    arg->def->array->iv_size = (cell_t)array->iv.size();
+    arg->def->array->data_size = (cell_t)array->data.size();
 }
 
 bool Semantics::CheckChangeScopeNode(ChangeScopeNode* node) {

--- a/compiler/semantics.h
+++ b/compiler/semantics.h
@@ -212,7 +212,8 @@ class Semantics final
     bool CheckArrayDeclaration(VarDecl* decl);
     bool CheckExprForArrayInitializer(Expr* expr);
     bool CheckNewArrayExprForArrayInitializer(NewArrayExpr* expr);
-    bool CheckArgument(CallExpr* call, arginfo* arg, Expr* expr, unsigned int argpos);
+    bool CheckArgument(CallExpr* call, arginfo* arg, Expr* expr,
+                       std::vector<ComputedArg>* argv, unsigned int argpos);
     symbol* BindNewTarget(Expr* target);
     symbol* BindCallTarget(CallExpr* call, Expr* target);
 

--- a/compiler/semantics.h
+++ b/compiler/semantics.h
@@ -162,7 +162,8 @@ class Semantics final
     bool CheckSwitchStmt(SwitchStmt* stmt);
     bool CheckForStmt(ForStmt* stmt);
     bool CheckDoWhileStmt(DoWhileStmt* stmt);
-    bool CheckLoopControlStmt(LoopControlStmt* stmt);
+    bool CheckBreakStmt(BreakStmt* stmt);
+    bool CheckContinueStmt(ContinueStmt* stmt);
     bool CheckExitStmt(ExitStmt* stmt);
     bool CheckDeleteStmt(DeleteStmt* stmt);
     bool CheckAssertStmt(AssertStmt* stmt);

--- a/compiler/semantics.h
+++ b/compiler/semantics.h
@@ -271,5 +271,5 @@ void check_void_decl(const typeinfo_t* type, int variable);
 void check_void_decl(const declinfo_t* decl, int variable);
 int check_operatortag(int opertok, int resulttag, const char* opername);
 int argcompare(arginfo* a1, arginfo* a2);
-void fill_arg_defvalue(VarDecl* decl, arginfo* arg);
+void fill_arg_defvalue(CompileContext& cc, VarDecl* decl, arginfo* arg);
 bool IsLegacyEnumTag(SymbolScope* scope, int tag);

--- a/compiler/symbols.cpp
+++ b/compiler/symbols.cpp
@@ -319,12 +319,14 @@ GetNewNameStatus(SemaContext& sc, sp::Atom* name, int vclass)
     symbol* sym = FindSymbol(sc, name, &scope);
     if (!sym)
         return NewNameStatus::Ok;
-    if (scope->kind() == sGLOBAL && sc.scope()->IsGlobalOrFileStatic()) {
+
+    SymbolScope* current = sc.ScopeForAdd();
+    if (scope->kind() == sGLOBAL && current->IsGlobalOrFileStatic()) {
         if (vclass == sSTATIC)
             return NewNameStatus::Shadowed;
         return NewNameStatus::Duplicated;
     }
-    if (scope == sc.scope())
+    if (scope == current)
         return NewNameStatus::Duplicated;
     return NewNameStatus::Shadowed;
 }
@@ -430,7 +432,7 @@ declare_methodmap_symbol(CompileContext& cc, methodmap_t* map)
 void
 DefineSymbol(SemaContext& sc, symbol* sym)
 {
-    auto scope = sc.scope();
+    auto scope = sc.ScopeForAdd();
     if (scope->kind() == sFILE_STATIC && sym->vclass != sSTATIC) {
         // The default scope is global scope, but "file static" scope comes
         // earlier in the lookup hierarchy, so skip past it if we need to.

--- a/compiler/symbols.cpp
+++ b/compiler/symbols.cpp
@@ -76,6 +76,8 @@ markusage(symbol* sym, int usage)
     // special handling, there's no concept of "stock" there.
     if (sym->vclass != sGLOBAL && sym->vclass != sSTATIC)
         return;
+    if (sym->ident != iFUNCTN)
+        return;
 
     parent_func->add_reference_to(sym);
 }
@@ -159,7 +161,7 @@ symbol::add_reference_to(symbol* other)
         if (sym == other)
             return;
     }
-    refers_to_.push_back(other);
+    refers_to_.emplace_front(other);
 }
 
 bool

--- a/compiler/symbols.cpp
+++ b/compiler/symbols.cpp
@@ -167,7 +167,7 @@ symbol::symbol(const symbol& other)
 void
 symbol::add_reference_to(symbol* other)
 {
-    for (symbol* sym : other->function()->refers_to) {
+    for (symbol* sym : function()->refers_to) {
         if (sym == other)
             return;
     }

--- a/compiler/symbols.cpp
+++ b/compiler/symbols.cpp
@@ -118,7 +118,6 @@ symbol::symbol(sp::Atom* symname, cell symaddr, int symident, int symvclass, int
    documentation(nullptr),
    addr_(symaddr),
    name_(nullptr),
-   referred_from_count_(0),
    parent_(nullptr),
    child_(nullptr)
 {
@@ -161,25 +160,6 @@ symbol::add_reference_to(symbol* other)
             return;
     }
     refers_to_.push_back(other);
-    other->referred_from_.push_back(this);
-    other->referred_from_count_++;
-}
-
-void
-symbol::drop_reference_from(symbol* from)
-{
-#if !defined(NDEBUG)
-    bool found = false;
-    for (size_t i = 0; i < referred_from_.size(); i++) {
-        if (referred_from_[i] == from) {
-            referred_from_[i] = nullptr;
-            found = true;
-            break;
-        }
-    }
-    assert(found);
-#endif
-    referred_from_count_--;
 }
 
 bool

--- a/compiler/symbols.cpp
+++ b/compiler/symbols.cpp
@@ -34,16 +34,26 @@
 void
 SymbolScope::Add(symbol* sym)
 {
-    assert(symbols_.find(sym->nameAtom()) == symbols_.end());
-    symbols_.emplace(sym->nameAtom(), sym);
+    if (!symbols_) {
+        auto& cc = CompileContext::get();
+        symbols_ = cc.NewSymbolMap();
+    }
+
+    assert(symbols_->find(sym->nameAtom()) == symbols_->end());
+    symbols_->emplace(sym->nameAtom(), sym);
 }
 
 void
 SymbolScope::AddChain(symbol* sym)
 {
-    auto iter = symbols_.find(sym->nameAtom());
-    if (iter == symbols_.end()) {
-        symbols_.emplace(sym->nameAtom(), sym);
+    if (!symbols_) {
+        auto& cc = CompileContext::get();
+        symbols_ = cc.NewSymbolMap();
+    }
+
+    auto iter = symbols_->find(sym->nameAtom());
+    if (iter == symbols_->end()) {
+        symbols_->emplace(sym->nameAtom(), sym);
     } else {
         sym->next = iter->second;
         iter->second = sym;

--- a/compiler/symbols.cpp
+++ b/compiler/symbols.cpp
@@ -157,11 +157,11 @@ symbol::symbol(const symbol& other)
 void
 symbol::add_reference_to(symbol* other)
 {
-    for (symbol* sym : refers_to_) {
+    for (symbol* sym : other->function()->refers_to) {
         if (sym == other)
             return;
     }
-    refers_to_.emplace_front(other);
+    function()->refers_to.emplace_front(other);
 }
 
 bool
@@ -297,7 +297,7 @@ deduce_liveness(CompileContext& cc)
     while (!work.empty()) {
         symbol* live = ke::PopBack(&work);
 
-        for (const auto& other : live->refers_to()) {
+        for (const auto& other : live->function()->refers_to) {
             if (!enqueue(other))
                 continue;
             if (auto alias = other->function()->alias)

--- a/compiler/symbols.cpp
+++ b/compiler/symbols.cpp
@@ -86,8 +86,6 @@ FunctionData::FunctionData()
    forward(nullptr),
    alias(nullptr)
 {
-    // Always have one empty argument at the end.
-    args.emplace_back();
 }
 
 symbol::symbol(sp::Atom* symname, cell symaddr, int symident, int symvclass, int symtag)
@@ -197,15 +195,9 @@ bool
 symbol::is_variadic() const
 {
     assert(ident == iFUNCTN);
-    arginfo* arg = &function()->args[0];
-    while (arg->type.ident) {
-        if (arg->type.ident == iVARARGS)
-            return true;
-        arg++;
-    }
-    return false;
+    const auto& args = function()->args;
+    return !args.empty() && args.back().type.ident == iVARARGS;
 }
-
 
 symbol*
 NewVariable(sp::Atom* name, cell addr, int ident, int vclass, int tag, int dim[], int numdim,
@@ -237,14 +229,11 @@ NewVariable(sp::Atom* name, cell addr, int ident, int vclass, int tag, int dim[]
     return sym;
 }
 
-int
-findnamedarg(arginfo* arg, sp::Atom* name)
-{
-    int i;
-
-    for (i = 0; arg[i].type.ident != 0 && arg[i].type.ident != iVARARGS; i++)
-        if (arg[i].name == name)
-            return i;
+int findnamedarg(const PoolArray<arginfo>& args, sp::Atom* name) {
+    for (int i = 0; i < args.size() && args[i].type.ident != iVARARGS; i++) {
+        if (args[i].name == name)
+            return (int)i;
+    }
     return -1;
 }
 

--- a/compiler/symbols.cpp
+++ b/compiler/symbols.cpp
@@ -81,8 +81,7 @@ markusage(symbol* sym, int usage)
 }
 
 FunctionData::FunctionData()
- : array(nullptr),
-   node(nullptr),
+ : node(nullptr),
    forward(nullptr),
    alias(nullptr)
 {

--- a/compiler/symbols.h
+++ b/compiler/symbols.h
@@ -50,7 +50,7 @@ class FunctionData final : public SymbolData
 
     void resizeArgs(size_t nargs);
 
-    PoolList<PoolString> dbgstrs;
+    std::vector<std::string>* dbgstrs = nullptr;
     PoolArray<arginfo> args;
     ReturnArrayInfo* return_array = nullptr;
     FunctionInfo* node;

--- a/compiler/symbols.h
+++ b/compiler/symbols.h
@@ -34,6 +34,12 @@ class FunctionInfo;
 class SemaContext;
 struct token_pos_t;
 
+struct ReturnArrayInfo : public PoolObject {
+    cell_t iv_size;
+    cell_t dat_addr;
+    cell_t zeroes;
+};
+
 class FunctionData final : public SymbolData
 {
   public:
@@ -46,7 +52,7 @@ class FunctionData final : public SymbolData
 
     PoolList<PoolString> dbgstrs;
     PoolArray<arginfo> args;
-    ArrayData* array;    // For functions with array returns
+    ReturnArrayInfo* return_array = nullptr;
     FunctionInfo* node;
     FunctionInfo* forward;
     symbol* alias;

--- a/compiler/symbols.h
+++ b/compiler/symbols.h
@@ -247,12 +247,15 @@ class SymbolScope final : public PoolObject
     SymbolScope(SymbolScope* parent, ScopeKind kind, int fnumber = -1)
       : parent_(parent),
         kind_(kind),
+        symbols_(nullptr),
         fnumber_(fnumber)
     {}
 
     symbol* Find(sp::Atom* atom) const {
-        auto iter = symbols_.find(atom);
-        if (iter == symbols_.end())
+        if (!symbols_)
+            return nullptr;
+        auto iter = symbols_->find(atom);
+        if (iter == symbols_->end())
             return nullptr;
         return iter->second;
     }
@@ -263,7 +266,9 @@ class SymbolScope final : public PoolObject
     void AddChain(symbol* sym);
 
     void ForEachSymbol(const std::function<void(symbol*)>& callback) {
-        for (const auto& pair : symbols_) {
+        if (!symbols_)
+            return;
+        for (const auto& pair : *symbols_) {
             for (symbol* iter = pair.second; iter; iter = iter->next)
                 callback(iter);
         }
@@ -285,7 +290,7 @@ class SymbolScope final : public PoolObject
   private:
     SymbolScope* parent_;
     ScopeKind kind_;
-    PoolMap<sp::Atom*, symbol*> symbols_;
+    std::unordered_map<sp::Atom*, symbol*>* symbols_;
     int fnumber_;
 };
 

--- a/compiler/symbols.h
+++ b/compiler/symbols.h
@@ -45,7 +45,7 @@ class FunctionData final : public SymbolData
     void resizeArgs(size_t nargs);
 
     PoolList<PoolString> dbgstrs;
-    PoolList<arginfo> args;
+    PoolArray<arginfo> args;
     ArrayData* array;    // For functions with array returns
     FunctionInfo* node;
     FunctionInfo* forward;
@@ -352,7 +352,7 @@ bool CheckNameRedefinition(SemaContext& sc, sp::Atom* name, const token_pos_t& p
 void markusage(symbol* sym, int usage);
 symbol* NewVariable(sp::Atom* name, cell addr, int ident, int vclass, int tag, int dim[],
                     int numdim, int semantic_tag);
-int findnamedarg(arginfo* arg, sp::Atom* name);
+int findnamedarg(const PoolArray<arginfo>& arg, sp::Atom* name);
 symbol* FindEnumStructField(Type* type, sp::Atom* name);
 void deduce_liveness(CompileContext& cc);
 void declare_handle_intrinsics();

--- a/compiler/symbols.h
+++ b/compiler/symbols.h
@@ -209,17 +209,9 @@ struct symbol : public PoolObject
     }
 
     void add_reference_to(symbol* other);
-    void drop_reference_from(symbol* from);
 
     PoolList<symbol*>& refers_to() {
         return refers_to_;
-    }
-    bool is_unreferenced() const {
-        return referred_from_count_ == 0;
-    }
-    void clear_refers() {
-        refers_to_.clear();
-        referred_from_.clear();
     }
     bool is_variadic() const;
     bool must_return_value() const;
@@ -238,10 +230,6 @@ struct symbol : public PoolObject
 
     // Other symbols that this symbol refers to.
     PoolList<symbol*> refers_to_;
-
-    // All the symbols that refer to this symbol.
-    PoolList<symbol*> referred_from_;
-    size_t referred_from_count_;
 
     symbol* parent_;
     symbol* child_;

--- a/compiler/symbols.h
+++ b/compiler/symbols.h
@@ -67,7 +67,7 @@ class EnumData final : public SymbolData
   public:
     EnumData* asEnum() override { return this; }
 
-    PoolList<symbol*> children;
+    PoolArray<symbol*> children;
 };
 
 class EnumStructData final : public SymbolData
@@ -75,8 +75,8 @@ class EnumStructData final : public SymbolData
   public:
     EnumStructData* asEnumStruct() override { return this; }
 
-    PoolList<symbol*> fields;
-    PoolList<symbol*> methods;
+    PoolArray<symbol*> fields;
+    PoolArray<symbol*> methods;
 };
 
 /*  Symbol table format

--- a/compiler/symbols.h
+++ b/compiler/symbols.h
@@ -58,6 +58,9 @@ class FunctionData final : public SymbolData
     symbol* alias;
     sp::Label label;     // modern replacement for addr
     sp::Label funcid;
+
+    // Other symbols that this symbol refers to.
+    PoolForwardList<symbol*> refers_to;
 };
 
 class EnumStructVarData final : public SymbolData
@@ -210,9 +213,6 @@ struct symbol : public PoolObject
 
     void add_reference_to(symbol* other);
 
-    PoolForwardList<symbol*>& refers_to() {
-        return refers_to_;
-    }
     bool is_variadic() const;
     bool must_return_value() const;
     bool used() const {
@@ -227,9 +227,6 @@ struct symbol : public PoolObject
     cell addr_; /* address or offset (or value for constant, index for native function) */
     sp::Atom* name_;
     SymbolData* data_;
-
-    // Other symbols that this symbol refers to.
-    PoolForwardList<symbol*> refers_to_;
 
     symbol* parent_;
     symbol* child_;

--- a/compiler/symbols.h
+++ b/compiler/symbols.h
@@ -210,7 +210,7 @@ struct symbol : public PoolObject
 
     void add_reference_to(symbol* other);
 
-    PoolList<symbol*>& refers_to() {
+    PoolForwardList<symbol*>& refers_to() {
         return refers_to_;
     }
     bool is_variadic() const;
@@ -229,7 +229,7 @@ struct symbol : public PoolObject
     SymbolData* data_;
 
     // Other symbols that this symbol refers to.
-    PoolList<symbol*> refers_to_;
+    PoolForwardList<symbol*> refers_to_;
 
     symbol* parent_;
     symbol* child_;

--- a/compiler/symbols.h
+++ b/compiler/symbols.h
@@ -277,6 +277,8 @@ class SymbolScope final : public PoolObject
     }
 
     SymbolScope* parent() const { return parent_; }
+    void set_parent(SymbolScope* scope) { parent_ = scope; }
+
     ScopeKind kind() const { return kind_; }
     int fnumber() const { return fnumber_; }
 

--- a/compiler/types.h
+++ b/compiler/types.h
@@ -168,7 +168,7 @@ struct functag_t : public PoolObject
        args()
     {}
     int ret_tag;
-    PoolList<funcarg_t> args;
+    PoolArray<funcarg_t> args;
 };
 
 class Type

--- a/compiler/types.h
+++ b/compiler/types.h
@@ -100,12 +100,12 @@ struct typeinfo_t {
     PoolList<int> dim;
 
     // Either null or an array of size |numdim|, pool-allocated.
-    PoolList<Expr*> dim_exprs;
+    PoolArray<Expr*> dim_exprs;
 
     // Type information.
     sp::Atom* type_atom;    // Parsed atom.
     int tag_;               // Effective tag.
-    int ident;              // Either iREFERENCE, iARRAY, or iVARIABLE.
+    int ident;          // Either iREFERENCE, iARRAY, or iVARIABLE.
     bool is_const : 1;
     bool is_new : 1;        // New-style declaration.
     bool has_postdims : 1;  // Dimensions, if present, were in postfix position.
@@ -153,7 +153,7 @@ struct typeinfo_t {
     bool isCharArray() const;
     Expr* get_dim_expr(int i) {
         assert(i < numdim());
-        return dim_exprs.empty() ? nullptr : dim_exprs[i];
+        return i < dim_exprs.size() ? dim_exprs[i] : nullptr;
     }
 };
 

--- a/tests/compile-only/ok-recursive-liveness.sp
+++ b/tests/compile-only/ok-recursive-liveness.sp
@@ -1,0 +1,16 @@
+
+
+void initPlayerData(int i) {
+    if (i < 5)
+        initPlayerData(i++);
+}
+void initAllPlayerData() {
+    initPlayerData(0);
+}
+void initStructures() {
+    initAllPlayerData();
+}
+
+public void main() {
+    initStructures();
+}

--- a/vm/compiled-function.cpp
+++ b/vm/compiled-function.cpp
@@ -66,7 +66,7 @@ CompiledFunction::FindCipByPc(void* pc)
 
   if (!cip_map_sorted_) {
     qsort(cip_map_->buffer(),
-          cip_map_->length(),
+          cip_map_->size(),
           sizeof(CipMapEntry),
           cip_map_entry_sort_cmp);
     cip_map_sorted_ = true;
@@ -75,7 +75,7 @@ CompiledFunction::FindCipByPc(void* pc)
   void* ptr = bsearch(
     (void*)(uintptr_t)pcoffs,
     cip_map_->buffer(),
-    cip_map_->length(),
+    cip_map_->size(),
     sizeof(CipMapEntry),
     cip_map_entry_cmp);
   assert(ptr);

--- a/vm/compiled-function.h
+++ b/vm/compiled-function.h
@@ -62,7 +62,7 @@ class CompiledFunction
     return code_offset_;
   }
   uint32_t NumLoopEdges() const {
-    return edges_->length();
+    return edges_->size();
   }
   LoopEdge& GetLoopEdge(size_t i) {
     return edges_->at(i);


### PR DESCRIPTION
This is a series of minor refactorings that restructure how memory is allocated in the compiler.  As part of the rewrite of the compiler, we played fast and loose with how memory is allocated. It's not terrible, but for embedding, especially in a 32-bit application, where we might want parallel compilation - it can be a lot better.

PoolAllocator is a bump-pointer allocator which allows efficient AST construction. However we've been using it with STL data structures. Anytime STL reallocates something, the memory is wasted. Most changes in this series are moving STL data structures out of PoolAllocator wherever it is easy to do so. Primarily, this means changing PoolList (std::vector) to PoolArray (ke::FixedArray), which required slight changes to how the AST is constructed.

Another offender is PoolMap. Construction of symbol maps is now tied to CompileContext instead of PoolAllocator. Unfortunately we lose tracking of that memory for now, but it means we don't waste bump-pointer memory.

In addition we've removed a bunch of data structures and data structure fields that were unnecessary or unused.

Another major change is that symbol scopes are now lazily allocated. This is a technique taken from the defunct experimental compiler, and it saves a lot of memory due to the sheer number of possible scopes in most programs.

This work is not comprehensive, there are still many improvements to make. However I wanted this change in the 1.11 branch now in order to set a new standard for AST work going forward.

In total, this reduces PoolAllocator memory use by about 35%. Compiling funcommands.sp used to use 6.5M of memory and now it only uses 4MB.

Note: initially, I tried mimalloc as a replacement for PoolAllocator. It used an enormous amount of memory so I abandoned that change pretty quickly.