### PR TITLE
Remove nested array symbols.

### DIFF
--- a/compiler/array-helpers.cpp
+++ b/compiler/array-helpers.cpp
@@ -313,11 +313,11 @@ ArraySizeResolver::ResolveDimExprs()
             return false;
         } else {
             // Constant must be > 0.
-            if (v.constval <= 0) {
+            if (v.constval() <= 0) {
                 error(expr->pos(), 9);
                 return false;
             }
-            type_->dim[i] = v.constval;
+            type_->dim[i] = v.constval();
         }
     }
     return true;
@@ -340,8 +340,7 @@ ArraySizeResolver::ResolveDimExpr(Expr* expr, value* v)
         auto type = types_->find(sym->tag);
         if (sym->enumroot && !type->asEnumStruct() && sym->ident == iCONSTEXPR) {
             *v = {};
-            v->ident = iCONSTEXPR;
-            v->constval = sym->addr();
+            v->set_constval(sym->addr());
             return true;
         }
     }
@@ -652,7 +651,7 @@ FixedArrayValidator::ValidateRank(int rank, Expr* init)
         matchtag(type_.tag(), v.tag, MATCHTAG_COERCE);
 
         prev2 = prev1;
-        prev1 = ke::Some(v.constval);
+        prev1 = ke::Some(v.constval());
     }
 
     cell ncells = rank_size ? rank_size : array->exprs().size();
@@ -985,9 +984,9 @@ ArrayEmitter::Emit(int rank, Expr* init)
                 AddInlineArray(field, expr);
             } else {
                 assert(item->val().ident == iCONSTEXPR);
-                add_data(item->val().constval);
+                add_data(item->val().constval());
                 prev2 = prev1;
-                prev1 = ke::Some(item->val().constval);
+                prev1 = ke::Some(item->val().constval());
             }
 
             if (field_list) {
@@ -1016,9 +1015,9 @@ ArrayEmitter::AddInlineArray(symbol* field, ArrayExpr* array)
 
     for (const auto& item : array->exprs()) {
         assert(item->val().ident == iCONSTEXPR);
-        add_data(item->val().constval);
+        add_data(item->val().constval());
         prev2 = prev1;
-        prev1 = ke::Some(item->val().constval);
+        prev1 = ke::Some(item->val().constval());
     }
 
     EmitPadding(field->dim.array.length, field->x.tags.index, array->exprs().size(),

--- a/compiler/array-helpers.cpp
+++ b/compiler/array-helpers.cpp
@@ -308,7 +308,7 @@ ArraySizeResolver::ResolveDimExprs()
 
             // The array type must automatically become iREFARRAY.
             type_->ident = iREFARRAY;
-        } else if (IsLegacyEnumTag(sema_->current_scope(), v.tag) && v.sym && !v.sym->parent()) {
+        } else if (IsLegacyEnumTag(sema_->current_scope(), v.tag) && v.sym && v.sym->enumroot) {
             error(expr->pos(), 153);
             return false;
         } else {
@@ -717,7 +717,7 @@ FixedArrayValidator::ValidateEnumStruct(Expr* init)
                 continue;
             }
 
-            matchtag(field->x.tags.index, v.tag, MATCHTAG_COERCE | MATCHTAG_ENUM_ASSN);
+            matchtag(field->tag, v.tag, MATCHTAG_COERCE | MATCHTAG_ENUM_ASSN);
         }
     }
 
@@ -970,7 +970,7 @@ ArrayEmitter::Emit(int rank, Expr* init)
                 symbol* field = *field_iter;
                 assert(field);
 
-                EmitPadding(field->dim(0), field->x.tags.index, emitted, false, {}, {});
+                EmitPadding(field->dim(0), field->tag, emitted, false, {}, {});
             } else if (ArrayExpr* expr = item->as<ArrayExpr>()) {
                 // Subarrays can only appear in an enum struct. Normal 2D cases
                 // would flow through the check at the start of this function.
@@ -985,7 +985,7 @@ ArrayEmitter::Emit(int rank, Expr* init)
             }
 
             if (field_list) {
-                assert(field_iter != field_list->end() && (*field_iter)->ident == iCONSTEXPR);
+                assert(field_iter != field_list->end());
                 field_iter++;
             }
         }
@@ -1015,7 +1015,7 @@ ArrayEmitter::AddInlineArray(symbol* field, ArrayExpr* array)
         prev1 = ke::Some(item->val().constval());
     }
 
-    EmitPadding(field->dim(0), field->x.tags.index, array->exprs().size(),
+    EmitPadding(field->dim(0), field->tag, array->exprs().size(),
                 array->ellipses(), prev1, prev2);
 }
 

--- a/compiler/array-helpers.h
+++ b/compiler/array-helpers.h
@@ -28,13 +28,13 @@ class Semantics;
 // Determine the static size of an iARRAY based on dimension expressions and
 // array initializers. The array may be converted to an iREFARRAY if it is
 // determined to be dynamic.
