### PR TITLE
Track big allocations that skip PoolAllocator.

### DIFF
--- a/compiler/array-helpers.cpp
+++ b/compiler/array-helpers.cpp
@@ -867,10 +867,10 @@ class ArrayEmitter final
 
     void Emit();
 
-    std::vector<cell>& iv() {
+    tr::vector<cell>& iv() {
         return iv_;
     }
-    std::vector<cell>& data() {
+    tr::vector<cell>& data() {
         return data_;
     }
     size_t pending_zeroes() const {
@@ -895,8 +895,8 @@ class ArrayEmitter final
     const typeinfo_t& type_;
     Type* es_;
     Expr* init_;
-    std::vector<cell> iv_;
-    std::vector<cell> data_;
+    tr::vector<cell> iv_;
+    tr::vector<cell> data_;
     size_t pending_zeroes_;
 };
 

--- a/compiler/code-generator.h
+++ b/compiler/code-generator.h
@@ -42,11 +42,11 @@ class CodeGenerator final
 
     void LinkPublicFunction(symbol* sym, uint32_t id);
 
-    const std::vector<std::string>& debug_strings() const { return debug_strings_; }
-    const std::vector<symbol*>& native_list() const { return native_list_; }
+    const tr::vector<tr::string>& debug_strings() const { return debug_strings_; }
+    const tr::vector<symbol*>& native_list() const { return native_list_; }
 
     const uint8_t* code_ptr() const { return asm_.bytes(); }
-    uint32_t code_size() const { return asm_.size(); }
+    uint32_t code_size() const { return (uint32_t)asm_.size(); }
     const uint8_t* data_ptr() const { return data_.dat(); }
     uint32_t data_size() const { return data_.size(); }
     int max_script_memory() const { return max_script_memory_; }
@@ -116,7 +116,7 @@ class CodeGenerator final
     void AddDebugFile(const std::string& line);
     void AddDebugLine(int linenr);
     void AddDebugSymbol(symbol* sym);
-    void AddDebugSymbols(std::vector<symbol*>* list);
+    void AddDebugSymbols(tr::vector<symbol*>* list);
     void EnqueueDebugSymbol(symbol* sym);
 
     // Helper that automatically handles heap deallocations.
@@ -187,12 +187,12 @@ class CodeGenerator final
         return !stack_scopes_.empty() || !heap_scopes_.empty();
     }
 
-    void EnterMemoryScope(std::vector<MemoryScope>& frame);
+    void EnterMemoryScope(tr::vector<MemoryScope>& frame);
     void AllocInScope(MemoryScope& scope, MemuseType type, int size);
-    int PopScope(std::vector<MemoryScope>& scope_list);
+    int PopScope(tr::vector<MemoryScope>& scope_list);
 
   private:
-    typedef std::vector<std::vector<symbol*>> SymbolStack;
+    typedef tr::vector<tr::vector<symbol*>> SymbolStack;
 
     class AutoEnterScope {
       public:
@@ -211,18 +211,18 @@ class CodeGenerator final
     symbol* func_ = nullptr;
     int max_script_memory_ = 0;
 
-    std::vector<std::string> debug_strings_;
-    std::vector<symbol*> native_list_;
+    tr::vector<tr::string> debug_strings_;
+    tr::vector<symbol*> native_list_;
     sp::SmxAssemblyBuffer asm_;
     DataQueue data_;
 
     ke::Maybe<uint32_t> last_break_op_;
-    std::vector<MemoryScope> stack_scopes_;
-    std::vector<MemoryScope> heap_scopes_;
+    tr::vector<MemoryScope> stack_scopes_;
+    tr::vector<MemoryScope> heap_scopes_;
     SymbolStack local_syms_;
-    std::vector<symbol*> global_syms_;
-    std::vector<std::pair<SymbolScope*, std::vector<symbol*>>> static_syms_;
-    std::unordered_set<SymbolScope*> static_scopes_;
+    tr::vector<symbol*> global_syms_;
+    tr::vector<std::pair<SymbolScope*, tr::vector<symbol*>>> static_syms_;
+    tr::unordered_set<SymbolScope*> static_scopes_;
 
     // Loop handling.
     struct LoopContext {

--- a/compiler/data-queue.cpp
+++ b/compiler/data-queue.cpp
@@ -61,7 +61,7 @@ DataQueue::Add(const char* text, size_t length)
 }
 
 void
-DataQueue::Add(std::vector<cell>&& cells)
+DataQueue::Add(tr::vector<cell>&& cells)
 {
     if (cells.empty())
         return;

--- a/compiler/data-queue.h
+++ b/compiler/data-queue.h
@@ -28,14 +28,14 @@ class DataQueue final
     DataQueue();
 
     void Add(cell value);
-    void Add(std::vector<cell>&& cells);
+    void Add(tr::vector<cell>&& cells);
     void Add(const char* text, size_t length);
     void AddZeroes(cell count);
 
-    cell size() const { return buffer_.size() * sizeof(cell); }
+    cell size() const { return (cell)buffer_.size() * sizeof(cell); }
     cell dat_address() const { return (cell)buffer_.size() * sizeof(cell); }
     const uint8_t* dat() const { return reinterpret_cast<const uint8_t*>(buffer_.data()); }
 
   private:
-    std::vector<cell> buffer_;
+    tr::vector<cell> buffer_;
 };

--- a/compiler/main.cpp
+++ b/compiler/main.cpp
@@ -288,6 +288,10 @@ cleanup:
             size_t allocated, reserved, bookkeeping;
             cc.allocator().memoryUsage(&allocated, &reserved, &bookkeeping);
 
+            printf("\n");
+            printf(" -- Compiler memory usage --\n");
+            printf("Malloc bytes:      %8" KE_FMT_SIZET " bytes\n", cc.malloc_bytes());
+            printf("Malloc bytes peak: %8" KE_FMT_SIZET " bytes\n", cc.malloc_bytes_peak());
             printf("Pool allocation:   %8" KE_FMT_SIZET " bytes\n", allocated);
             printf("Pool unused:       %8" KE_FMT_SIZET " bytes\n", reserved - allocated);
             printf("Pool bookkeeping:  %8" KE_FMT_SIZET " bytes\n", bookkeeping);

--- a/compiler/parse-node.cpp
+++ b/compiler/parse-node.cpp
@@ -95,3 +95,18 @@ BinaryExprBase::BinaryExprBase(AstKind kind, const token_pos_t& pos, int token, 
 {
     assert(right_ != this);
 }
+
+FunctionInfo::FunctionInfo(const token_pos_t& pos, const declinfo_t& decl)
+  : pos_(pos),
+    decl_(decl),
+    analyzed_(false),
+    analyze_result_(false),
+    is_public_(false),
+    is_static_(false),
+    is_stock_(false),
+    is_forward_(false),
+    is_native_(false),
+    is_analyzing_(false),
+    maybe_returns_array_(false)
+{
+}

--- a/compiler/parse-node.h
+++ b/compiler/parse-node.h
@@ -1592,9 +1592,12 @@ class FunctionInfo : public PoolObject
 
     bool is_analyzing() const { return is_analyzing_; }
     void set_is_analyzing(bool val) { is_analyzing_ = val; }
-    bool is_analyzed() const { return analyzed_.isValid(); }
-    bool analysis_status() const { return analyzed_.get(); }
-    void set_analyzed(bool val) { analyzed_.init(val); }
+    bool is_analyzed() const { return analyzed_; }
+    bool analysis_status() const { return analyze_result_; }
+    void set_analyzed(bool val) {
+        analyzed_ = true;
+        analyze_result_ = val;
+    }
 
     SymbolScope* scope() const { return scope_; }
 
@@ -1613,20 +1616,21 @@ class FunctionInfo : public PoolObject
     token_pos_t end_pos_;
     declinfo_t decl_;
     sp::Atom* name_ = nullptr;
-    bool is_public_ = false;
-    bool is_static_ = false;
-    bool is_stock_ = false;
-    bool is_forward_ = false;
-    bool is_native_ = false;
     Stmt* body_ = nullptr;
     PoolArray<VarDecl*> args_;
     symbol* sym_ = nullptr;
     SymbolScope* scope_ = nullptr;
     ke::Maybe<int> this_tag_;
     sp::Atom* alias_ = nullptr;
-    ke::Maybe<bool> analyzed_;
-    bool is_analyzing_ = false;
-    bool maybe_returns_array_ = false;
+    bool analyzed_ SP_BITFIELD(1);
+    bool analyze_result_ SP_BITFIELD(1);
+    bool is_public_ SP_BITFIELD(1);
+    bool is_static_ SP_BITFIELD(1);
+    bool is_stock_ SP_BITFIELD(1);
+    bool is_forward_ SP_BITFIELD(1);
+    bool is_native_ SP_BITFIELD(1);
+    bool is_analyzing_ SP_BITFIELD(1);
+    bool maybe_returns_array_ SP_BITFIELD(1);
 };
 
 class FunctionDecl : public Decl

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -190,4 +190,11 @@ constexpr cell char_array_cells(cell size) {
 
 extern sp::StringPool gAtoms;
 
+// Disable this to enable easy watchpoints on bitfield members.
+#if 1
+# define SP_BITFIELD(n) : n
+#else
+# define SP_BITFIELD(n)
+#endif
+
 #endif /* SC_H_INCLUDED */

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -2989,12 +2989,6 @@ ReportFunctionReturnError(symbol* sym)
     }
 }
 
-FunctionInfo::FunctionInfo(const token_pos_t& pos, const declinfo_t& decl)
-  : pos_(pos),
-    decl_(decl)
-{
-}
-
 bool
 FunctionInfo::IsVariadic() const
 {

--- a/compiler/semantics.h
+++ b/compiler/semantics.h
@@ -239,7 +239,7 @@ class Semantics final
     CompileContext& cc_;
     TypeDictionary* types_ = nullptr;
     ParseTree* tree_;
-    std::unordered_set<SymbolScope*> static_scopes_;
+    tr::unordered_set<SymbolScope*> static_scopes_;
     SemaContext* sc_ = nullptr;
     bool pending_heap_allocation_ = false;
 };

--- a/compiler/source-file.cpp
+++ b/compiler/source-file.cpp
@@ -108,7 +108,7 @@ SourceFile::Reset(int64_t pos)
 {
     assert(pos >= 0);
     assert((size_t)pos <= data_.size());
-    pos_ = pos;
+    pos_ = (size_t)pos;
 }
 
 int

--- a/compiler/source-file.h
+++ b/compiler/source-file.h
@@ -24,6 +24,8 @@
 #include <memory>
 #include <string>
 
+#include "stl/stl-string.h"
+
 class SourceFile
 {
   public:
@@ -41,6 +43,6 @@ class SourceFile
   private:
     std::unique_ptr<FILE, decltype(&::fclose)> fp_;
     std::string name_;
-    std::string data_;
+    tr::string data_;
     size_t pos_;
 };

--- a/compiler/stl/stl-allocator.h
+++ b/compiler/stl/stl-allocator.h
@@ -1,0 +1,64 @@
+// vim: set sts=4 ts=8 sw=4 tw=99 et:
+//
+// Copyright (C) 2012-2014 David Anderson
+//
+// This file is part of SourcePawn.
+//
+// SourcePawn is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// SourcePawn is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// SourcePawn. If not, see http://www.gnu.org/licenses/.
+
+#pragma once
+
+#include <stddef.h>
+
+#include <type_traits>
+
+#include <amtl/am-bits.h>
+
+class NativeAllocator
+{
+  public:
+    static void* Malloc(size_t n);
+    static void Free(void* p, size_t n);
+};
+
+template <typename T>
+class StlAllocator
+{
+  public:
+    typedef T value_type;
+    typedef std::true_type propagate_on_container_move_assignment;
+    typedef std::true_type propagate_on_container_copy_assignment;
+    typedef std::true_type propagate_on_container_swap;
+    typedef std::true_type is_always_equal;
+
+    StlAllocator() = default;
+    StlAllocator(const StlAllocator&) = default;
+
+    template <typename U>
+    StlAllocator(const StlAllocator<U>& other) {}
+
+    template <typename U>
+    using rebind = StlAllocator<U>;
+
+    static T* allocate(size_t n, const void* = nullptr) {
+        if (!ke::IsUintMultiplySafe(n, sizeof(T)))
+            throw std::bad_alloc{};
+        return reinterpret_cast<T*>(NativeAllocator::Malloc(n * sizeof(T)));
+    }
+    void deallocate(T* p, size_t n) {
+        NativeAllocator::Free(p, sizeof(T) * n);
+    }
+
+    bool operator ==(const StlAllocator& other) const { return true; }
+    bool operator !=(const StlAllocator& other) const { return false; }
+};

--- a/compiler/stl/stl-forward-list.h
+++ b/compiler/stl/stl-forward-list.h
@@ -1,0 +1,30 @@
+// vim: set sts=4 ts=8 sw=4 tw=99 et:
+//
+// Copyright (C) 2012-2014 David Anderson
+//
+// This file is part of SourcePawn.
+//
+// SourcePawn is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// SourcePawn is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// SourcePawn. If not, see http://www.gnu.org/licenses/.
+
+#pragma once
+
+#include <forward_list>
+
+#include "stl-allocator.h"
+
+namespace tr {
+ 
+template <typename T>
+using forward_list = std::forward_list<T, StlAllocator<T>>;
+
+} // namespace tr

--- a/compiler/stl/stl-string.h
+++ b/compiler/stl/stl-string.h
@@ -1,7 +1,6 @@
 // vim: set ts=8 sts=4 sw=4 tw=99 et:
-//  Pawn compiler - Recursive descend expresion parser
 //
-//  Copyright (c) ITB CompuPhase, 1997-2005
+//  Copyright (c) AlliedModders LLC 2021
 //
 //  This software is provided "as-is", without any express or implied warranty.
 //  In no event will the authors be held liable for any damages arising from
@@ -20,22 +19,16 @@
 //  3.  This notice may not be removed or altered from any source distribution.
 #pragma once
 
-#include <stdint.h>
+#include <string>
 
-#include <sp_vm_types.h>
-#include "stl/stl-vector.h"
+#include "stl-allocator.h"
 
-struct ArrayData {
-    tr::vector<cell_t> iv;
-    tr::vector<cell_t> data;
-    uint32_t zeroes;
+namespace tr {
 
-    size_t total_size() const {
-        return iv.size() + data.size() + zeroes;
-    }
-};
+template <typename Char,
+	  typename Traits = std::char_traits<Char>>
+using basic_string = std::basic_string<Char, Traits, StlAllocator<Char>>;
 
-struct DefaultArrayData : public ArrayData {
-    cell_t iv_size;
-    cell_t data_size;
-};
+using string = basic_string<char>;
+
+} // namespace tr

--- a/compiler/stl/stl-unordered-map.h
+++ b/compiler/stl/stl-unordered-map.h
@@ -1,0 +1,33 @@
+// vim: set sts=4 ts=8 sw=4 tw=99 et:
+//
+// Copyright (C) 2012-2014 David Anderson
+//
+// This file is part of SourcePawn.
+//
+// SourcePawn is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// SourcePawn is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// SourcePawn. If not, see http://www.gnu.org/licenses/.
+
+#pragma once
+
+#include <unordered_map>
+
+#include "stl-allocator.h"
+
+namespace tr {
+
+template <typename Key,
+	  typename T,
+	  typename Hash = std::hash<Key>,
+	  typename KeyEqual = std::equal_to<Key>>
+using unordered_map = std::unordered_map<Key, T, Hash, KeyEqual, StlAllocator<std::pair<const Key, T>>>;
+
+} // namespace tr

--- a/compiler/stl/stl-unordered-set.h
+++ b/compiler/stl/stl-unordered-set.h
@@ -1,0 +1,32 @@
+// vim: set sts=4 ts=8 sw=4 tw=99 et:
+//
+// Copyright (C) 2012-2014 David Anderson
+//
+// This file is part of SourcePawn.
+//
+// SourcePawn is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// SourcePawn is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// SourcePawn. If not, see http://www.gnu.org/licenses/.
+
+#pragma once
+
+#include <unordered_set>
+
+#include "stl-allocator.h"
+
+namespace tr {
+
+template <typename Key,
+	  typename Hash = std::hash<Key>,
+	  typename KeyEqual = std::equal_to<Key>>
+using unordered_set = std::unordered_set<Key, Hash, KeyEqual, StlAllocator<Key>>;
+
+} // namespace tr

--- a/compiler/stl/stl-vector.h
+++ b/compiler/stl/stl-vector.h
@@ -1,0 +1,30 @@
+// vim: set sts=4 ts=8 sw=4 tw=99 et:
+//
+// Copyright (C) 2012-2014 David Anderson
+//
+// This file is part of SourcePawn.
+//
+// SourcePawn is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// SourcePawn is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// SourcePawn. If not, see http://www.gnu.org/licenses/.
+
+#pragma once
+
+#include <vector>
+
+#include "stl-allocator.h"
+
+namespace tr {
+
+template <typename T>
+using vector = std::vector<T, StlAllocator<T>>;
+
+} // namespace tr

--- a/compiler/symbols.h
+++ b/compiler/symbols.h
@@ -28,6 +28,7 @@
 
 #include "label.h"
 #include "sc.h"
+#include "stl/stl-unordered-map.h"
 
 class CompileContext;
 class FunctionInfo;
@@ -50,7 +51,7 @@ class FunctionData final : public SymbolData
 
     void resizeArgs(size_t nargs);
 
-    std::vector<std::string>* dbgstrs = nullptr;
+    tr::vector<tr::string>* dbgstrs = nullptr;
     PoolArray<arginfo> args;
     ReturnArrayInfo* return_array = nullptr;
     FunctionInfo* node;
@@ -290,7 +291,7 @@ class SymbolScope final : public PoolObject
   private:
     SymbolScope* parent_;
     ScopeKind kind_;
-    std::unordered_map<sp::Atom*, symbol*>* symbols_;
+    tr::unordered_map<sp::Atom*, symbol*>* symbols_;
     int fnumber_;
 };
 

