### PR TITLE
Streamline CallExpr and add iteration support.

### DIFF
--- a/compiler/ast-types.h
+++ b/compiler/ast-types.h
@@ -43,6 +43,7 @@
     FOR_EACH(SizeofExpr) \
     FOR_EACH(SymbolExpr) \
     FOR_EACH(CallExpr) \
+    FOR_EACH(NamedArgExpr) \
     FOR_EACH(CallUserOpExpr) \
     FOR_EACH(DefaultArgExpr) \
     FOR_EACH(FieldAccessExpr) \

--- a/compiler/name-resolution.cpp
+++ b/compiler/name-resolution.cpp
@@ -592,10 +592,8 @@ CallExpr::Bind(SemaContext& sc)
         return false;
 
     bool ok = true;
-    for (const auto& arg : args_) {
-        if (arg.expr)
-           ok &= arg.expr->Bind(sc);
-    }
+    for (const auto& arg : args_)
+       ok &= arg->Bind(sc);
     return ok;
 }
 

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -387,13 +387,23 @@ bool Semantics::CheckExpr(Expr* expr) {
         case AstKind::SizeofExpr:
             return CheckSizeofExpr(expr->to<SizeofExpr>());
         case AstKind::RvalueExpr:
-            return CheckExpr(expr->to<RvalueExpr>()->expr());
+            return CheckWrappedExpr(expr, expr->to<RvalueExpr>()->expr());
+        case AstKind::NamedArgExpr:
+            return CheckWrappedExpr(expr, expr->to<NamedArgExpr>()->expr);
         default:
             assert(false);
-
             report(expr, 420) << (int)expr->kind();
             return false;
     }
+}
+
+bool Semantics::CheckWrappedExpr(Expr* outer, Expr* inner) {
+    if (!CheckExpr(inner))
+        return false;
+
+    outer->val() = inner->val();
+    outer->set_lvalue(inner->lvalue());
+    return true;
 }
 
 CompareOp::CompareOp(const token_pos_t& pos, int token, Expr* expr)
@@ -1963,7 +1973,7 @@ CallUserOpExpr::ProcessUses(SemaContext& sc)
 }
 
 DefaultArgExpr::DefaultArgExpr(const token_pos_t& pos, arginfo* arg)
