### PR TITLE
Track tokens more accurately, and compactly.

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -108,10 +108,10 @@ class Config(object):
                 cxx.postlink += ['-lpthread', '-lrt']
             elif cxx.target.platform == 'mac':
                 cxx.linkflags.remove('-lstdc++')
-                cxx.cflags += ['-mmacosx-version-min=10.7']
+                cxx.cflags += ['-mmacosx-version-min=10.15']
                 cxx.cflags += ['-stdlib=libc++']
                 cxx.linkflags += ['-stdlib=libc++']
-                cxx.linkflags += ['-mmacosx-version-min=10.7']
+                cxx.linkflags += ['-mmacosx-version-min=10.15']
             elif cxx.target.platform == 'windows':
                 cxx.defines += ['WIN32', '_WINDOWS']
                 cxx.cxxdefines += ['NOMINMAX']
@@ -224,6 +224,7 @@ class Config(object):
             '/EHsc',
             '/GR-',
             '/TP',
+            '/std:c++17',
         ]
         cxx.linkflags += [
             'kernel32.lib',

--- a/compiler/assembler.cpp
+++ b/compiler/assembler.cpp
@@ -563,7 +563,7 @@ RttiBuilder::encode_signature(symbol* sym)
         argc++;
     }
     if (argc > UCHAR_MAX)
-        error(45);
+        report(45);
 
     bytes.push_back((uint8_t)argc);
     if (is_variadic)
@@ -893,7 +893,7 @@ Assembler::Assemble(SmxByteBuffer* buffer)
 
         auto id = (uint32_t(i) << 1) | 1;
         if (!Label::ValueFits(id))
-            error(421);
+            report(421);
         cg_.LinkPublicFunction(sym, id);
 
         rtti.add_method(sym);

--- a/compiler/compile-context.cpp
+++ b/compiler/compile-context.cpp
@@ -40,7 +40,7 @@ CompileContext::CompileContext()
 
     reports_ = std::make_unique<ReportManager>(*this);
     options_ = std::make_unique<CompileOptions>();
-    sources_ = std::make_unique<SourceManager>(*this);
+    sources_ = std::make_unique<sp::SourceManager>(*this);
     types_ = std::make_unique<TypeDictionary>(*this);
     types_->init();
 }

--- a/compiler/compile-context.h
+++ b/compiler/compile-context.h
@@ -36,11 +36,14 @@
 class Lexer;
 class ReportManager;
 class SemaContext;
-class SourceManager;
 class SymbolScope;
 class TypeDictionary;
 struct CompileOptions;
 struct symbol;
+
+namespace sp {
+class SourceManager;
+} // namespace sp
 
 // The thread-safe successor to scvars.
 class CompileContext final
@@ -66,7 +69,7 @@ class CompileContext final
     const std::shared_ptr<Lexer>& lexer() const { return lexer_; }
     ReportManager* reports() const { return reports_.get(); }
     CompileOptions* options() const { return options_.get(); }
-    SourceManager* sources() const { return sources_.get(); }
+    sp::SourceManager* sources() const { return sources_.get(); }
     TypeDictionary* types() const { return types_.get(); }
     sp::StringPool* atoms() { return &atoms_; }
 
@@ -102,8 +105,8 @@ class CompileContext final
     std::string& outfname() { return outfname_; }
     void set_outfname(const std::string& value) { outfname_ = value; }
 
-    std::shared_ptr<SourceFile> inpf_org() const { return inpf_org_; }
-    void set_inpf_org(std::shared_ptr<SourceFile> sf) { inpf_org_ = sf; }
+    std::shared_ptr<sp::SourceFile> inpf_org() const { return inpf_org_; }
+    void set_inpf_org(std::shared_ptr<sp::SourceFile> sf) { inpf_org_ = sf; }
 
     bool must_abort() const { return must_abort_; }
     void set_must_abort() { must_abort_ = true; }
@@ -135,8 +138,8 @@ class CompileContext final
     std::unique_ptr<CompileOptions> options_;
     std::string outfname_;
     std::string errfname_;
