### PR TITLE
Clean up Lexer state a bit.

### DIFF
--- a/compiler/AMBuilder
+++ b/compiler/AMBuilder
@@ -23,6 +23,7 @@ module.sources += [
   'scvars.cpp',
   'semantics.cpp',
   'source-file.cpp',
+  'source-manager.cpp',
   'symbols.cpp',
   'type-checker.cpp',
   'types.cpp',

--- a/compiler/compile-context.cpp
+++ b/compiler/compile-context.cpp
@@ -26,6 +26,7 @@
 #include "compile-options.h"
 #include "errors.h"
 #include "scvars.h"
+#include "source-manager.h"
 #include "symbols.h"
 
 CompileContext* CompileContext::sInstance = nullptr;
@@ -39,6 +40,7 @@ CompileContext::CompileContext()
 
     reports_ = std::make_unique<ReportManager>(*this);
     options_ = std::make_unique<CompileOptions>();
+    sources_ = std::make_unique<SourceManager>(*this);
 }
 
 CompileContext::~CompileContext()

--- a/compiler/compile-context.h
+++ b/compiler/compile-context.h
@@ -35,6 +35,7 @@
 class Lexer;
 class ReportManager;
 class SemaContext;
+class SourceManager;
 class SymbolScope;
 struct CompileOptions;
 struct symbol;
@@ -63,8 +64,7 @@ class CompileContext final
     const std::shared_ptr<Lexer>& lexer() const { return lexer_; }
     ReportManager* reports() const { return reports_.get(); }
     CompileOptions* options() const { return options_.get(); }
-    tr::vector<std::string>& input_files() { return input_files_; }
-    tr::vector<std::string>& included_files() { return included_files_; }
+    SourceManager* sources() const { return sources_.get(); }
 
     const std::string& default_include() const { return default_include_; }
     void set_default_include(const std::string& file) { default_include_ = file; }
@@ -119,11 +119,10 @@ class CompileContext final
     tr::unordered_set<symbol*> functions_;
     tr::unordered_set<symbol*> publics_;
     std::unique_ptr<CompileOptions> options_;
-    tr::vector<std::string> input_files_;
-    tr::vector<std::string> included_files_;
     std::string outfname_;
     std::string binfname_;
     std::string errfname_;
+    std::unique_ptr<SourceManager> sources_;
     std::shared_ptr<SourceFile> inpf_org_;
 
     // The lexer is in CompileContext rather than Parser until we can eliminate

--- a/compiler/errors.cpp
+++ b/compiler/errors.cpp
@@ -210,7 +210,10 @@ MessageBuilder::~MessageBuilder()
     report.lineno = std::max(where_.line, 1);
     if (report.fileno < 0)
         report.fileno = cc.lexer()->fcurrent();
-    report.filename = cc.input_files().at(report.fileno);
+    if (report.fileno < cc.sources()->opened_files().size())
+        report.filename = cc.sources()->opened_files().at(report.fileno)->name();
+    else
+        report.filename = cc.options()->source_files[0];
     report.type = DeduceErrorType(number_);
 
     std::ostringstream out;
@@ -283,7 +286,10 @@ ErrorReport::create_va(int number, int fileno, int lineno, va_list ap)
     report.lineno = std::max(lineno, 1);
     if (report.fileno < 0)
         report.fileno = cc.lexer()->fcurrent();
-    report.filename = cc.input_files().at(report.fileno);
+    if (report.fileno < cc.sources()->opened_files().size())
+        report.filename = cc.sources()->opened_files().at(report.fileno)->name();
+    else
+        report.filename = cc.options()->source_files[0];
     report.type = DeduceErrorType(number);
 
     const char* prefix = GetErrorTypePrefix(report.type);

--- a/compiler/messages.h
+++ b/compiler/messages.h
@@ -300,4 +300,5 @@ static const char* errmsg_ex[] = {
     /*419*/ "cannot write to file: \"%s\"\n",
     /*420*/ "unhandled AST type: %d\n",
     /*421*/ "too many functions\n",
+    /*422*/ "no more source locations, too much source text\n",
 };

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -84,9 +84,10 @@ Parser::Parse()
         }
         assert(!static_scopes_.empty());
 
