### PR TITLE
Fix missing error message when const decl fails to evaluate.

### DIFF
--- a/compiler/name-resolution.cpp
+++ b/compiler/name-resolution.cpp
@@ -443,8 +443,10 @@ ConstDecl::Bind(SemaContext& sc)
 
     int tag;
     cell value;
-    if (!expr_->EvalConst(&value, &tag))
+    if (!expr_->EvalConst(&value, &tag)) {
+        report(expr_, 8);
         return false;
+    }
 
     AutoErrorPos aep(pos_);
     matchtag(type_.tag(), tag, 0);

--- a/tests/compile-only/fail-string-assigned-to-const-char.sp
+++ b/tests/compile-only/fail-string-assigned-to-const-char.sp
@@ -1,0 +1,10 @@
+// just this = emit no code
+const char g_BlockClass = "prop_door_rotating";
+
+// uncomment for assert as well
+int g_MapHeight = 8;
+
+
+public void main()
+{
+}

--- a/tests/compile-only/fail-string-assigned-to-const-char.txt
+++ b/tests/compile-only/fail-string-assigned-to-const-char.txt
@@ -1,0 +1,1 @@
+(2) : error 008: must be a constant expression; assumed zero


### PR DESCRIPTION
Bug: issue #802
Test: new test case