-void ResolveArraySize(Semantics* sema, VarDecl* decl);
+void ResolveArraySize(Semantics* sema, VarDeclBase* decl);
 void ResolveArraySize(Semantics* sema, const token_pos_t& pos, typeinfo_t* type, int vclass);
 
 // Perform type and size checks of an array and its initializer if present.
 bool CheckArrayInitialization(Semantics* sema, const typeinfo_t& type, Expr* init);
 
-void BuildArrayInitializer(VarDecl* decl, ArrayData* array, cell_t base_addr);
+void BuildArrayInitializer(VarDeclBase* decl, ArrayData* array, cell_t base_addr);
 void BuildArrayInitializer(const typeinfo_t& type, Expr* init, ArrayData* array);
 
 cell_t CalcArraySize(symbol* sym);

--- a/compiler/assembler.cpp
+++ b/compiler/assembler.cpp
@@ -475,8 +475,8 @@ RttiBuilder::add_enumstruct(Type* type)
         auto field = *iter;
 
         int dims[1], dimcount = 0;
-        if (field->dim.array.length)
-            dims[dimcount++] = field->dim.array.length;
+        if (field->dim_count())
+            dims[dimcount++] = field->dim(0);
 
         variable_type_t type = {field->x.tags.index, dims, dimcount, false};
         std::vector<uint8_t> encoding;
@@ -570,7 +570,7 @@ RttiBuilder::encode_signature(symbol* sym)
         bytes.push_back(cb::kVariadic);
 
     symbol* child = sym->array_return();