-    std::unique_ptr<SourceManager> sources_;
-    std::shared_ptr<SourceFile> inpf_org_;
+    std::unique_ptr<sp::SourceManager> sources_;
+    std::shared_ptr<sp::SourceFile> inpf_org_;
     std::unique_ptr<TypeDictionary> types_;
     sp::StringPool atoms_;
 

--- a/compiler/errors.cpp
+++ b/compiler/errors.cpp
@@ -283,7 +283,7 @@ ErrorReport
 ErrorReport::infer(int number)
 {
     auto& cc = CompileContext::get();
-    return create(number, -1, cc.lexer()->current_token()->end.line);
+    return create(number, -1, cc.lexer()->current_token()->start.line);
 }
 
 void

--- a/compiler/errors.cpp
+++ b/compiler/errors.cpp
@@ -132,9 +132,7 @@ MessageBuilder::MessageBuilder(int number)
 MessageBuilder::MessageBuilder(symbol* sym, int number)
   : number_(number)
 {
-    where_.file = sym->fnumber;
-    where_.line = sym->lnumber;
-    where_.col = 0;
+    where_ = sym->pos;
 }
 
 MessageBuilder::MessageBuilder(MessageBuilder&& other)

--- a/compiler/errors.cpp
+++ b/compiler/errors.cpp
@@ -283,7 +283,7 @@ ErrorReport
 ErrorReport::infer(int number)
 {
     auto& cc = CompileContext::get();
-    return create(number, -1, cc.lexer()->fline());
+    return create(number, -1, cc.lexer()->current_token()->end.line);
 }
 
 void

--- a/compiler/errors.cpp
+++ b/compiler/errors.cpp
@@ -170,7 +170,7 @@ MessageBuilder::~MessageBuilder()
 
     ErrorReport report;
     report.number = number_;
-    report.fileno = where_.file;
+    report.fileno = cc.sources()->GetSourceFileIndex(where_);
     report.lineno = std::max(where_.line, 1);
     if (report.fileno < 0)
         report.fileno = cc.lexer()->fcurrent();

--- a/compiler/errors.cpp
+++ b/compiler/errors.cpp
@@ -136,7 +136,7 @@ error(int number)
 {
     auto& cc = CompileContext::get();
     if (auto pos_override = cc.reports()->pos_override()) {
-        error(pos_override->pos(), number);
+        report(pos_override->pos(), number);
         return 0;
     }
 
@@ -231,25 +231,6 @@ MessageBuilder::~MessageBuilder()
 
     report.message = out.str();
     report_error(std::move(report));
-}
-
-int
-error(const token_pos_t& where, int number)
-{
-    ErrorReport report = ErrorReport::create(number, where.file, where.line);
-
-    report.lineno = where.line;
-    report_error(std::move(report));
-    return 0;
-}
-
-int
-error(symbol* sym, int number)
-{
-    ErrorReport report = ErrorReport::create(number, sym->fnumber, sym->lnumber);
-
-    report_error(std::move(report));
-    return 0;
 }
 
 ErrorReport

--- a/compiler/errors.cpp
+++ b/compiler/errors.cpp
@@ -170,7 +170,10 @@ MessageBuilder::~MessageBuilder()
 
     ErrorReport report;
     report.number = number_;
-    report.fileno = cc.sources()->GetSourceFileIndex(where_);
+    if (where_.valid())
+        report.fileno = cc.sources()->GetSourceFileIndex(where_);
+    else
+        report.fileno = 0;
     report.lineno = std::max(where_.line, 1);
     if (report.fileno < 0)
         report.fileno = cc.lexer()->fcurrent();

--- a/compiler/errors.h
+++ b/compiler/errors.h
@@ -72,8 +72,6 @@ class AutoErrorPos final
 };
 
 int error(int number);