-        if (changed)
+        if (changed) {
             stmts.emplace_back(new ChangeScopeNode(lexer_->pos(), static_scopes_.back(),
-                                                   cc_.input_files().at(fcurrent)));
+                                                   lexer_->inpf()->name()));
+        }
 
         switch (tok) {
             case 0:
@@ -200,7 +201,7 @@ void Parser::CreateInitialScopes(std::vector<Stmt*>* stmts) {
         assert(fcurrent == 0);
         static_scopes_.emplace_back(new SymbolScope(cc_.globals(), sFILE_STATIC, fcurrent));
         stmts->emplace_back(new ChangeScopeNode({}, static_scopes_.back(),
-                                                cc_.input_files().at(fcurrent)));
+                                                lexer_->inpf()->name()));
     }
 
     if (!cc_.default_include().empty()) {
@@ -209,7 +210,7 @@ void Parser::CreateInitialScopes(std::vector<Stmt*>* stmts) {
             int fcurrent = lexer_->fcurrent();
             static_scopes_.emplace_back(new SymbolScope(cc_.globals(), sFILE_STATIC, fcurrent));
             stmts->emplace_back(new ChangeScopeNode({}, static_scopes_.back(),
-                                                    cc_.input_files().at(fcurrent)));
+                                lexer_->inpf()->name()));
         }
     }
 }

--- a/compiler/source-file.h
+++ b/compiler/source-file.h
@@ -24,14 +24,17 @@
 #include <memory>
 #include <string>
 
+#include <amtl/am-maybe.h>
 #include "stl/stl-string.h"
 
 class SourceFile
 {
+    friend class SourceManager;
+
   public:
     SourceFile();
-
-    bool Open(const std::string& file_name);
+    SourceFile(const SourceFile&) = delete;
+    SourceFile(SourceFile&&) = delete;
 
     bool Read(unsigned char* target, int maxchars);
     int64_t Pos();
@@ -39,10 +42,28 @@ class SourceFile
     int Eof();
 
     const char* name() const { return name_.c_str(); }
+    const std::string& path() const { return name_; }
+    size_t size() const { return data_.size(); }
+    uint32_t sources_index() const { return sources_index_.get(); }
+
+    bool is_main_file() const { return is_main_file_; }
+    void set_is_main_file() { is_main_file_ = true; }
+
+    void operator =(const SourceFile&) = delete;
+    void operator =(SourceFile&&) = delete;
 
   private:
-    std::unique_ptr<FILE, decltype(&::fclose)> fp_;
+    bool Open(const std::string& file_name);
+
+    void set_sources_index(uint32_t sources_index) { sources_index_ = ke::Some(sources_index); }
+    uint32_t location_index() const { return location_index_.get(); }
+    void set_location_index(uint32_t location_index) { location_index_ = ke::Some(location_index); }
+
+  private:
     std::string name_;
     tr::string data_;
     size_t pos_;
+    bool is_main_file_ = false;
+    ke::Maybe<uint32_t> sources_index_;
+    ke::Maybe<uint32_t> location_index_;
 };

