### PR TITLE
Fix peek_same_line

### DIFF
--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -2486,10 +2486,12 @@ Lexer::peek_same_line()
     // If there's tokens pushed back, then |fline| is the line of the furthest
     // token parsed. If fline == current token's line, we are guaranteed any
     // buffered token is still on the same line.
-    if (token_buffer_->depth > 0
-        && current_token()->end.file == next_token()->start.file
-        && current_token()->end.line == fline_)
+    if (token_buffer_->depth > 0 &&
+        current_token()->end.file == next_token()->start.file &&
+        current_token()->end.line == fline_)
+    {
         return next_token()->id;
+    }
 
     // Make sure the next token is lexed, then buffer it.
     full_token_t next = lex_tok();
@@ -2497,9 +2499,11 @@ Lexer::peek_same_line()
 
     // If the next token starts on the line the last token ends, then the next
     // token is considered on the same line.
-    if (next.start.line == current_token()->end.line
-        && next.start.file == current_token()->end.file)
+    if (next.start.line == current_token()->end.line &&
+        next.start.file == current_token()->end.file)
+    {
         return next.id;
+    }
 
     return tEOL;
 }

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -2486,7 +2486,9 @@ Lexer::peek_same_line()
     // If there's tokens pushed back, then |fline| is the line of the furthest
     // token parsed. If fline == current token's line, we are guaranteed any
     // buffered token is still on the same line.
-    if (token_buffer_->depth > 0 && current_token()->end.line == fline_)
+    if (token_buffer_->depth > 0
+        && current_token()->end.file == next_token()->start.file
+        && current_token()->end.line == fline_)
         return next_token()->id;
 
     // Make sure the next token is lexed, then buffer it.
@@ -2495,7 +2497,8 @@ Lexer::peek_same_line()
 
     // If the next token starts on the line the last token ends, then the next
     // token is considered on the same line.
-    if (next.start.line == current_token()->end.line)
+    if (next.start.line == current_token()->end.line
+        && next.start.file == current_token()->end.file)
         return next.id;
 
     return tEOL;

--- a/tests/regressions/ok-peek-same-line-lex.inc
+++ b/tests/regressions/ok-peek-same-line-lex.inc
@@ -1,0 +1,5 @@
+methodmap Number {
+	public Number(int number) {
+		return view_as<Number>(number);
+	}
+}

--- a/tests/regressions/ok-peek-same-line-lex.sp
+++ b/tests/regressions/ok-peek-same-line-lex.sp
@@ -1,0 +1,7 @@
+/* Issue 793
+ */
+
+#include "ok-peek-same-line-lex.inc"
+public void main() { 
+	Number(3);
+}


### PR DESCRIPTION
Fix peek_same_line when the next token is in a different file, but happens to have the same line number.
