### PR TITLE
Don't force the output file to have an .smx extension.

### DIFF
--- a/compiler/compile-context.h
+++ b/compiler/compile-context.h
@@ -88,9 +88,6 @@ class CompileContext final
     std::string& outfname() { return outfname_; }
     void set_outfname(const std::string& value) { outfname_ = value; }
 
-    std::string& binfname() { return binfname_; }
-    void set_binfname(const std::string& value) { binfname_ = value; }
-
     std::shared_ptr<SourceFile> inpf_org() const { return inpf_org_; }
     void set_inpf_org(std::shared_ptr<SourceFile> sf) { inpf_org_ = sf; }
 
@@ -120,7 +117,6 @@ class CompileContext final
     tr::unordered_set<symbol*> publics_;
     std::unique_ptr<CompileOptions> options_;
     std::string outfname_;
-    std::string binfname_;
     std::string errfname_;
     std::unique_ptr<SourceManager> sources_;
     std::shared_ptr<SourceFile> inpf_org_;

--- a/compiler/main.cpp
+++ b/compiler/main.cpp
@@ -187,15 +187,6 @@ pc_compile(int argc, char* argv[]) {
 
     parseoptions(cc, argc, argv);
 
-    cc.set_binfname(cc.outfname());
-    ext = get_extension(cc.binfname());
-    if (strcasecmp(ext.c_str(), ".asm") == 0)
-        set_extension(&cc.binfname(), ".smx", true);
-    else
-        set_extension(&cc.binfname(), ".smx", false);
-    /* set output names that depend on the input name */
-    set_extension(&cc.outfname(), ".asm", true);
-
     if (!cc.errfname().empty())
         remove(cc.errfname().c_str()); /* delete file on startup */
     else if (verbosity > 0)
@@ -218,7 +209,7 @@ pc_compile(int argc, char* argv[]) {
     setconstants(); /* set predefined constants and tagnames */
 
     inst_datetime_defines(cc);
-    inst_binary_name(cc, cc.binfname().c_str());
+    inst_binary_name(cc, cc.outfname().c_str());
 
     {
         Parser parser(cc);
@@ -270,7 +261,7 @@ cleanup:
 
     // Write the binary file.
     if (!sc_syntax_only && compile_ok) {
-        compile_ok &= assemble(cc, cg, cc.binfname().c_str(), opt_compression.value());
+        compile_ok &= assemble(cc, cg, cc.outfname().c_str(), opt_compression.value());
     }
 
     errnum += cc.reports()->NumErrorMessages();
@@ -548,8 +539,8 @@ static void parseoptions(CompileContext& cc, int argc, char** argv) {
                     ptr = str;
                 assert(strlen(ptr) < PATH_MAX);
                 cc.set_outfname(ptr);
+                set_extension(&cc.outfname(), ".smx", true);
             }
-            set_extension(&cc.outfname(), ".asm", true);
         }
     }
 


### PR DESCRIPTION
If an output name is specified, it's now used exactly as given.  Also clean up
some file name handling that was doing nothing now that .asm/.lst output is gone.
