### PR TITLE
Add beautiful error messages.

### DIFF
--- a/compiler/errors.h
+++ b/compiler/errors.h
@@ -42,10 +42,12 @@ enum class ErrorType {
 };
 
 struct ErrorReport {
+    sp::SourceLocation loc;
     int number;
-    int fileno;
-    int lineno;
-    std::string filename;
+    uint32_t fileno;
+    uint32_t lineno;
+    uint32_t col;
+    std::shared_ptr<sp::SourceFile> file;
     std::string message;
     ErrorType type;
 };

--- a/compiler/name-resolution.cpp
+++ b/compiler/name-resolution.cpp
@@ -514,7 +514,7 @@ bool VarDeclBase::Bind(SemaContext& sc) {
         sym_->usage |= uREAD;
     }
 
-    sym_->pos = pos_;
+    sym_->loc = pos_;
 
     if (def_ok)
         DefineSymbol(sc, sym_);
@@ -854,7 +854,7 @@ FunctionDecl::Bind(SemaContext& outer_sc)
 
     // But position info belongs to the implementation.
     if (!sym_->function()->forward || is_public_) {
-        sym_->pos = pos_;
+        sym_->loc = pos_;
     }
 
     // Ensure |this| argument exists.

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -727,7 +727,7 @@ bool Semantics::CheckBinaryExpr(BinaryExpr* expr) {
 
             // Update the line number as a hack so we can warn that it was never
             // used.
-            sym->pos = expr->pos();
+            sym->loc = expr->pos();
         } else if (auto* accessor = left->val().accessor()) {
             if (!accessor->setter) {
                 report(expr, 152) << accessor->name;

--- a/compiler/source-file.cpp
+++ b/compiler/source-file.cpp
@@ -99,24 +99,83 @@ SourceFile::Read(unsigned char* target, int maxchars)
     return true;
 }
 
-int64_t
-SourceFile::Pos()
-{
+int64_t SourceFile::Pos() {
     return pos_;
 }
 
-void
-SourceFile::Reset(int64_t pos)
-{
+void SourceFile::Reset(int64_t pos) {
     assert(pos >= 0);
     assert((size_t)pos <= data_.size());
     pos_ = (size_t)pos;
 }
 
-int
-SourceFile::Eof()
-{
+int SourceFile::Eof() {
     return pos_ == data_.size();
+}
+
+void SourceFile::ComputeLineExtents() {
+    if (!line_extents_.empty())
+        return;
+
+    line_extents_.emplace_back(0);
+    for (uint32_t i = 0; i < data_.size(); i++) {
+        if (data_[i] != '\r' && data_[i] != '\n')
+            continue;
+        if (data_[i] == '\r') {
+            // Detect \r\n.
+            if (i + 1 < data_.size() && data_[i + 1] == '\n')
+                i++;
+        }
+        line_extents_.emplace_back(i + 1);
+    }
+
+    line_extents_.shrink_to_fit();
+}
+
+bool SourceFile::OffsetToLineAndCol(uint32_t offset, uint32_t* line, uint32_t* col) {
+    if (offset > data_.size())
+        return false;
+
+    ComputeLineExtents();
+
+    if (offset == data_.size()) {
+        *line = line_extents_.size();
+        if (col)
+            *col = 0;
+        return true;
+    }
+
+    uint32_t lower = 0;
+    uint32_t upper = line_extents_.size();
+    while (lower < upper) {
+        uint32_t index = (lower + upper) / 2;
+        uint32_t line_start = line_extents_[index];
+        if (offset < line_start) {
+            upper = index;
+            continue;
+        }
+
+        // The range should be (start, end].
+        uint32_t line_end = (index < line_extents_.size() - 1)
+                            ? line_extents_[index + 1]
+                            : data_.size();
+        if (offset >= line_end) {
+            lower = index + 1;
+            continue;
+        }
+
+        // Either the offset is the first character of a line, or before the
+        // first character of the next line, or it should be the terminal
+        // offset.
+        assert(offset >= line_start && offset < line_end);
+        *line = index + 1;
+        if (col)
+            *col = offset - line_start + 1;
+        return true;
+    }
+
+    assert(false);
+    return false;
 }
 
 } // namespace sp

--- a/compiler/source-file.h
+++ b/compiler/source-file.h
@@ -61,6 +61,8 @@ class SourceFile : public std::enable_shared_from_this<SourceFile>
     std::shared_ptr<SourceFile> to_shared() { return shared_from_this(); }
 
     bool OffsetToLineAndCol(uint32_t offset, uint32_t* line, uint32_t* col = nullptr);
+    bool OffsetOfLine(uint32_t line, uint32_t* offset);
+    tr::string GetLine(uint32_t line);
 
   private:
     bool Open(const std::string& file_name);

--- a/compiler/source-file.h
+++ b/compiler/source-file.h
@@ -26,6 +26,7 @@
 
 #include <amtl/am-maybe.h>
 #include "stl/stl-string.h"
+#include "stl/stl-vector.h"
 
 namespace sp {
 
@@ -59,8 +60,11 @@ class SourceFile : public std::enable_shared_from_this<SourceFile>
 
     std::shared_ptr<SourceFile> to_shared() { return shared_from_this(); }
 
+    bool OffsetToLineAndCol(uint32_t offset, uint32_t* line, uint32_t* col = nullptr);
+
   private:
     bool Open(const std::string& file_name);
+    void ComputeLineExtents();
 
     void set_sources_index(uint32_t sources_index) { sources_index_ = ke::Some(sources_index); }
 
@@ -70,6 +74,7 @@ class SourceFile : public std::enable_shared_from_this<SourceFile>
     size_t pos_;
     bool is_main_file_ = false;
     ke::Maybe<uint32_t> sources_index_;
+    tr::vector<uint32_t> line_extents_;
 };
 
 } // namespace sp

--- a/compiler/source-manager.h
+++ b/compiler/source-manager.h
@@ -136,6 +136,11 @@ struct LocationRange
         return SourceLocation::FromMacro(id, offset);
     }
 
+    uint32_t ToOffset(SourceLocation loc) {
+        assert(owns(loc));
+        return loc.offset() - id;
+    }
+
     bool operator ==(const LocationRange& other) const {
         return id == other.id;
     }
@@ -157,6 +162,11 @@ class SourceManager final
     // For a given token location, retrieve the nearest source file index it maps to.
     uint32_t GetSourceFileIndex(const SourceLocation& loc);
 
+    // Return the closest line and column number for a given location. If the
+    // location is a macro expansion, the expansion location is used. If the
+    // location is invalid, 0 is returned.
+    uint32_t GetLineAndCol(SourceLocation loc, uint32_t* col);
+
     // Checks whether two tokens are in the same file. Runtime is O(log n) for
     // n = # of files opened.
     bool IsSameSourceFile(const SourceLocation& a, const SourceLocation& b);
@@ -175,6 +185,7 @@ class SourceManager final
   private:
     bool TrackExtents(uint32_t length, size_t* index);
     size_t FindLocRangeSlow(const SourceLocation& loc);
+    size_t FindSourceFileRangeIndex(SourceLocation loc, SourceLocation* expansion_loc);
 
   private:
     CompileContext& cc_;

--- a/compiler/symbols.cpp
+++ b/compiler/symbols.cpp
@@ -356,7 +356,7 @@ static symbol*
 NewConstant(sp::Atom* name, const token_pos_t& pos, cell val, int vclass, int tag)
 {
     auto sym = new symbol(name, val, iCONSTEXPR, vclass, tag);
-    sym->pos = pos;
+    sym->loc = pos;
     sym->defined = true;
     return sym;
 }

--- a/compiler/symbols.h
+++ b/compiler/symbols.h
@@ -29,6 +29,7 @@
 #include "label.h"
 #include "lexer.h"
 #include "sc.h"
+#include "source-location.h"
 #include "stl/stl-unordered-map.h"
 
 class CompileContext;
@@ -154,7 +155,7 @@ struct symbol : public PoolObject
 
     int semantic_tag;
     int* dim_data;     /* -1 = dim count, 0..n = dim sizes */
-    token_pos_t pos;
+    sp::SourceLocation loc;
     PoolString* documentation; /* optional documentation string */
 
     int dim_count() const { return dim_data ? dim_data[-1] : 0; }


### PR DESCRIPTION
This is easy now that we have proper location encoding.

The current formatting is debatable, but it's a start.
 Example:

    test.sp(3) : error 017: undefined symbol "ham"
         3 |     int hello = ham;
    -------------------------^

    test.sp(4) : error 017: undefined symbol "hhello"
         4 |     return hhello
    --------------------^