### PR TITLE
Add a warning when function names are used as test conditions.

### DIFF
--- a/compiler/messages.h
+++ b/compiler/messages.h
@@ -275,6 +275,7 @@ static const char* warnmsg[] = {
     /*246*/ "function %s returns an array but return type is not marked as an array\n",
     /*247*/ "include paths should be enclosed in \"quotes\" or <angle brackets>\n",
     /*248*/ "character is not utf-8 encoded\n",
+    /*249*/ "function name is always true - possible missing parenthesis?\n"
 };
 
 static const char* errmsg_ex[] = {

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -548,6 +548,9 @@ Expr* Semantics::AnalyzeForTest(Expr* expr) {
             report(expr, 206);
         else
             report(expr, 205);
+    } else if (auto sym_expr = expr->as<SymbolExpr>()) {
+        if (sym_expr->sym()->ident == iFUNCTN)
+            report(expr, 249);
     }
 
     if (expr->lvalue())

--- a/tests/compile-only/warn-function-name-in-test.sp
+++ b/tests/compile-only/warn-function-name-in-test.sp
@@ -1,0 +1,7 @@
+void blah() { }
+
+public main() {
+    if (blah)
+        return 1;
+    return 0;
+}

--- a/tests/compile-only/warn-function-name-in-test.txt
+++ b/tests/compile-only/warn-function-name-in-test.txt
@@ -1,0 +1,1 @@
+(4) : warning 249: function name is always true - possible missing parenthesis?


### PR DESCRIPTION
Bug: issue #831
Test: new test case