-int error(symbol* sym, int number);
-int error(const token_pos_t& where, int number);
 
 class MessageBuilder
 {

--- a/compiler/errors.h
+++ b/compiler/errors.h
@@ -42,9 +42,6 @@ enum class ErrorType {
 };
 
 struct ErrorReport {
-    static ErrorReport infer(int number);
-    static ErrorReport create(int number, int fileno, int lineno);
-
     int number;
     int fileno;
     int lineno;
@@ -70,8 +67,6 @@ class AutoErrorPos final
     token_pos_t pos_;
     AutoErrorPos* prev_;
 };
-
-int error(int number);
 
 class MessageBuilder
 {

--- a/compiler/expressions.cpp
+++ b/compiler/expressions.cpp
@@ -479,7 +479,7 @@ matchtag(int formaltag, int actualtag, int flags)
 
     if (actual->isFunction() && !formal->isFunction()) {
         // We're being given a function, but the destination is not a function.
-        error(130);
+        report(130);
         return FALSE;
     }
 
@@ -500,7 +500,7 @@ matchtag(int formaltag, int actualtag, int flags)
 
     if (formal->isFunction()) {
         if (!matchfunctags(formal, actual)) {
-            error(100);
+            report(100);
             return FALSE;
         }
         return TRUE;
@@ -575,19 +575,19 @@ calc(cell left, int oper_tok, cell right, char* boolresult)
             return (left * right);
         case '/':
             if (right == 0) {
-                error(29);
+                report(29);
                 return 0;
             }
             return left / right;
         case '%':
             if (right == 0) {
-                error(29);
+                report(29);
                 return 0;
             }
             return left % right;
     }
     assert(false);
-    error(29); /* invalid expression, assumed 0 (this should never occur) */
+    report(29); /* invalid expression, assumed 0 (this should never occur) */
     return 0;
 }
 

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -1329,7 +1329,6 @@ Lexer::PushSynthesizedToken(TokenKind kind, int col)
     tok->start.line = state_.tokline;
     tok->start.col = col;
     tok->start.file = state_.inpf->sources_index();
-    tok->end = tok->start;
     lexpush();
     return tok;
 }
@@ -1365,7 +1364,6 @@ int Lexer::LexNewToken() {
                 // We hit the end of the line; preprocessor should not eat more
                 // tokens without a continuation.
                 FillTokenPos(&tok->start);
-                FillTokenPos(&tok->end);
                 return tok->id = tEOL;
             }
             return 0;
