### PR TITLE
Add warning when comma expressions contain discarded non-effectful subexpressions.

### DIFF
--- a/compiler/messages.h
+++ b/compiler/messages.h
@@ -256,7 +256,7 @@ static const char* warnmsg[] = {
     /*228*/ "enum multiplers are deprecated and will be removed in the next release\n",
     /*229*/ "index tag mismatch (symbol \"%s\")\n",
     /*230*/ "symbol \"%s\" is not a preprocessor symbol; this behavior is undefined and will be removed in the future\n",
-    /*231*/ "unused231\n",
+    /*231*/ "sub-expression at position %d has no effect; comma expression only returns last value\n",
     /*232*/ "output file is written, but with compact encoding disabled\n",
     /*233*/ "unused233\n",
     /*234*/ "symbol \"%s\" is marked as deprecated: %s\n",

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -1368,6 +1368,12 @@ bool Semantics::CheckCommaExpr(CommaExpr* comma) {
         comma->exprs().back() = last;
     }
 
+    for (size_t i = 0; i < comma->exprs().size() - 1; i++) {
+        auto expr = comma->exprs().at(i);
+        if (!expr->HasSideEffects())
+            report(expr, 231) << i;
+    }
+
     comma->val() = last->val();
     comma->set_lvalue(last->lvalue());
 

--- a/tests/compile-only/fail-subexpr-in-comma-has-no-effect.sp
+++ b/tests/compile-only/fail-subexpr-in-comma-has-no-effect.sp
@@ -1,0 +1,6 @@
+// warnings_are_errors: true
+
+public main() {
+    int x = (5, 6, 7);
+    return x;
+}

--- a/tests/compile-only/fail-subexpr-in-comma-has-no-effect.txt
+++ b/tests/compile-only/fail-subexpr-in-comma-has-no-effect.txt
@@ -1,0 +1,2 @@
+(4) : error 231: sub-expression at position 0 has no effect; comma expression only returns last value
+(4) : error 231: sub-expression at position 1 has no effect; comma expression only returns last value


### PR DESCRIPTION
Bug: issue #877
Test: new test