--- a/compiler/source-location.h
+++ b/compiler/source-location.h
@@ -1,0 +1,91 @@
+// vim: set ts=2 sw=2 tw=99 et:
+// 
+// Copyright (C) 2022 AlliedModders LLC
+// 
+// This file is part of SourcePawn.
+// 
+// SourcePawn is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+// 
+// SourcePawn is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License along with
+// SourcePawn. If not, see http://www.gnu.org/licenses/.
+#pragma once
+
+#include <stdint.h>
+
+// An encoded referece to a location in a source file. We keep this structure
+// as small as feasible since our average script can have hundreds of thousands
+// of source locations.
+class SourceLocation
+{
+  friend class MacroLexer;
+  friend class SourceFile;
+  friend class SourceManager;
+  friend struct LREntry;
+  friend struct Macro;
+
+  static const uint32_t kInMacro = 0x80000000;
+
+  static SourceLocation FromFile(uint32_t sourceId, uint32_t offset) {
+    SourceLocation loc;
+    loc.id_ = sourceId + offset;
+    return loc;
+  }
+  static SourceLocation FromMacro(uint32_t sourceId, uint32_t offset) {
+    SourceLocation loc;
+    loc.id_ = sourceId + offset;
+    loc.id_ |= kInMacro;
+    return loc;
+  }
+
+ public:
+  SourceLocation()
+   : id_(0)
+  {
+  }
+
+  bool IsSet() const {
+    return id_ != 0;
+  }
+  bool operator ==(const SourceLocation& other) {
+    return id_ == other.id_;
+  }
+  bool operator !=(const SourceLocation& other) {
+    return id_ != other.id_;
+  }
+
+  bool IsInMacro() const {
+    return !!(id_ & kInMacro);
+  }
+
+  uint32_t id() const {
+    return id_;
+  }
+
+ private:
+  uint32_t offset() const {
+    return id_ & ~kInMacro;
+  }
+
+ private:
+  uint32_t id_;
+};
+
+struct SourceRange
+{
+  SourceLocation start;
+  SourceLocation end;
+
+  SourceRange()
+  {}
+  SourceRange(const SourceLocation& start, const SourceLocation& end)
+   : start(start),
+     end(end)
+  {}
+};

--- a/compiler/source-manager.cpp
+++ b/compiler/source-manager.cpp
@@ -1,0 +1,79 @@
+// vim: set ts=4 sw=4 tw=99 et:
+// 
+// Copyright (C) 2022 David Anderson
+// 
+// This file is part of SourcePawn.
+// 
+// SourcePawn is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+// 
+// SourcePawn is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License along with
+// SourcePawn. If not, see http://www.gnu.org/licenses/.
+#include "source-manager.h"
+
+#include <amtl/am-arithmetic.h>
+#include "errors.h"
+#include "lexer.h"
+
+SourceManager::SourceManager(CompileContext& cc)
+  : cc_(cc)
+{
+}
+
+std::shared_ptr<SourceFile> SourceManager::Open(const std::string& path,
+                                                const token_pos_t& from)
+{
+    auto file = std::make_shared<SourceFile>();
+    if (!file->Open(path))
+	      return nullptr;
+
+    size_t loc_index;
+    if (!TrackExtents(file->size(), &loc_index)) {
+        report(from, 422);
+        return nullptr;
+    }
+
+    if (opened_files_.size() >= UINT_MAX) {
+        report(from, 422);
+        return nullptr;
+    }
+
+    file->set_sources_index(opened_files_.size());
+    opened_files_.emplace_back(file);
+
+    // :TODO: fix
+    locations_[loc_index].init({}, file);
+    file->set_location_index(loc_index);
+    return file;
+}
+
+bool SourceManager::TrackExtents(uint32_t length, size_t* index) {
+    // We allocate an extra 2 so we can refer to the end-of-file position without
+    // colling with the next range.
+    uint32_t next_source_id;
+    if (!ke::TryUint32Add(next_source_id_, length, &next_source_id) ||
+        !ke::TryUint32Add(next_source_id, 2, &next_source_id) ||
+        next_source_id > INT_MAX)
+    {
+        return false;
+    }
+
+    *index = locations_.size();
+
+    LREntry tracker;
+    tracker.id = next_source_id_;
+    locations_.push_back(tracker);
+
+    next_source_id_ = next_source_id;
+    return true;
+}
+
+LREntry SourceManager::GetLocationRangeEntryForFile(const std::shared_ptr<SourceFile>& file) {
+    return locations_[file->location_index()];
+}

