### PR TITLE
Fix crash when calling invalid address.

### DIFF
--- a/compiler/main.cpp
+++ b/compiler/main.cpp
@@ -168,8 +168,8 @@ args::ToggleOption opt_no_verify(nullptr, "--no-verify", Some(false),
  */
 int
 pc_compile(int argc, char* argv[]) {
-    int retcode;
     ParseTree* tree = nullptr;
+    bool ok = false;
     std::string ext;
 
     CompileContext cc;
@@ -249,10 +249,14 @@ pc_compile(int argc, char* argv[]) {
                 goto cleanup;
 
             tree->stmts()->ProcessUses(sc);
+            ok = true;
         }
     }
 
 cleanup:
+    if (!ok && cc.reports()->NumErrorMessages() == 0)
+        error(423);
+
     unsigned int errnum = cc.reports()->NumErrorMessages();
     unsigned int warnnum = cc.reports()->NumWarnMessages();
     bool compile_ok = (errnum == 0);
@@ -310,6 +314,8 @@ cleanup:
     funcenums_free();
     methodmaps_free();
     pstructs_free();
+
+    int retcode;
     if (!compile_ok) {
         if (cc.errfname().empty())
             printf("\n%d Error%s.\n", errnum, (errnum > 1) ? "s" : "");

--- a/compiler/messages.h
+++ b/compiler/messages.h
@@ -301,4 +301,5 @@ static const char* errmsg_ex[] = {
     /*420*/ "unhandled AST type: %d\n",
     /*421*/ "too many functions\n",
     /*422*/ "no more source locations, too much source text\n",
+    /*423*/ "internal compiler error: error propagated with no message\n",
 };

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -1693,8 +1693,10 @@ symbol* Semantics::BindCallTarget(CallExpr* call, Expr* target) {
                 return nullptr;
 
             auto& val = expr->val();
-            if (val.ident != iFUNCTN)
+            if (val.ident != iFUNCTN) {
+                report(target, 12);
                 return nullptr;
+            }
 
             // The static accessor (::) is offsetof(), so it can't return functions.
             assert(expr->token() == '.');
@@ -1741,6 +1743,8 @@ symbol* Semantics::BindCallTarget(CallExpr* call, Expr* target) {
             }
             return sym;
         }
+        default:
+            report(target, 12);
     }
     return nullptr;
 }
@@ -2564,7 +2568,7 @@ bool Semantics::CheckBlockStmt(BlockStmt* block) {
 
     // Blocks always taken heap ownership.
     AssignHeapOwnership(block);
-    return true;
+    return ok;
 }
 
 AutoCollectSemaFlow::AutoCollectSemaFlow(SemaContext& sc, ke::Maybe<bool>* out)
@@ -3133,7 +3137,7 @@ bool Semantics::CheckFunctionDeclImpl(FunctionDecl* info) {
         report(info->pos(), 234) << sym->name() << ptr; /* deprecated (probably a public function) */
     }
 
-    CheckStmt(body, STMT_OWNS_HEAP);
+    bool ok = CheckStmt(body, STMT_OWNS_HEAP);
 
     sym->returns_value = sc_->returns_value();
     sym->always_returns = sc_->always_returns();
@@ -3169,7 +3173,7 @@ bool Semantics::CheckFunctionDeclImpl(FunctionDecl* info) {
 
     if (sym->is_public)
         cc_.publics().emplace(sym);
-    return true;
+    return ok;
 }
 
 void Semantics::CheckFunctionReturnUsage(FunctionDecl* info) {

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -1195,8 +1195,7 @@ bool Semantics::CheckTernaryExpr(TernaryExpr* expr) {
         return false;
     }
 
-    if (!matchtag_commutative(left.tag, right.tag, FALSE))
-        return false;
+    matchtag_commutative(left.tag, right.tag, FALSE);
 
     /* If both sides are arrays, we should return the maximal as the lvalue.
      * Otherwise we could buffer overflow and the compiler is too stupid.

--- a/tests/compile-only/fail-call-with-invalid-address.sp
+++ b/tests/compile-only/fail-call-with-invalid-address.sp
@@ -1,0 +1,12 @@
+public void OnPluginStart() {
+    Hell hell;
+    hell.DoACrash();
+}
+
+methodmap Hell {
+    property int DoACrash {
+        public get() {
+            return 7;
+        }
+    }
+}

--- a/tests/compile-only/fail-call-with-invalid-address.txt
+++ b/tests/compile-only/fail-call-with-invalid-address.txt
@@ -1,0 +1,1 @@
+(3) : error 012: invalid function call, not a valid address


### PR DESCRIPTION
This was due to a missing error report causing us to generate code off
an invalid AST. Probably the AST should include placeholders to prevent
this. For now, add some guardrails against this kind of problem.

Bug: issue #750
Test: new test case