### PR TITLE
Error when missing parens on member function calls.

### DIFF
--- a/compiler/messages.h
+++ b/compiler/messages.h
@@ -74,7 +74,7 @@ static const char* errmsg[] = {
     /*047*/ "array sizes do not match, or destination array is too small\n",
     /*048*/ "arrays do not match\n",
     /*049*/ "invalid line continuation\n",
-    /*050*/ "unused\n",
+    /*050*/ "missing function call, cannot use non-static member function as a value\n",
     /*051*/ "overloaded operator '%s' does not return bool\n",
     /*052*/ "array size exceeds memory capacity\n",
     /*053*/ "unused53\n",

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -1658,6 +1658,11 @@ bool Semantics::CheckFieldAccessExpr(FieldAccessExpr* expr, bool from_call) {
         return false;
     }
 
+    if (!from_call) {
+        report(expr, 50);
+        return false;
+    }
+
     val.ident = iFUNCTN;
     val.sym = method->target;
     markusage(method->target, uREAD);

--- a/tests/compile-only/fail-member-function-missing-call.sp
+++ b/tests/compile-only/fail-member-function-missing-call.sp
@@ -1,0 +1,17 @@
+#pragma semicolon 1
+#pragma newdecls required
+
+methodmap Test 
+{
+	public int GetNum()
+	{
+		return 1;
+	}
+}
+
+public int main()
+{
+	Test test;
+	int num = test.GetNum;  // problematic code. should be: test.GetNum();
+	return num;
+}

--- a/tests/compile-only/fail-member-function-missing-call.txt
+++ b/tests/compile-only/fail-member-function-missing-call.txt
@@ -1,0 +1,1 @@
+fail-member-function-missing-call.sp(15) : error 050: missing function call, cannot use non-static member function as a value


### PR DESCRIPTION
Bug: issue #806
Test: new test case