--- a/compiler/source-manager.h
+++ b/compiler/source-manager.h
@@ -1,0 +1,121 @@
+// vim: set ts=2 sw=2 tw=99 et:
+// 
+// Copyright (C) 2022 David Anderson
+// 
+// This file is part of SourcePawn.
+// 
+// SourcePawn is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+// 
+// SourcePawn is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License along with
+// SourcePawn. If not, see http://www.gnu.org/licenses/.
+#pragma once
+
+#include <limits.h>
+
+#include <memory>
+
+#include "stl/stl-unordered-map.h"
+#include "stl/stl-vector.h"
+#include "source-file.h"
+#include "source-location.h"
+
+class CompileContext;
+struct token_pos_t;
+
+// An LREntry is created each time we register a range of locations (it is
+// short for LocationRangeEntry). For a file, an LREntry covers each character
+// in the file, including a position for EOF. For macros, it covers the number
+// of characters in its token stream, with a position for EOF.
+//
+// LREntries are allocated by calling trackFile() or trackMacro() in the
+// SourceManager.
+//
+// LREntries are not malloc'd, so references must not be held past calls to
+// trackFile() or trackMacro().
+struct LREntry
+{
+  // Starting id for this source range.
+  uint32_t id;
+
+ private:
+  // If we're creating a range from an #include, this is the location in the
+  // parent file we were #included from, if any.
+  //
+  // If we're creating a range for macro insertion, this is where we started
+  // inserting tokens.
+  SourceLocation parent_;
+
+  // If we included from a file, this is where we included.
+  std::shared_ptr<SourceFile> file_;
+
+ public:
+  LREntry()
+   : id(0)
+  {}
+
+  bool valid() const {
+    return id != 0;
+  }
+
+  void init(const SourceLocation& parent, std::shared_ptr<SourceFile> file) {
+    this->parent_ = parent;
+    this->file_ = std::move(file);
+  }
+
+  std::shared_ptr<SourceFile> file() const {
+    return file_;
+  }
+  const SourceLocation& parent() const {
+    return parent_;
+  }
+
+  uint32_t length() const {
+    return file_->size();
+  }
+
+  bool owns(const SourceLocation& loc) const {
+    if (loc.offset() >= id && loc.offset() <= id + length())
+      return true;
+    return false;
+  }
+
+  SourceLocation FilePos(uint32_t offset) const {
+    assert(file_);
+    assert(offset <= file_->size());
+    return SourceLocation::FromFile(id, offset);
+  }
+};
+
+class SourceManager final
+{
+  public:
+    explicit SourceManager(CompileContext& cc);
+
+    std::shared_ptr<SourceFile> Open(const std::string& path, const token_pos_t& from);
+
+    LREntry GetLocationRangeEntryForFile(const std::shared_ptr<SourceFile>& file);
+
+    const tr::vector<std::shared_ptr<SourceFile>>& opened_files() const {
+      return opened_files_;
+    }
+
+  private:
+    bool TrackExtents(uint32_t length, size_t* index);
+
+  private:
+    CompileContext& cc_;
+    tr::vector<std::shared_ptr<SourceFile>> opened_files_;
+    tr::vector<LREntry> locations_;
+
+    // Source ids start from 1. The source file id is 1 + len(source) + 1. This
+    // lets us store source locations as a single integer, as we can always
+    // bisect to a particular file, and from there, to a line number and column.
+    uint32_t next_source_id_ = 1;
+};

--- a/exp/compiler/source-manager.h
+++ b/exp/compiler/source-manager.h
@@ -157,7 +157,7 @@ struct LREntry
     return id != 0;
   }
 
-  void init(const SourceLocation& parent, SourceFile* file) {
+  void init(const SourceLocation& parent, std::shared_ptr<SourceFile> file) {
     this->parent = parent;
     this->file = file;
   }


### PR DESCRIPTION
This consolidates a bunch of per-file lexer state into a single object. It also introduces a SourceManager class, which opens and tracks source files. These are both concepts from the experimental compiler that are necessary for a long-overdue correction to the lexer, which is that it scans on a line-by-line basis rather than by character.