### PR TITLE
Allow argument names to shadow global functions.

### DIFF
--- a/compiler/symbols.cpp
+++ b/compiler/symbols.cpp
@@ -344,6 +344,8 @@ GetNewNameStatus(SemaContext& sc, sp::Atom* name, int vclass)
     }
     if (scope == current)
         return NewNameStatus::Duplicated;
+    if (current->kind() == sARGUMENT && sym->ident == iFUNCTN)
+        return NewNameStatus::Ok;
     return NewNameStatus::Shadowed;
 }
 

--- a/tests/compile-only/ok-argument-shadows-function.sp
+++ b/tests/compile-only/ok-argument-shadows-function.sp
@@ -1,0 +1,12 @@
+// warnings_are_errors: true
+
+int min(int a, int b) {
+    return a < b ? a : b;
+}
+
+stock void test(float min, float max) {
+}
+
+public main() {
+    return min(2, 3);
+}


### PR DESCRIPTION
This mimics an allowance made in the 1.10 compiler.

Bug: issue #791
Test: new test case