--- a/compiler/types.cpp
+++ b/compiler/types.cpp
@@ -127,7 +127,7 @@ TypeDictionary::find(sp::Atom* name)
 {
     for (const auto& type : types_) {
         if (type->nameAtom() == name)
-            return type.get();
+            return type;
     }
     return nullptr;
 }
@@ -137,7 +137,7 @@ TypeDictionary::find(int tag)
 {
     assert(size_t(tag) < types_.size());
 
-    return types_[tag].get();
+    return types_[tag];
 }
 
 Type*
@@ -146,13 +146,13 @@ TypeDictionary::findOrAdd(const char* name)
     sp::Atom* atom = gAtoms.add(name);
     for (const auto& type : types_) {
         if (type->nameAtom() == atom)
-            return type.get();
+            return type;
     }
 
     int tag = int(types_.size());
-    std::unique_ptr<Type> type = std::make_unique<Type>(atom, tag);
-    types_.push_back(std::move(type));
-    return types_.back().get();
+    Type* type = new Type(atom, tag);
+    types_.push_back(type);
+    return types_.back();
 }
 
 void

--- a/compiler/types.h
+++ b/compiler/types.h
@@ -34,6 +34,7 @@
 #include <sp_vm_types.h>
 #include "pool-objects.h"
 #include "shared/string-atom.h"
