### PR TITLE
Read settings like warnings_are_errors from manifest.ini

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -314,25 +314,28 @@ class Test(object):
     base_path = os.path.dirname(os.path.abspath(__file__))
     return os.path.relpath(self.path, base_path)
 
+  def checkManifests(self, key, default = None):
+    return self.local_manifest_.get(key) or manifest_get(self.manifest_, self.name, key, default)
+
   @property
   def type(self):
-    return manifest_get(self.manifest_, self.name, 'type', 'runtime')
+    return self.checkManifests('type', 'runtime')
 
   @property
   def includes(self):
-    return manifest_get(self.manifest_, self.name, 'includes', [])
+    return self.checkManifests('includes', [])
 
   @property
   def warnings_are_errors(self):
-    return self.local_manifest_.get('warnings_are_errors', None) == 'true'
+    return self.checkManifests('warnings_are_errors') == 'true'
 
   @property
   def force_old_parser(self):
-    return self.local_manifest_.get('force_old_parser', None) == 'true'
+    return self.checkManifests('force_old_parser') == 'true'
 
   @property
   def force_new_parser(self):
-    return self.local_manifest_.get('force_new_parser', None) == 'true'
+    return self.checkManifests('force_new_parser') == 'true'
 
   @property
   def expectedReturnCode(self):

--- a/tests/sourcemod/manifest.ini
+++ b/tests/sourcemod/manifest.ini
@@ -2,3 +2,4 @@
 type: compile-only
 compiler: spcomp
 includes: include
+warnings_are_errors: true

--- a/tests/sourcemod/testsuite/fakenative1.sp
+++ b/tests/sourcemod/testsuite/fakenative1.sp
@@ -9,14 +9,14 @@ public Plugin:myinfo =
 	url = "http://www.sourcemod.net/"
 };
 
-public bool:AskPluginLoad(Handle:myself, bool:late, String:error[], err_max)
+public APLRes AskPluginLoad2(Handle:myself, bool:late, String:error[], err_max)
 {
 	CreateNative("TestNative1", __TestNative1);
 	CreateNative("TestNative2", __TestNative2);
 	CreateNative("TestNative3", __TestNative3);
 	CreateNative("TestNative4", __TestNative4);
 	CreateNative("TestNative5", __TestNative5);
-	return true;
+	return APLRes_Success;
 }
 
 public __TestNative1(Handle:plugin, numParams)

--- a/tests/sourcemod/testsuite/ptstest.sp
+++ b/tests/sourcemod/testsuite/ptstest.sp
@@ -17,7 +17,7 @@ public OnPluginStart()
 public bool:filter(const String:pattern[], Handle:clients)
 {
 	for (new i = 1; i <= MaxClients; i++) {
-		if (IsPlayerInGame(i))
+		if (IsClientInGame(i))
 			PushArrayCell(clients, i)
 	}
 

--- a/tests/sourcemod/testsuite/tf2-test.sp
+++ b/tests/sourcemod/testsuite/tf2-test.sp
@@ -47,11 +47,11 @@ public Action:Command_Remove(client, args)
 	
 	PrintToChat(client, "Test: heavy's classnum is %i (should be %i)", TF2_GetClass("heavy"), TFClass_Heavy);
 	
-	new doms = TF2_GetPlayerResourceData(client, TFResource_Dominations);
+	new doms = GetEntProp(GetPlayerResourceEntity(), Prop_Send, "m_iDominations", _, client);
 	PrintToChat(client, "Dominations read test: %i", doms);
 	
-	TF2_SetPlayerResourceData(client, TFResource_Dominations, doms + 10);
-	doms = TF2_GetPlayerResourceData(client, TFResource_Dominations);
+	SetEntProp(GetPlayerResourceEntity(), Prop_Send, "m_iDominations", doms + 10, _, client);
+	doms = GetEntProp(GetPlayerResourceEntity(), Prop_Send, "m_iDominations", _, client);
 	PrintToChat(client, "Dominations write test: %i", doms);
 	
 	/* Note: This didn't appear to change my dominations value when I pressed tab. */


### PR DESCRIPTION
SM compiles plugins with -E, so our tests here for it also
should.  This also fixes some warnings in tests/sourcemod/testsuite,
but the shadowing warnings are currently expected.
