### PR TITLE
Fix missing "expression has no side effect" warnings.

### DIFF
--- a/tests/compile-only/fail-expression-has-no-effect.sp
+++ b/tests/compile-only/fail-expression-has-no-effect.sp
@@ -1,0 +1,5 @@
+// warnings_are_errors: true
+public void main() {
+  int a, b;
+  a == b;
+}

--- a/tests/compile-only/fail-expression-has-no-effect.txt
+++ b/tests/compile-only/fail-expression-has-no-effect.txt
@@ -1,0 +1,1 @@
+(4) : error 215: expression has no effect


### PR DESCRIPTION
This also moves side effect testing into a single function, to eliminate
another virtual call.

Bug: issue #749
Test: new test case