@@ -1385,7 +1383,6 @@ int Lexer::LexNewToken() {
         // Current token may be different if we're in the preproc buffer, so
         // grab it.
         tok = current_token();
-        FillTokenPos(&tok->end);
 
         if (tok->id == tSTRING && !in_string_continuation_) {
             LexStringContinuation();
@@ -1942,8 +1939,8 @@ Lexer::peek_same_line()
     // token parsed. If fline == current token's line, we are guaranteed any
     // buffered token is still on the same line.
     if (token_buffer_->depth > 0 &&
-        current_token()->end.file == next_token()->start.file &&
-        current_token()->end.line == state_.fline)
+        current_token()->start.file == next_token()->start.file &&
+        current_token()->start.line == state_.fline)
     {
         return next_token()->id ? next_token()->id : tEOL;
     }
@@ -1957,8 +1954,8 @@ Lexer::peek_same_line()
 
     // If the next token starts on the line the last token ends, then the next
     // token is considered on the same line.
-    if (next.start.line == current_token()->end.line &&
-        next.start.file == current_token()->end.file)
+    if (next.start.line == current_token()->start.line &&
+        next.start.file == current_token()->start.file)
     {
         return next.id;
     }

--- a/compiler/lexer.h
+++ b/compiler/lexer.h
@@ -345,7 +345,7 @@ class Lexer
     void LexSymbol(full_token_t* tok, sp::Atom* atom);
     bool MaybeHandleLineContinuation();
     bool PlungeQualifiedFile(const char* name);
-    full_token_t* PushSynthesizedToken(TokenKind kind, int col);
+    full_token_t* PushSynthesizedToken(TokenKind kind, const token_pos_t& pos);
     void SynthesizeIncludePathToken();
     void SetFileDefines(std::string file);
     void EnterFile(std::shared_ptr<SourceFile>&& fp);

--- a/compiler/lexer.h
+++ b/compiler/lexer.h
@@ -436,7 +436,6 @@ class Lexer
     size_t iflevel_;             /* nesting level if #if/#else/#endif */
     size_t skiplevel_; /* level at which we started skipping (including nested #if .. #endif) */
     std::string deprecate_;
-    bool lexnewline_ = false;
     bool allow_tags_ = true;
     int stmtindent_ = 0;
     bool indent_nowarn_ = false;

--- a/compiler/lexer.h
+++ b/compiler/lexer.h
@@ -46,7 +46,6 @@ struct full_token_t {
     };
     int value();
     token_pos_t start;
-    token_pos_t end;
     const std::string& data() const {
         return atom->str();
     }

--- a/compiler/lexer.h
+++ b/compiler/lexer.h
@@ -32,12 +32,6 @@
 class CompileContext;
 class Type;
 
-struct token_pos_t {
-    int file = 0;
-    int line = 0;
-    int col = 0;
-};
-
 struct full_token_t {
     int id = 0;
     union {

--- a/compiler/lexer.h
+++ b/compiler/lexer.h
@@ -40,8 +40,11 @@ struct token_pos_t {
 
 struct full_token_t {
     int id = 0;
-    int value = 0;
-    sp::Atom* atom = nullptr;
+    union {
+        sp::Atom* atom = nullptr;
+        int numeric_value; // Set on tRATIONAL, tNUMBER, and tCHAR_LITERAL.
+    };
+    int value();
     token_pos_t start;
     token_pos_t end;
     const std::string& data() const {
@@ -219,6 +222,11 @@ enum TokenKind {
     tENTERED_MACRO,  /* internal lexer command */
     tLAST_TOKEN_ID
 };
+
+inline int full_token_t::value() {
+    assert(id == tRATIONAL || id == tNUMBER || id == tCHAR_LITERAL);
+    return numeric_value;
+}
 
 static inline bool
 IsChainedOp(int token)

--- a/compiler/main.cpp
+++ b/compiler/main.cpp
@@ -187,7 +187,7 @@ int RunCompiler(int argc, char** argv, CompileContext& cc) {
 
 cleanup:
     if (!ok && cc.reports()->NumErrorMessages() == 0)
-        error(423);
+        report(423);
 
     unsigned int errnum = cc.reports()->NumErrorMessages();
     unsigned int warnnum = cc.reports()->NumWarnMessages();

--- a/compiler/main.cpp
+++ b/compiler/main.cpp
@@ -132,7 +132,7 @@ int RunCompiler(int argc, char** argv, CompileContext& cc) {
 
     assert(options->source_files.size() == 1);
     {
-        auto sf = cc.sources()->Open(options->source_files[0], {});
+        auto sf = cc.sources()->Open(options->source_files[0]);
         if (!sf) {
             report(417) << options->source_files[0];
             goto cleanup;

--- a/compiler/name-resolution.cpp
+++ b/compiler/name-resolution.cpp
@@ -514,8 +514,7 @@ bool VarDeclBase::Bind(SemaContext& sc) {
         sym_->usage |= uREAD;
     }
 
-    sym_->fnumber = pos_.file;
-    sym_->lnumber = pos_.line;
+    sym_->pos = pos_;
 
     if (def_ok)
         DefineSymbol(sc, sym_);
@@ -855,8 +854,7 @@ FunctionDecl::Bind(SemaContext& outer_sc)
 
     // But position info belongs to the implementation.
     if (!sym_->function()->forward || is_public_) {
-        sym_->fnumber = pos_.file;
-        sym_->lnumber = pos_.line;
+        sym_->pos = pos_;
     }
 
     // Ensure |this| argument exists.

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -1955,6 +1955,7 @@ Parser::parse_methodmap()
                 ok = false;
         } else {
             error(124);
+            ok = false;
         }
         if (!ok) {
             if (!consume_line())

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -376,7 +376,7 @@ Parser::parse_enum(int vclass)
         error(228);
         if (lexer_->match(taADD)) {
             if (lexer_->need(tNUMBER)) {
-                if (lexer_->current_token()->value != 1)
+                if (lexer_->current_token()->value() != 1)
                     report(404);
             }
         } else if (lexer_->match(taMULT)) {
@@ -384,7 +384,7 @@ Parser::parse_enum(int vclass)
                 report(404);
         } else if (lexer_->match(taSHL)) {
             if (lexer_->need(tNUMBER)) {
-                if (lexer_->current_token()->value != 1)
+                if (lexer_->current_token()->value() != 1)
                     report(404);
                 multiplier = 2;
             }
@@ -1057,9 +1057,9 @@ Parser::constant()
             return new NullExpr(pos);
         case tCHAR_LITERAL:
         case tNUMBER:
-            return new NumberExpr(pos, lexer_->current_token()->value);
+            return new NumberExpr(pos, lexer_->current_token()->value());
         case tRATIONAL:
-            return new FloatExpr(cc_, pos, lexer_->current_token()->value);
+            return new FloatExpr(cc_, pos, lexer_->current_token()->value());
         case tSTRING: {
             const auto& atom = lexer_->current_token()->atom;
             return new StringExpr(pos, atom);
@@ -1183,10 +1183,10 @@ Parser::struct_init()
             }
             case tCHAR_LITERAL:
             case tNUMBER:
-                expr = new NumberExpr(pos, lexer_->current_token()->value);
+                expr = new NumberExpr(pos, lexer_->current_token()->value());
                 break;
             case tRATIONAL:
-                expr = new FloatExpr(cc_, pos, lexer_->current_token()->value);
+                expr = new FloatExpr(cc_, pos, lexer_->current_token()->value());
                 break;
             case tSYMBOL:
                 expr = new SymbolExpr(pos, lexer_->current_token()->atom);

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -251,7 +251,7 @@ bool Semantics::CheckPstructArg(VarDeclBase* decl, const pstruct_t* ps,
 
     if (auto expr = field->value->as<StringExpr>()) {
         if (arg->type.ident != iREFARRAY) {
-            error(expr->pos(), 48);
+            report(expr->pos(), 48);
             return false;
         }
         if (arg->type.tag() != types_->tag_string())
@@ -259,7 +259,7 @@ bool Semantics::CheckPstructArg(VarDeclBase* decl, const pstruct_t* ps,
                                      << type_to_name(arg->type.tag());
     } else if (auto expr = field->value->as<TaggedValueExpr>()) {
         if (arg->type.ident != iVARIABLE) {
-            error(expr->pos(), 23);
+            report(expr->pos(), 23);
             return false;
         }
 
@@ -275,21 +275,21 @@ bool Semantics::CheckPstructArg(VarDeclBase* decl, const pstruct_t* ps,
         auto sym = expr->sym();
         if (arg->type.ident == iVARIABLE) {
             if (sym->ident != iVARIABLE) {
-                error(expr->pos(), 405);
+                report(expr->pos(), 405);
                 return false;
             }
             matchtag(arg->type.tag(), sym->tag, MATCHTAG_COERCE);
         } else if (arg->type.ident == iREFARRAY) {
             if (sym->ident != iARRAY) {
-                error(expr->pos(), 405);
+                report(expr->pos(), 405);
                 return false;
             }
             if (sym->dim_count() != 1) {
-                error(expr->pos(), 405);
+                report(expr->pos(), 405);
                 return false;
             }
         } else {
-            error(expr->pos(), 405);
+            report(expr->pos(), 405);
             return false;
         }
     } else {
@@ -971,11 +971,11 @@ BinaryExpr::FoldToConstant()
         case '/':
         case '%':
             if (!right_val) {
-                error(pos_, 93);
+                report(pos_, 93);
                 return false;
             }
             if (left_val == cell(0x80000000) && right_val == -1) {
-                error(pos_, 97);
+                report(pos_, 97);
                 return false;
             }
             if (token_ == '/')
@@ -3281,12 +3281,12 @@ void Semantics::CheckVoidDecl(const typeinfo_t* type, int variable) {
         return;
 
     if (variable) {
-        error(144);
+        report(144);
         return;
     }
 
     if (type->numdim() > 0) {
-        error(145);
+        report(145);
         return;
     }
 }

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -727,7 +727,7 @@ bool Semantics::CheckBinaryExpr(BinaryExpr* expr) {
 
             // Update the line number as a hack so we can warn that it was never
             // used.
-            sym->lnumber = expr->pos().line;
+            sym->pos = expr->pos();
         } else if (auto* accessor = left->val().accessor()) {
             if (!accessor->setter) {
                 report(expr, 152) << accessor->name;

--- a/compiler/source-file.cpp
+++ b/compiler/source-file.cpp
@@ -29,6 +29,8 @@
 # include <unistd.h>
 #endif
 
+namespace sp {
+
 SourceFile::SourceFile()
   : pos_(0)
 {
@@ -116,3 +118,5 @@ SourceFile::Eof()
 {
     return pos_ == data_.size();
 }
+
+} // namespace sp

--- a/compiler/source-file.h
+++ b/compiler/source-file.h
@@ -27,7 +27,9 @@
 #include <amtl/am-maybe.h>
 #include "stl/stl-string.h"
 
-class SourceFile
+namespace sp {
+
+class SourceFile : public std::enable_shared_from_this<SourceFile>
 {
     friend class SourceManager;
 
@@ -55,12 +57,12 @@ class SourceFile
         return reinterpret_cast<const unsigned char*>(data_.data());
     }
 
+    std::shared_ptr<SourceFile> to_shared() { return shared_from_this(); }
+
   private:
     bool Open(const std::string& file_name);
 
     void set_sources_index(uint32_t sources_index) { sources_index_ = ke::Some(sources_index); }
-    uint32_t location_index() const { return location_index_.get(); }
-    void set_location_index(uint32_t location_index) { location_index_ = ke::Some(location_index); }
 
   private:
     std::string name_;
@@ -68,5 +70,6 @@ class SourceFile
     size_t pos_;
     bool is_main_file_ = false;
     ke::Maybe<uint32_t> sources_index_;
-    ke::Maybe<uint32_t> location_index_;
 };
+
+} // namespace sp

--- a/compiler/source-location.h
+++ b/compiler/source-location.h
@@ -19,6 +19,10 @@
 
 #include <stdint.h>
 
+namespace sp {
+
+class SourceManager;
+
 // An encoded referece to a location in a source file. We keep this structure
 // as small as feasible since our average script can have hundreds of thousands
 // of source locations.
@@ -27,7 +31,7 @@ class SourceLocation
   friend class MacroLexer;
   friend class SourceFile;
   friend class SourceManager;
-  friend struct LREntry;
+  friend struct LocationRange;
   friend struct Macro;
 
   static const uint32_t kInMacro = 0x80000000;
@@ -49,8 +53,9 @@ class SourceLocation
    : id_(0)
   {
   }
+  SourceLocation(const SourceLocation&) = default;
 
-  bool IsSet() const {
+  bool valid() const {
     return id_ != 0;
   }
   bool operator ==(const SourceLocation& other) {
@@ -76,3 +81,5 @@ class SourceLocation
  private:
   uint32_t id_;
 };
+
+} // namespace sp

--- a/compiler/source-location.h
+++ b/compiler/source-location.h
@@ -76,16 +76,3 @@ class SourceLocation
  private:
   uint32_t id_;
 };
-
-struct SourceRange
-{
-  SourceLocation start;
-  SourceLocation end;
-
-  SourceRange()
-  {}
-  SourceRange(const SourceLocation& start, const SourceLocation& end)
-   : start(start),
-     end(end)
-  {}
-};

--- a/compiler/source-manager.cpp
+++ b/compiler/source-manager.cpp
@@ -31,7 +31,7 @@ std::shared_ptr<SourceFile> SourceManager::Open(const std::string& path,
 {
     auto file = std::make_shared<SourceFile>();
     if (!file->Open(path))
-	      return nullptr;
+        return nullptr;
 
     size_t loc_index;
     if (!TrackExtents(file->size(), &loc_index)) {

--- a/compiler/source-manager.h
+++ b/compiler/source-manager.h
@@ -31,7 +31,6 @@ class CompileContext;
 struct token_pos_t {
     int file = 0;
     int line = 0;
-    int col = 0;
 };
 
 // An LREntry is created each time we register a range of locations (it is

--- a/compiler/source-manager.h
+++ b/compiler/source-manager.h
@@ -27,7 +27,12 @@
 #include "source-location.h"
 
 class CompileContext;
-struct token_pos_t;
+
+struct token_pos_t {
+    int file = 0;
+    int line = 0;
+    int col = 0;
+};
 
 // An LREntry is created each time we register a range of locations (it is
 // short for LocationRangeEntry). For a file, an LREntry covers each character

--- a/compiler/source-manager.h
+++ b/compiler/source-manager.h
@@ -29,7 +29,7 @@
 class CompileContext;
 
 struct token_pos_t {
-    int file = 0;
+    int file_ = 0;
     int line = 0;
 };
 
@@ -105,6 +105,14 @@ class SourceManager final
     std::shared_ptr<SourceFile> Open(const std::string& path, const token_pos_t& from);
 
     LREntry GetLocationRangeEntryForFile(const std::shared_ptr<SourceFile>& file);
+
+    // For a given token location, retrieve the nearest source file index it maps to.
+    uint32_t GetSourceFileIndex(const token_pos_t& pos) {
+      return pos.file_;
+    }
+    bool IsSameSourceFile(const token_pos_t& current, const token_pos_t& next) {
+      return current.file_ == next.file_;
+    }
 
     const tr::vector<std::shared_ptr<SourceFile>>& opened_files() const {
       return opened_files_;

--- a/compiler/source-manager.h
+++ b/compiler/source-manager.h
@@ -45,56 +45,56 @@ struct token_pos_t {
 // trackFile() or trackMacro().
 struct LREntry
 {
-  // Starting id for this source range.
-  uint32_t id;
+    // Starting id for this source range.
+    uint32_t id;
 
  private:
-  // If we're creating a range from an #include, this is the location in the
-  // parent file we were #included from, if any.
-  //
-  // If we're creating a range for macro insertion, this is where we started
-  // inserting tokens.
-  SourceLocation parent_;
+    // If we're creating a range from an #include, this is the location in the
+    // parent file we were #included from, if any.
+    //
+    // If we're creating a range for macro insertion, this is where we started
+    // inserting tokens.
+    SourceLocation parent_;
 
-  // If we included from a file, this is where we included.
-  std::shared_ptr<SourceFile> file_;
+    // If we included from a file, this is where we included.
+    std::shared_ptr<SourceFile> file_;
 
  public:
-  LREntry()
-   : id(0)
-  {}
+    LREntry()
+     : id(0)
+    {}
 
-  bool valid() const {
-    return id != 0;
-  }
+    bool valid() const {
+        return id != 0;
+    }
 
-  void init(const SourceLocation& parent, std::shared_ptr<SourceFile> file) {
-    this->parent_ = parent;
-    this->file_ = std::move(file);
-  }
+    void init(const SourceLocation& parent, std::shared_ptr<SourceFile> file) {
+        this->parent_ = parent;
+        this->file_ = std::move(file);
+    }
 
-  std::shared_ptr<SourceFile> file() const {
-    return file_;
-  }
-  const SourceLocation& parent() const {
-    return parent_;
-  }
+    std::shared_ptr<SourceFile> file() const {
+        return file_;
+    }
+    const SourceLocation& parent() const {
+        return parent_;
+    }
 
-  uint32_t length() const {
-    return file_->size();
-  }
+    uint32_t length() const {
+        return file_->size();
+    }
 
-  bool owns(const SourceLocation& loc) const {
-    if (loc.offset() >= id && loc.offset() <= id + length())
-      return true;
-    return false;
-  }
+    bool owns(const SourceLocation& loc) const {
+        if (loc.offset() >= id && loc.offset() <= id + length())
+            return true;
+        return false;
+    }
 
-  SourceLocation FilePos(uint32_t offset) const {
-    assert(file_);
-    assert(offset <= file_->size());
-    return SourceLocation::FromFile(id, offset);
-  }
+    SourceLocation FilePos(uint32_t offset) const {
+        assert(file_);
+        assert(offset <= file_->size());
+        return SourceLocation::FromFile(id, offset);
+    }
 };
 
 class SourceManager final

--- a/compiler/symbols.cpp
+++ b/compiler/symbols.cpp
@@ -127,9 +127,6 @@ symbol::symbol(sp::Atom* symname, cell symaddr, IdentifierKind symident, int sym
    explicit_return_type(false),
    semantic_tag(0),
    dim_data(nullptr),
-   fnumber(0),
-   /* assume global visibility (ignored for local symbols) */
-   lnumber(0),
    documentation(nullptr),
    addr_(symaddr),
    name_(nullptr)
@@ -359,8 +356,7 @@ static symbol*
 NewConstant(sp::Atom* name, const token_pos_t& pos, cell val, int vclass, int tag)
 {
     auto sym = new symbol(name, val, iCONSTEXPR, vclass, tag);
-    sym->fnumber = pos.file;
-    sym->lnumber = pos.line;
+    sym->pos = pos;
     sym->defined = true;
     return sym;
 }

--- a/compiler/symbols.h
+++ b/compiler/symbols.h
@@ -27,6 +27,7 @@
 #include <unordered_map>
 
 #include "label.h"
+#include "lexer.h"
 #include "sc.h"
 #include "stl/stl-unordered-map.h"
 
@@ -153,8 +154,7 @@ struct symbol : public PoolObject
 
     int semantic_tag;
     int* dim_data;     /* -1 = dim count, 0..n = dim sizes */
-    int fnumber; /* file number in which the symbol is declared */
-    int lnumber; /* line number for the declaration */
+    token_pos_t pos;
     PoolString* documentation; /* optional documentation string */
 
     int dim_count() const { return dim_data ? dim_data[-1] : 0; }

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -30,10 +30,9 @@ def main():
   parser.add_argument('--spcomp-arg', default=None, type=str, action='append',
                       dest='spcomp_args',
                       help="Add an extra argument to all spcomp invocations.")
+  parser.add_argument('--filter', default=None, type=str,
+                      help='Filter for tests with a particular name.')
   args = parser.parse_args()
-
-  if args.test and args.test.startswith('tests/'):
-    args.test = args.test[6:]
 
   plan = TestPlan(args)
   plan.find_compilers()
@@ -245,6 +244,8 @@ class TestPlan(object):
           'manifest': manifest,
         })
         if manifest_get(manifest, test.name, 'skip') == 'true':
+          continue
+        if self.args.filter and self.args.filter not in path:
           continue
         self.tests.append(test)
 


### PR DESCRIPTION
This is a big refactoring of how tokens are tracked throughout the compiler.

Rather than carry explicit file and column information on every token, instead we now track a 32-bit encoded location id. This id can be decoded back to a specific file, column, and line. It's much more compact, and it supports correct tracking of macro expanded tokens (which can cross file boundaries). It can also track the complete #include lineage of a token.

Gradually, the error reporter and AST will migrate to the new location id. The lexer still needs token_pos_t, which tracks the decoded line number. Decoding line numbers from a location id is very expensive, and the hottest function in the lexer is peek_same_line() which relies on this information.

The motivation for this is twofold. First, it makes tokens and the AST more compact, which means we can retain more stuff in memory. The AST is enormous due to the size of #includes. And being able to save and replay tokens is an important feature for future work. Reducing the size of each token will reduce peak memory pressure.

The accuracy of location ids will also let us retain a rather weird feature of spcomp: tab/space linting. The way it's implemented now requires tight coupling between the lexer state and parser, which makes it hard to save and replay token streams. Now that location ids can provide indexes into the source text, we can lint no matter what state the lexer is in.

Finally, this paves the way for clang style error messages. Not implemented here, but, you know, it's doable now.

This merge will bump the minimum C++ standard to C++17 and requires std::filesystem support. This also bumps macOS requirements up to 10.15.