### PR TITLE
Update runtests.py to support running external test suites

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -61,7 +61,10 @@ class TestPlan(object):
     self.shells = []
     self.tests = []
     self.modes = []
-    self.tests_path = os.path.split(__file__)[0]
+    if args.test is None:
+      self.tests_path = os.path.split(__file__)[0]
+    else:
+      self.tests_path = args.test
     self.env_ = None
 
     if self.args.coverage:
@@ -236,11 +239,6 @@ class TestPlan(object):
       if os.path.isdir(path):
         self.find_tests_impl(local_path, manifest)
       elif path.endswith('.sp') or path.endswith('.smx'):
-        if self.args.test is not None:
-          if not local_path.startswith(self.args.test) and \
-             not local_path.endswith(self.args.test):
-            continue
-
         test = Test(**{
           'path': os.path.abspath(path),
           'manifest': manifest,
@@ -527,7 +525,7 @@ class TestRunner(object):
     if test.stderr_file is not None:
       if not self.compare_output(test, 'stderr', stderr):
         return False
-        
+
     self.out("PASS")
     return True
 

--- a/tests/sourcemod/manifest.ini
+++ b/tests/sourcemod/manifest.ini
@@ -1,5 +1,5 @@
 [folder]
 type: compile-only
 compiler: spcomp
-includes: include
+includes: tests/sourcemod/include
 warnings_are_errors: true

--- a/tests/testutil.py
+++ b/tests/testutil.py
@@ -76,7 +76,7 @@ def parse_manifest(path, local_folder, source = {}):
     includes = manifest[entry].get('includes', None)
     if includes and isinstance(includes, str):
       includes = [include.strip() for include in includes.split(',')]
-      includes = [os.path.join(local_folder, include) for include in includes]
+      includes = [os.path.realpath(include) for include in includes]
       manifest[entry]['includes'] = includes
 
   return manifest


### PR DESCRIPTION
`runtest.py` has an options for passing in the test directory however this does not seem to be properly configurable, I've updated the script to allow for more easily running external test suites.

Specifically for [ColorLib](https://github.com/c0rp3n/colorlib-sm) with which I have added some new unit tests.

The updated script seems to run fine locally and on github actions (for ColorLib).