-  : EmitOnlyExpr(AstKind::DefaultArgExpr, pos),
+  : Expr(AstKind::DefaultArgExpr, pos),
     arg_(arg)
 {
     // Leave val bogus, it doesn't participate in anything, and we can't
@@ -2014,7 +2024,7 @@ bool Semantics::CheckCallExpr(CallExpr* call) {
         report(call, 234) << sym->name() << ptr; /* deprecated (probably a native function) */
     }
 
-    std::vector<ComputedArg> argv;
+    ParamState ps;
 
     unsigned int nargs = 0;
     unsigned int argidx = 0;
@@ -2024,7 +2034,7 @@ bool Semantics::CheckCallExpr(CallExpr* call) {
             report(call->implicit_this(), 92);
             return false;
         }
-        if (!CheckArgument(call, &arglist[0], call->implicit_this(), &argv, 0))
+        if (!CheckArgument(call, &arglist[0], call->implicit_this(), &ps, 0))
             return false;
         nargs++;
         argidx++;
@@ -2033,10 +2043,10 @@ bool Semantics::CheckCallExpr(CallExpr* call) {
     bool namedparams = false;
     for (const auto& param : call->args()) {
         unsigned int argpos;
-        if (param.name) {
-            int pos = findnamedarg(arglist, param.name);
+        if (auto named = param->as<NamedArgExpr>()) {
+            int pos = findnamedarg(arglist, named->name);
             if (pos < 0) {
-                report(call, 17) << param.name;
+                report(call, 17) << named->name;
                 break;
             }
             argpos = pos;
@@ -2048,7 +2058,7 @@ bool Semantics::CheckCallExpr(CallExpr* call) {
             }
             argpos = nargs;
             if (argidx >= arglist.size()) {
-                report(param.expr, 92);
+                report(param->pos(), 92);
                 return false;
             }
         }
@@ -2057,20 +2067,16 @@ bool Semantics::CheckCallExpr(CallExpr* call) {
             report(call, 45); // too many function arguments
             return false;
         }
-        if (argpos < argv.size() && argv[argpos].expr) {
+        if (argpos < ps.argv.size() && ps.argv[argpos]) {
             report(call, 58); // argument already set
             return false;
         }
-        // Note: we don't do this in ProcessArg, since we don't want to double-call
-        // analyze on implicit_this (Analyze is not idempotent).
-        if (param.expr && !CheckExpr(param.expr))
-            return false;
 
         // Add the argument to |argv| and perform type checks.
-        if (!CheckArgument(call, &arglist[argidx], param.expr, &argv, argpos))
+        if (!CheckArgument(call, &arglist[argidx], param, &ps, argpos))
             return false;
 
-        assert(argv[argpos].expr != nullptr);
+        assert(ps.argv[argpos] != nullptr);
         nargs++;
 
         // Don't iterate past terminators (0 or varargs).
@@ -2094,32 +2100,38 @@ bool Semantics::CheckCallExpr(CallExpr* call) {
         auto& arg = arglist[argidx];
         if (arg.type.ident == iVARARGS)
             break;
-        if (argidx >= argv.size() || !argv[argidx].expr) {
-            if (!CheckArgument(call, &arg, nullptr, &argv, argidx))
+        if (argidx >= ps.argv.size() || !ps.argv[argidx]) {
+            if (!CheckArgument(call, &arg, nullptr, &ps, argidx))
                 return false;
         }
 
-        Expr* expr = argv[argidx].expr;
+        Expr* expr = ps.argv[argidx];
         if (expr->as<DefaultArgExpr>() && arg.type.ident == iVARIABLE) {
             UserOperation userop;
             if (find_userop(*sc_, 0, arg.def->tag, arg.type.tag(), 2, nullptr, &userop))
-                argv[argidx].expr = new CallUserOpExpr(userop, expr);
+                ps.argv[argidx] = new CallUserOpExpr(userop, expr);
         }
     }
 
-    new (&call->argv()) PoolArray<ComputedArg>(argv);
+    // Copy newly deduced argument information.
+    if (call->args().size() == ps.argv.size()) {
+        for (size_t i = 0; i < ps.argv.size(); i++)
+            call->args()[i] = ps.argv[i];
+    } else {
+        new (&call->args()) PoolArray<Expr*>(ps.argv);
+    }
     return true;
 }
 
 bool Semantics::CheckArgument(CallExpr* call, arginfo* arg, Expr* param,
-                              std::vector<ComputedArg>* argv, unsigned int pos)
+                              ParamState* ps, unsigned int pos)
 {
-    while (pos >= argv->size())
-        argv->push_back(ComputedArg{});
+    while (pos >= ps->argv.size())
+        ps->argv.push_back(nullptr);
 
     unsigned int visual_pos = call->implicit_this() ? pos : pos + 1;
 
-    if (!param) {
+    if (!param || param->as<DefaultArgExpr>()) {
         if (arg->type.ident == 0 || arg->type.ident == iVARARGS) {
             report(call, 92); // argument count mismatch
             return false;
@@ -2129,16 +2141,25 @@ bool Semantics::CheckArgument(CallExpr* call, arginfo* arg, Expr* param,
             return false;
         }
 
+        if (!param)
+            param = new DefaultArgExpr(call->pos(), arg);
+        else
+            param->as<DefaultArgExpr>()->set_arg(arg);
+
         // The rest of the code to handle default values is in DoEmit.
-        argv->at(pos).expr = new DefaultArgExpr(call->pos(), arg);
-        argv->at(pos).arg = arg;
+        ps->argv[pos] = param;
 
         if (arg->type.ident == iREFERENCE ||
             (arg->type.ident == iREFARRAY && !arg->type.is_const && arg->def->array))
         {
-            NeedsHeapAlloc(argv->at(pos).expr);
+            NeedsHeapAlloc(ps->argv[pos]);
         }
         return true;
+    }
+
+    if (param != call->implicit_this()) {
+        if (!CheckExpr(param))
+            return false;
     }
 
     AutoErrorPos aep(param->pos());
@@ -2303,19 +2324,15 @@ bool Semantics::CheckArgument(CallExpr* call, arginfo* arg, Expr* param,
             break;
     }
 
-    argv->at(pos).expr = param;
-    argv->at(pos).arg = arg;
+    ps->argv[pos] = param;
     return true;
 }
 
 void
 CallExpr::ProcessUses(SemaContext& sc)
 {
-    for (const auto& arg : argv_) {
-        if (!arg.expr)
-            continue;
-        arg.expr->MarkAndProcessUses(sc);
-    }
+    for (const auto& arg : args_)
+        arg->MarkAndProcessUses(sc);
 }
 
 void

--- a/compiler/semantics.h
+++ b/compiler/semantics.h
@@ -207,7 +207,6 @@ class Semantics final
     bool CheckBinaryExpr(BinaryExpr* expr);
     bool CheckUnaryExpr(UnaryExpr* expr);
     bool CheckIsDefinedExpr(IsDefinedExpr* expr);
-
     bool CheckFieldAccessExpr(FieldAccessExpr* expr, bool from_call);
     bool CheckStaticFieldAccessExpr(FieldAccessExpr* expr);
     bool CheckEnumStructFieldAccessExpr(FieldAccessExpr* expr, Type* type, symbol* root,
@@ -215,13 +214,18 @@ class Semantics final
 
     bool CheckAssignmentLHS(BinaryExpr* expr);
     bool CheckAssignmentRHS(BinaryExpr* expr);
-
     bool AddImplicitDynamicInitializer(VarDecl* decl);
+
+    struct ParamState {
+        std::vector<Expr*> argv;
+    };
+
     bool CheckArrayDeclaration(VarDecl* decl);
     bool CheckExprForArrayInitializer(Expr* expr);
     bool CheckNewArrayExprForArrayInitializer(NewArrayExpr* expr);
     bool CheckArgument(CallExpr* call, arginfo* arg, Expr* expr,
-                       std::vector<ComputedArg>* argv, unsigned int argpos);
+                       ParamState* ps, unsigned int argpos);
+    bool CheckWrappedExpr(Expr* outer, Expr* inner);
     symbol* BindNewTarget(Expr* target);
     symbol* BindCallTarget(CallExpr* call, Expr* target);
 


### PR DESCRIPTION
CallExpr wasn't iterable because it stored its arguments in too many
places. This reduces it down to one list.

We also switch DefaultArgExpr to a parse-time node, and introduce
NamedArgExpr to eliminate more one-off weird structs.