### PR TITLE
Allow static_assert as a statement.

### DIFF
--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -1441,6 +1441,11 @@ Parser::parse_stmt(int* lastindent, bool allow_decl)
             }
             return new ReturnStmt(pos, expr);
         }
+        case tSTATIC_ASSERT: {
+            auto stmt = parse_static_assert();
+            lexer_->need(tTERM);
+            return stmt;
+        }
         case tASSERT: {
             auto pos = lexer_->pos();
             Expr* expr = parse_expr(true);

--- a/tests/compile-only/fail-static-assert-message.sp
+++ b/tests/compile-only/fail-static-assert-message.sp
@@ -9,4 +9,5 @@ static_assert(TEST_MAX == TEST_1, "oh no this failed how come")
 
 public main()
 {
+    static_assert(TEST_MAX == TEST_1, "oh no this failed how come 2")
 }

--- a/tests/compile-only/fail-static-assert-message.txt
+++ b/tests/compile-only/fail-static-assert-message.txt
@@ -1,1 +1,2 @@
 (8) : error 070: assertion failed: oh no this failed how come
+(12) : error 070: assertion failed: oh no this failed how come 2

--- a/tests/compile-only/fail-static-assert-no-message.sp
+++ b/tests/compile-only/fail-static-assert-no-message.sp
@@ -9,4 +9,5 @@ static_assert(TEST_MAX == TEST_1)
 
 public main()
 {
+    static_assert(TEST_MAX == TEST_1)
 }

--- a/tests/compile-only/fail-static-assert-no-message.txt
+++ b/tests/compile-only/fail-static-assert-no-message.txt
@@ -1,1 +1,2 @@
 (8) : error 070: assertion failed
+(12) : error 070: assertion failed

--- a/tests/compile-only/ok-static-assert-enum-value.sp
+++ b/tests/compile-only/ok-static-assert-enum-value.sp
@@ -9,4 +9,5 @@ static_assert(TEST_MAX == TEST_MAX)
 
 public main()
 {
+    static_assert(TEST_MAX == TEST_MAX)
 }


### PR DESCRIPTION
Bug: issue #823
Tests: compile-only/fail-static-assert-message.sp
       compile-only/fail-static-assert-no-message.sp
       compile-only/ok-static-assert-enum-value.sp
