### PR TITLE
Remove the indentation warning. 

### DIFF
--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -782,9 +782,6 @@ bool Lexer::FindNextToken() {
         auto work_line = line_start();
         bool is_line_start = (work_line == work_start) && !IsInMacro();
 
-        if (is_line_start)
-            stmtindent_ = 0;
-
         // Skip whitespace.
         while (true) {
             char c = peek();
@@ -793,16 +790,6 @@ bool Lexer::FindNextToken() {
 
             if (c == '\r' || c == '\n')
                 break;
-
-            if (is_line_start) {
-                int indent = 1;
-                if (c == '\t') {
-                    int tabsize = cc_.options()->tabsize;
-                    if (tabsize != 0)
-                        indent = (int)(tabsize - (stmtindent_ + tabsize) % tabsize);
-                }
-                stmtindent_ += indent;
-            }
 
             advance();
         }

--- a/compiler/lexer.h
+++ b/compiler/lexer.h
@@ -318,8 +318,6 @@ class Lexer
     std::string& deprecate() { return deprecate_; }
     bool& allow_tags() { return allow_tags_; }
     int& require_newdecls() { return state_.require_newdecls; }
-    int& stmtindent() { return stmtindent_; }
-    bool& indent_nowarn() { return indent_nowarn_; }
     bool freading() const { return freading_; }
     int fcurrent() const { return state_.inpf->sources_index(); }
     unsigned fline() const { return state_.fline; }
@@ -440,8 +438,6 @@ class Lexer
     size_t skiplevel_; /* level at which we started skipping (including nested #if .. #endif) */
     std::string deprecate_;
     bool allow_tags_ = true;
-    int stmtindent_ = 0;
-    bool indent_nowarn_ = false;
     bool freading_ = false;
     int ctrlchar_ = CTRL_CHAR;
     unsigned int tokens_on_line_ = 0;

--- a/compiler/main.cpp
+++ b/compiler/main.cpp
@@ -153,7 +153,8 @@ int RunCompiler(int argc, char** argv, CompileContext& cc) {
     inst_binary_name(cc, cc.outfname().c_str());
 
     {
-        Parser parser(cc);
+        Semantics sema(cc);
+        Parser parser(cc, &sema);
 
         AutoCountErrors errors;
         tree = parser.Parse();      /* process all input */
@@ -162,7 +163,6 @@ int RunCompiler(int argc, char** argv, CompileContext& cc) {
 
         errors.Reset();
 
-        Semantics sema(cc, tree);
         {
             SemaContext sc(&sema);
             sema.set_context(&sc);
@@ -177,7 +177,7 @@ int RunCompiler(int argc, char** argv, CompileContext& cc) {
             sema.set_context(nullptr);
 
             errors.Reset();
-            if (!sema.Analyze() || !errors.ok())
+            if (!sema.Analyze(tree) || !errors.ok())
                 goto cleanup;
 
             tree->stmts()->ProcessUses(sc);

--- a/compiler/messages.h
+++ b/compiler/messages.h
@@ -242,7 +242,7 @@ static const char* warnmsg[] = {
     /*214*/ "possibly a \"const\" array argument was intended: \"%s\"\n",
     /*215*/ "expression has no effect\n",
     /*216*/ "nested comment\n",
-    /*217*/ "inconsistent indentation (did you mix tabs and spaces?)\n",
+    /*217*/ "unused217\n",
     /*218*/ "old style prototypes used with optional semicolumns\n",
     /*219*/ "local variable \"%s\" shadows a variable at a preceding level\n",
     /*220*/ "expression with tag override must appear between parentheses\n",

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -38,8 +38,9 @@
 
 using namespace sp;
 
-Parser::Parser(CompileContext& cc)
+Parser::Parser(CompileContext& cc, Semantics* sema)
   : cc_(cc),
+    sema_(sema),
     lexer_(cc.lexer())
 {
     types_ = cc_.types();
@@ -300,12 +301,12 @@ bool
 Parser::PreprocExpr(cell* val, int* tag)
 {
     auto& cc = CompileContext::get();
-    Parser parser(cc);
+
+    Semantics sema(cc);
+    Parser parser(cc, &sema);
     auto expr = parser.hier14();
     if (!expr)
         return false;
-
-    Semantics sema(cc, nullptr);
 
     SemaContext sc(&sema);
     sc.set_preprocessing();

--- a/compiler/parser.h
+++ b/compiler/parser.h
@@ -48,7 +48,7 @@ class Parser
     Stmt* parse_unknown_decl(const full_token_t* tok);
     Decl* parse_enum(int vclass);
     Stmt* parse_const(int vclass);
-    Stmt* parse_stmt(int* lastindent, bool allow_decl);
+    Stmt* parse_stmt(bool allow_decl);
     Stmt* parse_static_assert();
     Decl* parse_pstruct();
     Decl* parse_typedef();
@@ -86,7 +86,7 @@ class Parser
     void rewrite_type_for_enum_struct(typeinfo_t* info);
     int operatorname(sp::Atom** name);
 
-    Stmt* parse_compound(bool sameline);
+    Stmt* parse_compound();
     Stmt* parse_local_decl(int tokid, bool autozero);
     Stmt* parse_if();
     Stmt* parse_for();

--- a/compiler/parser.h
+++ b/compiler/parser.h
@@ -26,10 +26,12 @@
 #include "sc.h"
 #include "sctracker.h"
 
+class Semantics;
+
 class Parser
 {
   public:
-    explicit Parser(CompileContext& cc);
+    Parser(CompileContext& cc, Semantics* sema);
     ~Parser();
 
     static bool PreprocExpr(cell* val, int* tag);
@@ -128,6 +130,7 @@ class Parser
 
   private:
     CompileContext& cc_;
+    Semantics* sema_;
     bool in_loop_ = false;
     bool in_test_ = false;
     std::vector<SymbolScope*> static_scopes_;

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -33,19 +33,18 @@
 #include "sctracker.h"
 #include "symbols.h"
 
-Semantics::Semantics(CompileContext& cc, ParseTree* tree)
-  : cc_(cc),
-    tree_(tree)
+Semantics::Semantics(CompileContext& cc)
+  : cc_(cc)
 {
     types_ = cc.types();
 }
 
-bool Semantics::Analyze() {
+bool Semantics::Analyze(ParseTree* tree) {
     SemaContext sc(this);
     ke::SaveAndSet<SemaContext*> push_sc(&sc_, &sc);
 
     AutoCountErrors errors;
-    if (!CheckStmtList(tree_->stmts()) || !errors.ok())
+    if (!CheckStmtList(tree->stmts()) || !errors.ok())
         return false;
 
     // This inserts missing return statements at the global scope, so it cannot

--- a/compiler/semantics.h
+++ b/compiler/semantics.h
@@ -147,9 +147,9 @@ class Semantics final
     friend class Parser;
 
   public:
-    Semantics(CompileContext& cc, ParseTree* tree);
+    explicit Semantics(CompileContext& cc);
 
-    bool Analyze();
+    bool Analyze(ParseTree* tree);
 
     CompileContext& cc() { return cc_; }
     SymbolScope* current_scope() const;
@@ -248,7 +248,6 @@ class Semantics final
   private:
     CompileContext& cc_;
     TypeDictionary* types_ = nullptr;
-    ParseTree* tree_;
     tr::unordered_set<SymbolScope*> static_scopes_;
     SemaContext* sc_ = nullptr;
     bool pending_heap_allocation_ = false;

--- a/tests/compile-only/file-reporting/fail-main.txt
+++ b/tests/compile-only/file-reporting/fail-main.txt
@@ -1,3 +1,2 @@
 ignore-otherfile.sp(3) : error 017: undefined symbol "PrintToServer"
-ignore-otherfile.sp(4) : warning 217: inconsistent indentation (did you mix tabs and spaces?)
 ignore-otherfile.sp(4) : error 017: undefined symbol "PrintToServer"


### PR DESCRIPTION
In the early days of AMX Mod X/SourceMod there weren't really good
source editors. Many people used Notepad for their scripting. Mixing
tabs/spaces and getting indents wrong was very common.

These days there are a few factors that make this less critical:
  - There are many high quality editors available, and there is much
    more awareness around them.
 - The industry has basically settled on spaces for indentation.
 - Modern programming languages tend to come with auto-formatting tools now as
   well, which is probably something SourcePawn should do.

Either way, the inline linter is a huge, huge hack and has no business
being right there in the lexer. It makes token caching very complex.
It's slow. And it requires knowing a predefined value for tabsizes,
which makes no sense.

So awaaaay it goes.