### PR TITLE
Edit rebind method for StlAllocator::other

### DIFF
--- a/compiler/stl/stl-allocator.h
+++ b/compiler/stl/stl-allocator.h
@@ -47,9 +47,6 @@ class StlAllocator
     template <typename U>
     StlAllocator(const StlAllocator<U>& other) {}
 
-    template <typename U>
-    using rebind = StlAllocator<U>;
-
     static T* allocate(size_t n, const void* = nullptr) {
         if (!ke::IsUintMultiplySafe(n, sizeof(T)))
             throw std::bad_alloc{};

--- a/compiler/stl/stl-allocator.h
+++ b/compiler/stl/stl-allocator.h
@@ -59,6 +59,11 @@ class StlAllocator
         NativeAllocator::Free(p, sizeof(T) * n);
     }
 
+    template<typename U>
+    struct rebind {
+      typedef StlAllocator<U> other;
+    };
+
     bool operator ==(const StlAllocator& other) const { return true; }
     bool operator !=(const StlAllocator& other) const { return false; }
 };


### PR DESCRIPTION
This should fix some builds, as the stl allocator requires itself to be able to be rebound to other types and the previous definition of rebound isn't similar to other stl allocator implementations. 

This could potentially be fixed by
```c++
    template <typename U>
    using other = StlAllocator<U>;
```

But it's better to walk the beaten path here