### PR TITLE
Merge FunctionInfo and FunctionDecl.

### DIFF
--- a/compiler/code-generator.cpp
+++ b/compiler/code-generator.cpp
@@ -206,11 +206,9 @@ CodeGenerator::EmitStmt(Stmt* stmt)
         case AstKind::SwitchStmt:
             EmitSwitchStmt(stmt->to<SwitchStmt>());
             break;
-        case AstKind::FunctionDecl: {
-            auto decl = stmt->to<FunctionDecl>();
-            EmitFunctionInfo(decl->info());
+        case AstKind::FunctionDecl:
+            EmitFunctionDecl(stmt->to<FunctionDecl>());
             break;
-        }
         case AstKind::EnumStructDecl:
             EmitEnumStructDecl(stmt->to<EnumStructDecl>());
             break;
@@ -1734,7 +1732,7 @@ CodeGenerator::EmitSwitchStmt(SwitchStmt* stmt)
 }
 
 void
-CodeGenerator::EmitFunctionInfo(FunctionInfo* info)
+CodeGenerator::EmitFunctionDecl(FunctionDecl* info)
 {
     ke::SaveAndSet<symbol*> set_func(&func_, info->sym());
 
@@ -1798,7 +1796,7 @@ void
 CodeGenerator::EmitEnumStructDecl(EnumStructDecl* decl)
 {
     for (const auto& fun : decl->methods())
-        EmitFunctionInfo(fun->info());
+        EmitFunctionDecl(fun);
 }
 
 void
@@ -1806,12 +1804,12 @@ CodeGenerator::EmitMethodmapDecl(MethodmapDecl* decl)
 {
     for (const auto& prop : decl->properties()) {
         if (prop->getter)
-            EmitFunctionInfo(prop->getter);
+            EmitFunctionDecl(prop->getter);
         if (prop->setter)
-            EmitFunctionInfo(prop->setter);
+            EmitFunctionDecl(prop->setter);
     }
     for (const auto& method : decl->methods())
-        EmitFunctionInfo(method->decl->info());
+        EmitFunctionDecl(method->decl);
 }
 
 void

--- a/compiler/code-generator.h
+++ b/compiler/code-generator.h
@@ -67,7 +67,7 @@ class CodeGenerator final
     void EmitDoWhileStmt(DoWhileStmt* stmt);
     void EmitForStmt(ForStmt* stmt);
     void EmitSwitchStmt(SwitchStmt* stmt);
-    void EmitFunctionInfo(FunctionInfo* info);
+    void EmitFunctionDecl(FunctionDecl* info);
     void EmitEnumStructDecl(EnumStructDecl* info);
     void EmitMethodmapDecl(MethodmapDecl* info);
     void EmitReturnStmt(ReturnStmt* stmt);

--- a/compiler/parse-node.cpp
+++ b/compiler/parse-node.cpp
@@ -96,8 +96,8 @@ BinaryExprBase::BinaryExprBase(AstKind kind, const token_pos_t& pos, int token, 
     assert(right_ != this);
 }
 
-FunctionInfo::FunctionInfo(const token_pos_t& pos, const declinfo_t& decl)
-  : pos_(pos),
+FunctionDecl::FunctionDecl(const token_pos_t& pos, const declinfo_t& decl)
+  : Decl(AstKind::FunctionDecl, pos, decl.name),
     decl_(decl),
     analyzed_(false),
     analyze_result_(false),

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -277,17 +277,15 @@ Parser::parse_unknown_decl(const full_token_t* tok)
         return stmt;
     } else {
         auto pos = lexer_->pos();
-        FunctionInfo* info = new FunctionInfo(pos, decl);
-        info->set_name(decl.name);
+        FunctionDecl* stmt = new FunctionDecl(pos, decl);
         if (fpublic)
-            info->set_is_public();
+            stmt->set_is_public();
         if (fstatic)
-            info->set_is_static();
+            stmt->set_is_static();
         if (fstock)
-            info->set_is_stock();
-        if (!parse_function(info, 0, false))
+            stmt->set_is_stock();
+        if (!parse_function(stmt, 0, false))
             return nullptr;
-        auto stmt = new FunctionDecl(pos, info);
         if (!lexer_->deprecate().empty()) {
             stmt->set_deprecate(lexer_->deprecate());
             lexer_->deprecate() = {};
@@ -462,14 +460,12 @@ Parser::parse_enumstruct()
 
         auto decl_pos = lexer_->pos();
         if (!decl.type.has_postdims && lexer_->peek('(')) {
-            auto info = new FunctionInfo(decl_pos, decl);
-            info->set_name(decl.name);
-            info->set_is_stock();
-            if (!parse_function(info, 0, true))
+            auto fun = new FunctionDecl(decl_pos, decl);
+            fun->set_is_stock();
+            if (!parse_function(fun, 0, true))
                 continue;
 
-            auto method = new FunctionDecl(decl_pos, info);
-            methods.emplace_back(method);
+            methods.emplace_back(fun);
             continue;
         }
 
@@ -1797,31 +1793,29 @@ Decl*
 Parser::parse_inline_function(int tokid, const declinfo_t& decl)
 {
     auto pos = lexer_->pos();
-    auto info = new FunctionInfo(pos, decl);
-    info->set_name(decl.name);
+    auto fun = new FunctionDecl(pos, decl);
 
     if (tokid == tNATIVE || tokid == tMETHODMAP)
-        info->set_is_native();
+        fun->set_is_native();
     else if (tokid == tPUBLIC)
-        info->set_is_public();
+        fun->set_is_public();
     else if (tokid == tFORWARD)
-        info->set_is_forward();
+        fun->set_is_forward();
     else
-        info->set_is_stock();
+        fun->set_is_stock();
 
-    if (!parse_function(info, tokid, false))
+    if (!parse_function(fun, tokid, false))
         return nullptr;
 
-    auto stmt = new FunctionDecl(pos, info);
     if (!lexer_->deprecate().empty()) {
-        stmt->set_deprecate(lexer_->deprecate());
+        fun->set_deprecate(lexer_->deprecate());
         lexer_->deprecate() = {};
     }
-    return stmt;
+    return fun;
 }
 
 bool
-Parser::parse_function(FunctionInfo* info, int tokid, bool has_this)
+Parser::parse_function(FunctionDecl* fun, int tokid, bool has_this)
 {
     if (!lexer_->match('(')) {
         error(10);
@@ -1835,20 +1829,20 @@ Parser::parse_function(FunctionInfo* info, int tokid, bool has_this)
     if (has_this)
         args.emplace_back(nullptr);
 
-    parse_args(info, &args); // eats the close paren
+    parse_args(fun, &args); // eats the close paren
 
     // Copy arguments.
-    new (&info->args()) PoolArray<VarDecl*>(args);
+    new (&fun->args()) PoolArray<VarDecl*>(args);
 
-    if (info->is_native()) {
-        if (info->decl().opertok != 0) {
+    if (fun->is_native()) {
+        if (fun->decl().opertok != 0) {
             lexer_->need('=');
             lexer_->lexpush();
         }
         if (lexer_->match('=')) {
             sp::Atom* ident;
             if (lexer_->needsymbol(&ident))
-                info->set_alias(ident);
+                fun->set_alias(ident);
         }
     }
 
@@ -1864,7 +1858,7 @@ Parser::parse_function(FunctionInfo* info, int tokid, bool has_this)
             if (lexer_->match(';')) {
                 if (!lexer_->NeedSemicolon())
                     error(10); /* old style prototypes used with optional semicolumns */
-                info->set_is_forward();
+                fun->set_is_forward();
                 return true;
             }
             break;
@@ -1872,20 +1866,20 @@ Parser::parse_function(FunctionInfo* info, int tokid, bool has_this)
 
     if (lexer_->match('{'))
         lexer_->lexpush();
-    else if (info->decl().type.is_new)
+    else if (fun->decl().type.is_new)
         lexer_->need('{');
 
     Stmt* body = parse_stmt(nullptr, false);
     if (!body)
         return false;
 
-    info->set_body(BlockStmt::WrapStmt(body));
-    info->set_end_pos(lexer_->pos());
+    fun->set_body(BlockStmt::WrapStmt(body));
+    fun->set_end_pos(lexer_->pos());
     return true;
 }
 
 void
-Parser::parse_args(FunctionInfo* info, std::vector<VarDecl*>* args)
+Parser::parse_args(FunctionDecl* fun, std::vector<VarDecl*>* args)
 {
     if (lexer_->match(')'))
         return;
@@ -1898,7 +1892,7 @@ Parser::parse_args(FunctionInfo* info, std::vector<VarDecl*>* args)
             continue;
 
         if (decl.type.ident == iVARARGS) {
-            if (info->IsVariadic())
+            if (fun->IsVariadic())
                 error(401);
 
             auto p = new VarDecl(pos, gAtoms.add("..."), decl.type, sARGUMENT, false, false,
@@ -1907,14 +1901,14 @@ Parser::parse_args(FunctionInfo* info, std::vector<VarDecl*>* args)
             continue;
         }
 
-        if (info->IsVariadic())
+        if (fun->IsVariadic())
             error(402);
 
         Expr* init = nullptr;
         if (lexer_->match('='))
             init = var_init(sARGUMENT);
 
-        if (info->args().size() >= SP_MAX_CALL_ARGUMENTS)
+        if (fun->args().size() >= SP_MAX_CALL_ARGUMENTS)
             error(45);
         if (decl.name->chars()[0] == PUBLIC_CHAR)
             report(56) << decl.name; // function arguments cannot be public
@@ -2027,12 +2021,13 @@ Parser::parse_methodmap_method(MethodmapDecl* map)
 
         ret_type.type.ident = iVARIABLE;
     }
+    ret_type.name = symbol;
 
     // Build a new symbol. Construct a temporary name including the class.
     auto fullname = ke::StringPrintf("%s.%s", map->name()->chars(), symbol->chars());
     auto fqn = gAtoms.add(fullname);
 
-    auto fun = new FunctionInfo(pos, ret_type);
+    auto fun = new FunctionDecl(pos, ret_type);
     fun->set_name(fqn);
 
     if (is_native)
@@ -2051,7 +2046,7 @@ Parser::parse_methodmap_method(MethodmapDecl* map)
     // Use the short name for the function decl
     auto method = new MethodmapMethod;
     method->is_static = is_static;
-    method->decl = new FunctionDecl(pos, symbol, fun);
+    method->decl = fun;
 
     if (is_native)
         lexer_->require_newline(TerminatorPolicy::Semicolon);
@@ -2121,7 +2116,7 @@ Parser::parse_methodmap_property_accessor(MethodmapDecl* map, MethodmapProperty*
         ret_type.type.ident = iVARIABLE;
     }
 
-    auto fun = new FunctionInfo(pos, ret_type);
+    auto fun = new FunctionDecl(pos, ret_type);
     std::string tmpname = map->name()->str() + "." + prop->name->str();
     if (getter)
         tmpname += ".get";

--- a/compiler/parser.h
+++ b/compiler/parser.h
@@ -96,8 +96,8 @@ class Parser
     Stmt* parse_pragma_unused();
     TypedefInfo* parse_function_type();
 
-    bool parse_function(FunctionInfo* info, int tokid, bool has_this);
-    void parse_args(FunctionInfo* info, std::vector<VarDecl*>* args);
+    bool parse_function(FunctionDecl* info, int tokid, bool has_this);
+    void parse_args(FunctionDecl* info, std::vector<VarDecl*>* args);
 
     // Wrapper around hier14() that allows comma expressions without a wrapping
     // parens.

--- a/compiler/semantics.h
+++ b/compiler/semantics.h
@@ -42,7 +42,7 @@ class SemaContext
         cc_.set_sema(this);
         scope_ = cc_.globals();
     }
-    SemaContext(SemaContext& parent, symbol* func, FunctionInfo* func_node)
+    SemaContext(SemaContext& parent, symbol* func, FunctionDecl* func_node)
       : cc_(parent.cc_),
         sema_(parent.sema()),
         scope_(parent.scope_),
@@ -98,7 +98,7 @@ class SemaContext
     void set_warned_unreachable() { warned_unreachable_ = true; }
 
     symbol* func() const { return func_; }
-    FunctionInfo* func_node() const { return func_node_; }
+    FunctionDecl* func_node() const { return func_node_; }
     Semantics* sema() const { return sema_; }
 
     SymbolScope* ScopeForAdd();
@@ -119,7 +119,7 @@ class SemaContext
     SymbolScope* scope_ = nullptr;
     AutoCreateScope* scope_creator_ = nullptr;
     symbol* func_ = nullptr;
-    FunctionInfo* func_node_ = nullptr;
+    FunctionDecl* func_node_ = nullptr;
     Stmt* void_return_ = nullptr;
     bool warned_mixed_returns_ = false;
     bool returns_value_ = false;
@@ -138,7 +138,7 @@ class Semantics final
     friend class ConstDecl;
     friend class EnumDecl;
     friend class FixedArrayValidator;
-    friend class FunctionInfo;
+    friend class FunctionDecl;
     friend class Parser;
 
   public:
@@ -162,9 +162,9 @@ class Semantics final
     bool CheckChangeScopeNode(ChangeScopeNode* node);
     bool CheckMethodmapDecl(MethodmapDecl* info);
     bool CheckEnumStructDecl(EnumStructDecl* info);
-    bool CheckFunctionInfo(FunctionInfo* info);
-    bool CheckFunctionInfoImpl(FunctionInfo* info);
-    void CheckFunctionReturnUsage(FunctionInfo* info);
+    bool CheckFunctionDecl(FunctionDecl* info);
+    bool CheckFunctionDeclImpl(FunctionDecl* info);
+    void CheckFunctionReturnUsage(FunctionDecl* info);
     bool CheckPragmaUnusedStmt(PragmaUnusedStmt* stmt);
     bool CheckSwitchStmt(SwitchStmt* stmt);
     bool CheckForStmt(ForStmt* stmt);

--- a/compiler/symbols.h
+++ b/compiler/symbols.h
@@ -31,7 +31,7 @@
 #include "stl/stl-unordered-map.h"
 
 class CompileContext;
-class FunctionInfo;
+class FunctionDecl;
 class SemaContext;
 struct token_pos_t;
 
@@ -54,8 +54,8 @@ class FunctionData final : public SymbolData
     tr::vector<tr::string>* dbgstrs = nullptr;
     PoolArray<arginfo> args;
     ReturnArrayInfo* return_array = nullptr;
-    FunctionInfo* node;
-    FunctionInfo* forward;
+    FunctionDecl* node;
+    FunctionDecl* forward;
     symbol* alias;
     sp::Label label;     // modern replacement for addr
     sp::Label funcid;

--- a/compiler/types.h
+++ b/compiler/types.h
@@ -89,12 +89,12 @@ struct typeinfo_t {
     typeinfo_t()
       : type_atom(nullptr),
         tag_(-1),
+        declared_tag(0),
         ident(0),
         is_const(false),
         is_new(false),
         has_postdims(false),
-        is_label(false),
-        declared_tag(0)
+        is_label(false)
     {}
 
     // Array information.
@@ -106,15 +106,16 @@ struct typeinfo_t {
     // Type information.
     sp::Atom* type_atom;    // Parsed atom.
     int tag_;               // Effective tag.
-    int ident;          // Either iREFERENCE, iARRAY, or iVARIABLE.
-    bool is_const : 1;
-    bool is_new : 1;        // New-style declaration.
-    bool has_postdims : 1;  // Dimensions, if present, were in postfix position.
-    bool is_label : 1;      // If type_atom came from a tLABEL.
 
     // If non-zero, this type was originally declared with this type, but was
     // rewritten for desugaring.
     int declared_tag;
+
+    int ident : 5;          // Either iREFERENCE, iARRAY, or iVARIABLE.
+    bool is_const : 1;
+    bool is_new : 1;        // New-style declaration.
+    bool has_postdims : 1;  // Dimensions, if present, were in postfix position.
+    bool is_label : 1;      // If type_atom came from a tLABEL.
 
     TypenameInfo ToTypenameInfo() const {
         if (tag_ >= 0)


### PR DESCRIPTION
The thinking behind the split was that we'd have a base class for
function expressions versus function statements. But it's too
cumbersome and wasteful.

The remaining grossness is that Decl::name is decorated, which
complicates code that only cares about the undecorated name. For now
I've resolved this by holding the undecorated name separately, but there
may be lingering error messages and stuff that uses the wrong one.