### PR TITLE
Fix build on ancient STL.

### DIFF
--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -1729,8 +1729,12 @@ Parser::parse_switch()
                     error(15); /* "default" case must be last in switch statement */
 
                 std::vector<Expr*> exprs;
-                if (auto stmt = parse_case(&exprs))
-                    cases.emplace_back(std::move(exprs), stmt);
+                if (auto stmt = parse_case(&exprs)) {
+                    auto entry = SwitchStmt::Case{};
+                    entry.first = PoolArray<Expr*>(std::move(exprs));
+                    entry.second = stmt;
+                    cases.emplace_back(std::move(entry));
+                }
                 break;
             }
             case tDEFAULT:

--- a/compiler/stl/stl-allocator.h
+++ b/compiler/stl/stl-allocator.h
@@ -40,6 +40,14 @@ class StlAllocator
     typedef std::true_type propagate_on_container_copy_assignment;
     typedef std::true_type propagate_on_container_swap;
     typedef std::true_type is_always_equal;
+    typedef std::size_t size_type;
+    typedef std::ptrdiff_t difference_type;
+
+    // Legacy definitions.
+    typedef T& reference;
+    typedef T* pointer;
+    typedef const T* const_pointer;
+    typedef const T& const_reference;
 
     StlAllocator() = default;
     StlAllocator(const StlAllocator&) = default;


### PR DESCRIPTION
Our Linux buildbot is very old (Debian 7) and uses libstdc++ 4.9. Modern clang has a little trouble with it.