-    if (child && child->dim.array.length) {
+    if (child && child->dim_count()) {
         encode_ret_array_into(bytes, child);
     } else if (sym->tag == types_->tag_void()) {
         bytes.push_back(cb::kVoid);
@@ -689,8 +689,10 @@ RttiBuilder::encode_enumstruct_into(std::vector<uint8_t>& bytes, Type* type)
 void
 RttiBuilder::encode_ret_array_into(std::vector<uint8_t>& bytes, symbol* sym)
 {
-    bytes.push_back(cb::kFixedArray);
-    CompactEncodeUint32(bytes, sym->dim.array.length);
+    for (int i = 0; i < sym->dim_count(); i++) {
+        bytes.push_back(cb::kFixedArray);
+        CompactEncodeUint32(bytes, sym->dim(i));
+    }
     encode_tag_into(bytes, sym->tag);
 }
 

--- a/compiler/assembler.cpp
+++ b/compiler/assembler.cpp
@@ -478,7 +478,7 @@ RttiBuilder::add_enumstruct(Type* type)
         if (field->dim_count())
             dims[dimcount++] = field->dim(0);
 
-        variable_type_t type = {field->x.tags.index, dims, dimcount, false};
+        variable_type_t type = {field->semantic_tag, dims, dimcount, false};
         std::vector<uint8_t> encoding;
         encode_var_type(encoding, type);
 

--- a/compiler/code-generator.cpp
+++ b/compiler/code-generator.cpp
@@ -100,7 +100,7 @@ CodeGenerator::AddDebugSymbol(symbol* sym)
     if (sym->ident == iARRAY || sym->ident == iREFARRAY) {
         string += " [ ";
         for (int i = 0; i < sym->dim_count(); i++)
-            string += ke::StringPrintf("%x:%x ", sym->x.tags.index, sym->dim(i));
+            string += ke::StringPrintf("%x:%x ", sym->semantic_tag, sym->dim(i));
         string += "]";
     }
 

--- a/compiler/code-generator.h
+++ b/compiler/code-generator.h
@@ -59,10 +59,10 @@ class CodeGenerator final
     void EmitStmtList(StmtList* list);
     void EmitStmt(Stmt* stmt);
     void EmitChangeScopeNode(ChangeScopeNode* node);
-    void EmitVarDecl(VarDecl* decl);
-    void EmitPstruct(VarDecl* decl);
-    void EmitGlobalVar(VarDecl* decl);
-    void EmitLocalVar(VarDecl* decl);
+    void EmitVarDecl(VarDeclBase* decl);
+    void EmitPstruct(VarDeclBase* decl);
+    void EmitGlobalVar(VarDeclBase* decl);
+    void EmitLocalVar(VarDeclBase* decl);
     void EmitIfStmt(IfStmt* stmt);
     void EmitDeleteStmt(DeleteStmt* stmt);
     void EmitDoWhileStmt(DoWhileStmt* stmt);

--- a/compiler/expressions.h
+++ b/compiler/expressions.h
@@ -30,7 +30,6 @@
 
 class SemaContext;
 struct value;
-struct svalue;
 
 int NextExprOp(Lexer* lexer, int* opidx, int* list);
 

--- a/compiler/messages.h
+++ b/compiler/messages.h
@@ -275,8 +275,9 @@ static const char* warnmsg[] = {
     /*246*/ "function %s returns an array but return type is not marked as an array\n",
     /*247*/ "include paths should be enclosed in \"quotes\" or <angle brackets>\n",
     /*248*/ "character is not utf-8 encoded\n",
-    /*249*/ "function name is always true - possible missing parenthesis?\n"
+    /*249*/ "function name is always true - possible missing parenthesis?\n",
     /*250*/ "pragma has no effect\n",
+    /*251*/ "const variable was not initialized\n",
 };
 
 static const char* errmsg_ex[] = {

--- a/compiler/name-resolution.cpp
+++ b/compiler/name-resolution.cpp
@@ -456,7 +456,7 @@ ConstDecl::Bind(SemaContext& sc)
     return true;
 }
 
-bool VarDecl::Bind(SemaContext& sc) {
+bool VarDeclBase::Bind(SemaContext& sc) {
     if (!sc.BindType(pos(), &type_))
         return false;
 
@@ -491,7 +491,7 @@ bool VarDecl::Bind(SemaContext& sc) {
         sym_->stock = is_stock_;
         sym_->is_const = true;
     } else {
-        int ident = type_.ident;
+        IdentifierKind ident = type_.ident;
         if (vclass_ == sARGUMENT && ident == iARRAY)
             type_.ident = ident = iREFARRAY;
 
@@ -528,9 +528,7 @@ bool VarDecl::Bind(SemaContext& sc) {
     return true;
 }
 
-bool
-VarDecl::BindType(SemaContext& sc)
-{
+bool VarDeclBase::BindType(SemaContext& sc) {
     return sc.BindType(pos(), &type_);
 }
 
@@ -1191,8 +1189,10 @@ EnumStructDecl::EnterNames(SemaContext& sc)
         symbol* child = new symbol(field.decl.name, position, iCONSTEXPR, sGLOBAL, root_->tag);
         child->x.tags.index = field.decl.type.semantic_tag();
         child->x.tags.field = 0;
-        child->dim.array.length = field.decl.type.numdim() ? field.decl.type.dim[0] : 0;
-        child->dim.array.level = 0;
+        if (field.decl.type.numdim()) {
+            child->set_dim_count(1);
+            child->set_dim(0, field.decl.type.dim[0]);
+        }
         child->set_parent(root_);
         child->enumfield = true;
         fields.emplace_back(child);

--- a/compiler/parse-node.cpp
+++ b/compiler/parse-node.cpp
@@ -21,9 +21,10 @@
 
 #include "errors.h"
 
-VarDecl::VarDecl(const token_pos_t& pos, sp::Atom* name, const typeinfo_t& type, int vclass,
-                 bool is_public, bool is_static, bool is_stock, Expr* initializer)
- : Decl(StmtKind::VarDecl, pos, name),
+VarDeclBase::VarDeclBase(StmtKind kind, const token_pos_t& pos, sp::Atom* name,
+                         const typeinfo_t& type, int vclass, bool is_public, bool is_static,
+                         bool is_stock, Expr* initializer)
+ : Decl(kind, pos, name),
    type_(type),
    vclass_(vclass),
    is_public_(is_public),
@@ -36,16 +37,12 @@ VarDecl::VarDecl(const token_pos_t& pos, sp::Atom* name, const typeinfo_t& type,
         set_init(initializer);
 }
 
-void
-VarDecl::set_init(Expr* expr)
-{
+void VarDeclBase::set_init(Expr* expr) {
     init_ = new BinaryExpr(pos(), '=', new SymbolExpr(pos(), name()), expr);
     init_->set_initializer();
 }
 
-Expr*
-VarDecl::init_rhs() const
-{
+Expr* VarDeclBase::init_rhs() const {
     if (!init_)
         return nullptr;
     return init_->right();

--- a/compiler/parse-node.h
+++ b/compiler/parse-node.h
@@ -298,16 +298,14 @@ class Decl : public Stmt
 
 class BinaryExpr;
 
-class VarDecl : public Decl
+class VarDeclBase : public Decl
 {
   public:
-    VarDecl(const token_pos_t& pos, sp::Atom* name, const typeinfo_t& type, int vclass,
-            bool is_public, bool is_static, bool is_stock, Expr* initializer);
+    VarDeclBase(StmtKind kind, const token_pos_t& pos, sp::Atom* name, const typeinfo_t& type,
+                int vclass, bool is_public, bool is_static, bool is_stock, Expr* initializer);
 
     bool Bind(SemaContext& sc) override;
     void ProcessUses(SemaContext& sc) override;
-
-    static bool is_a(Stmt* node) { return node->kind() == StmtKind::VarDecl; }
 
     // Bind only the typeinfo.
     bool BindType(SemaContext& sc);
@@ -327,6 +325,7 @@ class VarDecl : public Decl
     bool autozero() const { return autozero_; }
     void set_no_autozero() { autozero_ = false; }
     symbol* sym() const { return sym_; }
+    bool is_public() const { return is_public_; }
 
   protected:
     typeinfo_t type_;
@@ -339,12 +338,25 @@ class VarDecl : public Decl
     symbol* sym_ = nullptr;
 };
 
-class ArgDecl : public VarDecl
+class VarDecl : public VarDeclBase
+{
+  public:
+    VarDecl(const token_pos_t& pos, sp::Atom* name, const typeinfo_t& type, int vclass,
+            bool is_public, bool is_static, bool is_stock, Expr* initializer)
+      : VarDeclBase(StmtKind::VarDecl, pos, name, type, vclass, is_public, is_static, is_stock,
+                    initializer)
+    {}
+
+    static bool is_a(Stmt* node) { return node->kind() == StmtKind::VarDecl; }
+};
+
+class ArgDecl : public VarDeclBase
 {
   public:
     ArgDecl(const token_pos_t& pos, sp::Atom* name, const typeinfo_t& type, int vclass,
             bool is_public, bool is_static, bool is_stock, Expr* initializer)
-      : VarDecl(pos, name, type, vclass, is_public, is_static, is_stock, initializer)
+      : VarDeclBase(StmtKind::ArgDecl, pos, name, type, vclass, is_public, is_static, is_stock,
+                    initializer)
     {}
 
     static bool is_a(Stmt* node) { return node->kind() == StmtKind::ArgDecl; }

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -456,6 +456,7 @@ Parser::parse_enumstruct()
         }
 
         declinfo_t decl = {};
+        decl.type.ident = iVARIABLE;
         if (!parse_new_decl(&decl, nullptr, DECLFLAG_FIELD))
             continue;
 

--- a/compiler/pool-allocator.h
+++ b/compiler/pool-allocator.h
@@ -53,6 +53,7 @@ class PoolAllocator final
 
     static const size_t kDefaultPoolSize = 64 * 1024;
     static const size_t kMaxReserveSize = 64 * 1024;
+    static const size_t kAlignment = sizeof(void*);
 
   private:
     std::vector<std::unique_ptr<Pool>> pools_;
@@ -78,7 +79,7 @@ class PoolAllocator final
 
     void* rawAllocate(size_t bytes) {
         // Guarantee malloc alignment.
-        size_t actualBytes = ke::Align(bytes, ke::kMallocAlignment);
+        size_t actualBytes = ke::Align(bytes, kAlignment);
         Pool* last = pools_.empty() ? nullptr : pools_.back().get();
         if (!last || (size_t(last->end - last->ptr) < actualBytes))
             last = ensurePool(actualBytes);

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -82,27 +82,6 @@ struct DefaultArg : public PoolObject {
 struct methodmap_t;
 struct stringlist;
  
-// Possible entries for "ident". These are used in the "symbol", "value"
-// and arginfo structures. Not every constant is valid for every use.
-// In an argument list, the list is terminated with a "zero" ident; labels
-// cannot be passed as function arguments, so the value 0 is overloaded.
-enum IdentifierKind {
-    iVARIABLE = 1,      /* cell that has an address and that can be fetched directly (lvalue) */
-    iREFERENCE = 2,     /* iVARIABLE, but must be dereferenced */
-    iARRAY = 3,
-    iREFARRAY = 4,      /* an array passed by reference (i.e. a pointer) */
-    iARRAYCELL = 5,     /* array element, cell that must be fetched indirectly */
-    iARRAYCHAR = 6,     /* array element, character from cell from array */
-    iEXPRESSION = 7,    /* expression result, has no address (rvalue) */
-    iCONSTEXPR = 8,     /* constant expression (or constant symbol) */
-    iFUNCTN = 9,
-    iVARARGS = 11,      /* function specified ... as argument(s) */
-    iACCESSOR = 13,     /* property accessor via a methodmap_method_t */
-    iMETHODMAP = 14,    /* symbol defining a methodmap */
-    iENUMSTRUCT = 15,   /* symbol defining an enumstruct */
-    iSCOPE = 16,        /* local scope chain */
-};
-
 class EnumData;
 class EnumStructData;
 class EnumStructVarData;

--- a/compiler/semantics.h
+++ b/compiler/semantics.h
@@ -181,10 +181,10 @@ class Semantics final
     bool CheckExprStmt(ExprStmt* stmt);
     bool CheckIfStmt(IfStmt* stmt);
     bool CheckConstDecl(ConstDecl* decl);
-    bool CheckVarDecl(VarDecl* decl);
+    bool CheckVarDecl(VarDeclBase* decl);
     bool CheckConstDecl(VarDecl* decl);
-    bool CheckPstructDecl(VarDecl* decl);
-    bool CheckPstructArg(VarDecl* decl, const pstruct_t* ps,
+    bool CheckPstructDecl(VarDeclBase* decl);
+    bool CheckPstructArg(VarDeclBase* decl, const pstruct_t* ps,
                          const StructInitFieldExpr* field, std::vector<bool>* visited);
 
     // Expressions.
@@ -214,13 +214,13 @@ class Semantics final
 
     bool CheckAssignmentLHS(BinaryExpr* expr);
     bool CheckAssignmentRHS(BinaryExpr* expr);
-    bool AddImplicitDynamicInitializer(VarDecl* decl);
+    bool AddImplicitDynamicInitializer(VarDeclBase* decl);
 
     struct ParamState {
         std::vector<Expr*> argv;
     };
 
-    bool CheckArrayDeclaration(VarDecl* decl);
+    bool CheckArrayDeclaration(VarDeclBase* decl);
     bool CheckExprForArrayInitializer(Expr* expr);
     bool CheckNewArrayExprForArrayInitializer(NewArrayExpr* expr);
     bool CheckArgument(CallExpr* call, ArgDecl* arg, Expr* expr,

--- a/compiler/symbols.cpp
+++ b/compiler/symbols.cpp
@@ -92,11 +92,12 @@ markusage(symbol* sym, int usage)
 }
 
 FunctionData::FunctionData()
- : node(nullptr),
-   forward(nullptr),
-   alias(nullptr),
-   checked_one_signature(false),
-   compared_prototype_args(false)
+  : node(nullptr),
+    forward(nullptr),
+    alias(nullptr),
+    checked_one_signature(false),
+    compared_prototype_args(false),
+    is_member_function(false)
 {
 }
 
@@ -124,16 +125,16 @@ symbol::symbol(sp::Atom* symname, cell symaddr, IdentifierKind symident, int sym
    deprecated(false),
    queued(false),
    explicit_return_type(false),
-   x({}),
+   semantic_tag(0),
    dim_data(nullptr),
    fnumber(0),
    /* assume global visibility (ignored for local symbols) */
    lnumber(0),
    documentation(nullptr),
    addr_(symaddr),
-   name_(nullptr),
-   parent_(nullptr)
+   name_(nullptr)
 {
+    assert(ident != iINVALID);
     name_ = symname;
     if (symident == iFUNCTN)
         data_ = new FunctionData;
@@ -159,9 +160,8 @@ symbol::symbol(const symbol& other)
     is_const = other.is_const;
     deprecated = other.deprecated;
     documentation = other.documentation;
+    semantic_tag = other.semantic_tag;
     // Note: explicitly don't add queued.
-
-    x = other.x;
 
     if (other.dim_data) {
         set_dim_count(other.dim_count());
@@ -216,7 +216,7 @@ NewVariable(sp::Atom* name, cell addr, IdentifierKind ident, int vclass, int tag
         sym->set_dim_count(numdim);
         for (int i = 0; i < numdim; i++)
             sym->set_dim(i, dim[i]);
-        sym->x.tags.index = semantic_tag;
+        sym->semantic_tag = semantic_tag;
     }
     return sym;
 }

--- a/compiler/symbols.h
+++ b/compiler/symbols.h
@@ -63,6 +63,7 @@ class FunctionData final : public SymbolData
     int max_callee_stack = 0;
     bool checked_one_signature SP_BITFIELD(1);
     bool compared_prototype_args SP_BITFIELD(1);
+    bool is_member_function SP_BITFIELD(1);
 
     // Other symbols that this symbol refers to.
     PoolForwardList<symbol*> refers_to;
@@ -150,12 +151,7 @@ struct symbol : public PoolObject
     bool queued : 1;        // symbol is queued for a local work algorithm
     bool explicit_return_type : 1; // transitional return type was specified
 
-    union {
-        struct {
-            int index; /* array & enum: tag of array indices or the enum item */
-            int field; /* enumeration fields, where a size is attached to the field */
-        } tags;        /* extra tags */
-    } x;               /* 'x' for 'extra' */
+    int semantic_tag;
     int* dim_data;     /* -1 = dim count, 0..n = dim sizes */
     int fnumber; /* file number in which the symbol is declared */
     int lnumber; /* line number for the declaration */
@@ -191,12 +187,6 @@ struct symbol : public PoolObject
         assert(ident == iFUNCTN);
         return data_->asFunction();
     }
-    symbol* parent() const {
-        return parent_;
-    }
-    void set_parent(symbol* parent) {
-        parent_ = parent;
-    }
 
     symbol* array_return() const {
         return function()->array_return;
@@ -228,8 +218,6 @@ struct symbol : public PoolObject
     cell addr_; /* address or offset (or value for constant, index for native function) */
     sp::Atom* name_;
     SymbolData* data_;
-
-    symbol* parent_;
 };
 
 enum ScopeKind {

--- a/compiler/type-checker.cpp
+++ b/compiler/type-checker.cpp
@@ -31,9 +31,9 @@ TypeInfoFromSymbol(symbol* sym)
     type.is_const = sym->is_const;
 
     if (sym->parent() && sym->parent()->ident == iENUMSTRUCT) {
-        if (sym->dim.array.length) {
+        if (sym->dim_count()) {
             type.ident = iARRAY;
-            type.dim.emplace_back(sym->dim.array.length);
+            type.dim.emplace_back(sym->dim(0));
         } else {
             type.ident = iVARIABLE;
         }
@@ -42,15 +42,8 @@ TypeInfoFromSymbol(symbol* sym)
         type.ident = sym->ident;
 
         if (sym->ident == iARRAY || sym->ident == iREFARRAY) {
-            for (symbol* iter = sym; iter; iter = iter->array_child()) {
-                if (iter->x.tags.index && iter->dim.array.level == 0)
-                    type.declared_tag = iter->x.tags.index;
-                if (iter->x.tags.index) {
-                    type.declared_tag = iter->x.tags.index;
-                    type.set_tag(0);
-                }
-                type.dim.emplace_back(iter->dim.array.length);
-            }
+            for (int i = 0; i < sym->dim_count(); i++)
+                type.dim.emplace_back(sym->dim(i));
         }
     }
     return type;

--- a/compiler/type-checker.cpp
+++ b/compiler/type-checker.cpp
@@ -29,22 +29,11 @@ TypeInfoFromSymbol(symbol* sym)
 
     type.set_tag(sym->tag);
     type.is_const = sym->is_const;
-
-    if (sym->parent() && sym->parent()->ident == iENUMSTRUCT) {
-        if (sym->dim_count()) {
-            type.ident = iARRAY;
-            type.dim.emplace_back(sym->dim(0));
-        } else {
-            type.ident = iVARIABLE;
-        }
-        type.set_tag(sym->x.tags.index);
-    } else {
-        type.ident = sym->ident;
-
-        if (sym->ident == iARRAY || sym->ident == iREFARRAY) {
-            for (int i = 0; i < sym->dim_count(); i++)
-                type.dim.emplace_back(sym->dim(i));
-        }
+    type.ident = sym->ident;
+    if (sym->ident == iARRAY || sym->ident == iREFARRAY) {
+        for (int i = 0; i < sym->dim_count(); i++)
+            type.dim.emplace_back(sym->dim(i));
+        type.declared_tag = sym->semantic_tag;
     }
     return type;
 }

--- a/compiler/types.h
+++ b/compiler/types.h
@@ -39,6 +39,28 @@
 typedef int32_t cell;
 typedef uint32_t ucell;
 
+// Possible entries for "ident". These are used in the "symbol", "value"
+// and arginfo structures. Not every constant is valid for every use.
+// In an argument list, the list is terminated with a "zero" ident; labels
+// cannot be passed as function arguments, so the value 0 is overloaded.
+enum IdentifierKind {
+    iINVALID = 0,
+    iVARIABLE = 1,      /* cell that has an address and that can be fetched directly (lvalue) */
+    iREFERENCE = 2,     /* iVARIABLE, but must be dereferenced */
+    iARRAY = 3,
+    iREFARRAY = 4,      /* an array passed by reference (i.e. a pointer) */
+    iARRAYCELL = 5,     /* array element, cell that must be fetched indirectly */
+    iARRAYCHAR = 6,     /* array element, character from cell from array */
+    iEXPRESSION = 7,    /* expression result, has no address (rvalue) */
+    iCONSTEXPR = 8,     /* constant expression (or constant symbol) */
+    iFUNCTN = 9,
+    iVARARGS = 11,      /* function specified ... as argument(s) */
+    iACCESSOR = 13,     /* property accessor via a methodmap_method_t */
+    iMETHODMAP = 14,    /* symbol defining a methodmap */
+    iENUMSTRUCT = 15,   /* symbol defining an enumstruct */
+    iSCOPE = 16,        /* local scope chain */
+};
+
 enum class TypeKind : uint8_t {
     Int,
     Object,
@@ -91,7 +113,7 @@ struct typeinfo_t {
       : type_atom(nullptr),
         tag_(-1),
         declared_tag(0),
-        ident(0),
+        ident(iINVALID),
         is_const(false),
         is_new(false),
         has_postdims(false),
@@ -112,7 +134,7 @@ struct typeinfo_t {
     // rewritten for desugaring.
     int declared_tag;
 
-    int ident : 5;          // Either iREFERENCE, iARRAY, or iVARIABLE.
+    IdentifierKind ident : 6;  // Either iREFERENCE, iARRAY, or iVARIABLE.
     bool is_const : 1;
     bool is_new : 1;        // New-style declaration.
     bool has_postdims : 1;  // Dimensions, if present, were in postfix position.

--- a/tests/compile-only/fail-pass-arraycell-to-refarray.sp
+++ b/tests/compile-only/fail-pass-arraycell-to-refarray.sp
@@ -1,0 +1,9 @@
+
+
+void blah(int x[3]) {
+}
+
+public main() {
+    int y[3];
+    blah(y[2]);
+}

--- a/tests/compile-only/fail-pass-arraycell-to-refarray.txt
+++ b/tests/compile-only/fail-pass-arraycell-to-refarray.txt
@@ -1,0 +1,1 @@
+(8) : error 047: array sizes do not match, or destination array is too small

--- a/tests/compile-only/fail-return-indeterminate-array.txt
+++ b/tests/compile-only/fail-return-indeterminate-array.txt
@@ -1,1 +1,2 @@
-(6) : error 046: unknown array size (variable "sNames")
+(6) : error 128: cannot return an array of indeterminate length
+(11) : error 411: cannot determine fixed array size of return value

--- a/tools/corpus/corpus_skip.list
+++ b/tools/corpus/corpus_skip.list
@@ -195,6 +195,8 @@ forums/A/t/o/AtomicStryker/l4d_stuckzombiemeleefix_932416.sp
 forums/A/t/o/AtomicStryker/l4d_tankvote_944071.sp
 forums/A/t/o/AtomicStryker/l4dready_1261748.sp
 forums/A/t/o/AtomicStryker/leetspeak_1054825.sp
+forums/A/t/r/Atreus/tf2-cap-regen_769135.sp
+forums/A/t/r/Atreus/tf2-cap-regen_770935.sp
 forums/A/u/T/AuTok1NGs/Menu_Gloves_v2_2461100.sp
 forums/A/u/T/AuTok1NGs/Menu_Gloves_v2_VIP_Flag__2461100.sp
 forums/A/v/o/Avo/noadminconfig_1853472.sp
@@ -734,6 +736,7 @@ forums/E/H/G/EHG/SuperSurvival_1082412.sp
 forums/E/M/I/EMINEM_FB/eminem_zeph_mathcredits_2559968.sp
 forums/E/M/I/EMINEM_FB/franug_weapons_non_zr_2699058.sp
 forums/E/M/I/EMINEM_FB/mostactive_2640172.sp
+forums/E/M/I/EMINEM_FB/sm_skinchooser_2498328.sp
 forums/E/M/I/EMINEM_FB/zp_lights_2477087.sp
 forums/E/P/a/EPacker2/soundscapes_2400149.sp
 forums/E/P/a/EPacker2/soundscapes_nmrih_2400149.sp
@@ -1123,6 +1126,7 @@ forums/J/a/-/Ja-Forces/l4d2_autoIS_2680835.sp
 forums/J/a/-/Ja-Forces/l4d2_multitanks_1474525.sp
 forums/J/a/-/Ja-Forces/l4d2_witchy_1292004.sp
 forums/J/a/-/Ja-Forces/l4d_multitanks_1474525.sp
+forums/J/a/-/Ja-Forces/l4d_profile_checker_v12_1335581.sp
 forums/J/a/-/Ja-Forces/l4d_stats_1260752.sp
 forums/J/a/-/Ja-Forces/l4d_witchy_1292004.sp
 forums/J/a/c/Jacoblairm/betterban_2483994.sp
@@ -1371,6 +1375,7 @@ forums/M/a/s/MasterMind420/l4d2_pistol_reloading_v1_4_beta_2447365.sp
 forums/M/a/s/MasterMind420/l4d_drop_2688084.sp
 forums/M/a/s/MasterMind420/l4d_multiple_equipment_final_2459368.sp
 forums/M/a/s/MasterMind420/l4d_pipebomb_duration_2558077.sp
+forums/M/a/s/MasterMind420/l4d_weapon_fire_modes_2687863.sp
 forums/M/a/s/MasterOfTheXP/betherobot_1772818.sp
 forums/M/a/s/MasterOfTheXP/betherobot_1858490.sp
 forums/M/a/s/MasterOfTheXP/betherobot_2009651.sp
@@ -1498,6 +1503,8 @@ forums/M/i/t/Mitchell/c4model_1821388.sp
 forums/M/i/t/Mitchell/csgo_rollthedice_1838295.sp
 forums/M/i/t/Mitchell/customchat_1744093.sp
 forums/M/i/t/Mitchell/duckpiano_2658893.sp
+forums/M/i/t/Mitchell/laserz_1749220.sp
+forums/M/i/t/Mitchell/laserz_1759151.sp
 forums/M/i/t/Mitchell/naplamgrenade_1666445.sp
 forums/M/i/t/Mitchell/playtime_1767585.sp
 forums/M/i/t/Mitchell/ztf2nades_1696393.sp
@@ -2182,9 +2189,11 @@ forums/S/i/l/Sillium/basevotes_826626.sp
 forums/S/i/l/Sillium/potential_2445192.sp
 forums/S/i/l/Sillium/sf_f2p_kicker_with_kicktype_1520181.sp
 forums/S/i/l/Sillium/update_notifier_warning_1558650.sp
+forums/S/i/l/Silvers/l4d2_fireworks_1441088.sp
 forums/S/i/l/Silvers/l4d2_holdout_1741099.sp
 forums/S/i/l/Silvers/l4d2_incapped_crawling_1291588.sp
 forums/S/i/l/Silvers/l4d_flare_1402003.sp
+forums/S/i/l/Silvers/l4d_gear_transfer_1294082.sp
 forums/S/i/l/Silvers/l4d_glare_1678497.sp
 forums/S/i/l/Silvers/l4d_god_frames_forward_2679991.sp
 forums/S/i/l/Silvers/l4d_rock_lagcomp_2685841.sp
@@ -2389,6 +2398,7 @@ forums/S/t/o/StomperG/sFullAnnounce_2743919.sp
 forums/S/t/o/StormishJustice/bedeflector_2311517.sp
 forums/S/t/o/StormishJustice/bethegiantv2_2312708.sp
 forums/S/t/r/StrikeR14/jackpot_2717163.sp
+forums/S/t/r/StrikerMan780/sm_skinchooser_2511695.sp
 forums/S/t/r/StrikerMan780/sourceirc-relayall_color_1798034.sp
 forums/S/t/r/StrikerMan780/sourceirc-relayall_color_1807835.sp
 forums/S/t/r/StrikerMan780/voice_channel_manager_v2_1724590.sp
@@ -2806,6 +2816,7 @@ forums/Y/a/m/Yamakashi/menu_2586653.sp
 forums/Y/a/m/Yamakashi/warden_2586653.sp
 forums/Y/o/N/YoNer/FileEditor_2502260.sp
 forums/Y/o/N/YoNer/classrestrict_ds_2402164.sp
+forums/Y/o/N/YoNer/l4d2_fireworksy_2500280.sp
 forums/Y/o/N/YoNer/ppush_2446018.sp
 forums/Y/o/N/YoNer/smrates_2454570.sp
 forums/Y/o/N/YoNer/sql__2479833.sp
@@ -2917,6 +2928,8 @@ forums/a/m/b/ambn/PlayerSkin_2519831.sp
 forums/a/m/b/ambn/PlayerSkin_2569685.sp
 forums/a/m/b/ambn/af_2596560.sp
 forums/a/m/b/ambn/sb_2492831.sp
+forums/a/n/d/andi67/sm_skinchooser_2496301.sp
+forums/a/n/d/andi67/sm_skinchooser_2496586.sp
 forums/a/n/d/andrzejmleczko/Slots_772062.sp
 forums/a/n/i/animalnots/adsoverlays_1860739.sp
 forums/a/n/i/animalnots/rulesoverlays_1861130.sp
@@ -3023,6 +3036,7 @@ forums/b/u/s/busted/VIP_Extend_2743738.sp
 forums/b/u/s/busted/announcementbysteamID_2743881.sp
 forums/b/u/s/busted/botfix_2741324.sp
 forums/b/u/s/busted/mapvotesound_2742066.sp
+forums/b/u/s/busted/sm_skinchooser_2742753.sp
 forums/b/u/t/butaford/RoundEndSound_1482268.sp
 forums/b/u/t/butare/fortnite_hits_2694424.sp
 forums/b/u/t/butare/influx_simpleranks_chat_2555595.sp
@@ -3464,6 +3478,7 @@ forums/h/e/a/headline/awponly_2537273.sp
 forums/h/e/a/headline/hl_regenhp_2345376.sp
 forums/h/e/a/headline/hl_regenhp_2345424.sp
 forums/h/e/a/headline/hnsbeacon_2565541.sp
+forums/h/e/a/headline/laserz_2354941.sp
 forums/h/e/f/heffebaycay/TF2_Stats_ball_1376616.sp
 forums/h/e/i/heiioween/tf_any_servermode_2441860.sp
 forums/h/e/n/hengen/Test_2376221.sp
@@ -3731,6 +3746,7 @@ forums/m/i/n/minimoney1/autorecorder_mod_1669163.sp
 forums/m/i/n/minimoney1/css_dice_1734856.sp
 forums/m/i/n/minimoney1/fwdex_sample_1843662.sp
 forums/m/i/n/minimoney1/grenspeed_1752684.sp
+forums/m/i/n/minimoney1/laserz_1749227.sp
 forums/m/i/n/minimoney1/simple-chatprocessor_1825790.sp
 forums/m/i/n/minimoney1/sm_friendban_1879090.sp
 forums/m/i/n/minimoney1/sm_friendban_steamtools_1879090.sp
@@ -3739,6 +3755,7 @@ forums/m/i/n/minimoney1/tag_admin_1839960.sp
 forums/m/i/s/misterul/sodstats_2699923.sp
 forums/m/m/m/mmmm124/tf2bwr_2122633.sp
 forums/m/o/i/moilc/mspawn_2603575.sp
+forums/m/o/n/monn/gunxpmod_1149087.sp
 forums/m/o/r/moriss/event_2015429.sp
 forums/m/o/s/mostten/c_nmrih_diffmoder_2549109.sp
 forums/m/o/t/motte/freak_fortress_2_2045763.sp


### PR DESCRIPTION
There's a bunch of stuff in this series, removing more crap from the pre-AST compiler. But the biggie is removing symbol::child. We no longer create a symbol for each dimension of an array. This simplifies a lot of code, and fixes some long-standing semantic bugs in the compiler.

As a result of this change, const is now respected when passing 2-dimensional arrays as arguments.

In addition, the following declaration now emits a warning:

    const int X;

This is because future assignment is no longer possible if "X" is a two-dimensional array.