### PR TITLE
Fix wrong line reporting for errors (issue #786)

### DIFF
--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -81,6 +81,7 @@ bool Semantics::CheckStmtList(StmtList* list) {
 }
 
 bool Semantics::CheckStmt(Stmt* stmt, StmtFlags flags) {
+    AutoErrorPos aep(stmt->pos());
     ke::Maybe<ke::SaveAndSet<bool>> restore_heap_ownership;
     if (flags & STMT_OWNS_HEAP)
         restore_heap_ownership.init(&pending_heap_allocation_, false);
@@ -345,6 +346,7 @@ static inline int GetOperToken(int token) {
 }
 
 bool Semantics::CheckExpr(Expr* expr) {
+    AutoErrorPos aep(expr->pos());
     switch (expr->kind()) {
         case AstKind::UnaryExpr:
             return CheckUnaryExpr(expr->to<UnaryExpr>());

--- a/tests/regressions/fail-error-reporting-pos.sp
+++ b/tests/regressions/fail-error-reporting-pos.sp
@@ -1,0 +1,36 @@
+// warnings_are_errors: true
+// type: compiler-output
+
+int i;
+bool b;
+enum e { e1 };
+
+public void main()
+{
+	if (i > b ) {}
+	if (e1 > b ) {}
+	
+	i > b;
+	e1 > b;
+}
+
+/*
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+*/

--- a/tests/regressions/fail-error-reporting-pos.txt
+++ b/tests/regressions/fail-error-reporting-pos.txt
@@ -1,0 +1,6 @@
+(10) : error 213: tag mismatch (expected "int", got "bool")
+(11) : error 213: tag mismatch (expected "e", got "bool")
+(13) : error 213: tag mismatch (expected "int", got "bool")
+(13) : error 215: expression has no effect
+(14) : error 213: tag mismatch (expected "e", got "bool")
+(14) : error 215: expression has no effect

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -252,6 +252,7 @@ class TestPlan(object):
 ###
 class Test(object):
   ManifestKeys = set([
+    'type',
     'returnCode',
     'warnings_are_errors',
     'compiler',


### PR DESCRIPTION
Bug: issue #786
Test: regressions/fail-error-reporting-pos.sp

Also modifies `runtests.py` to allow passing `type` through from the
test file into the manifest.