+#include "stl/stl-vector.h"
 
 typedef int32_t cell;
 typedef uint32_t ucell;
@@ -153,7 +154,7 @@ struct typeinfo_t {
     bool isCharArray() const;
     Expr* get_dim_expr(int i) {
         assert(i < numdim());
-        return i < dim_exprs.size() ? dim_exprs[i] : nullptr;
+        return (size_t)i < dim_exprs.size() ? dim_exprs[i] : nullptr;
     }
 };
 
@@ -171,7 +172,7 @@ struct functag_t : public PoolObject
     PoolArray<funcarg_t> args;
 };
 
-class Type
+class Type : public PoolObject
 {
     friend class TypeDictionary;
 
@@ -338,7 +339,7 @@ class TypeDictionary
     template <typename T>
     void forEachType(const T& callback) {
         for (const auto& type : types_)
-            callback(type.get());
+            callback(type);
     }
 
     int tag_nullfunc() const { return tag_nullfunc_; }
@@ -352,7 +353,7 @@ class TypeDictionary
     Type* findOrAdd(const char* name);
 
   private:
-    std::vector<std::unique_ptr<Type>> types_;
+    tr::vector<Type*> types_;
     int tag_nullfunc_ = -1;
     int tag_object_ = -1;
     int tag_null_ = -1;


### PR DESCRIPTION
This isn't perfect - overriding malloc/free would be better. But that's difficult and platform-specific, and probably would run into conflicts in embedding. So this is a reasonable stop-gap.