### PR TITLE
Require braces for global function bodies.

### DIFF
--- a/compiler/messages.h
+++ b/compiler/messages.h
@@ -318,4 +318,5 @@ static const char* errmsg_ex[] = {
     /*434*/ "constructor cannot have a return type\n",
     /*435*/ "can't get current working directory\n",
     /*436*/ "wrong number of dimensions, expected %d got %d\n",
+    /*437*/ "functions in global scope must use braces\n",
 };

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -1808,10 +1808,8 @@ Parser::parse_function(FunctionDecl* fun, int tokid, bool has_this)
             break;
     }
 
-    if (lexer_->match('{'))
-        lexer_->lexpush();
-    else if (fun->decl().type.is_new)
-        lexer_->need('{');
+    if (!lexer_->peek('{'))
+        report(437);
 
     Stmt* body = parse_stmt(false);
     if (!body)

--- a/tests/compile-only/fail-method-requires-brace.txt
+++ b/tests/compile-only/fail-method-requires-brace.txt
@@ -1,1 +1,1 @@
-expected token: "{", but found "return"
+(2) : error 437: functions in global scope must use braces


### PR DESCRIPTION
This is not a change I wanted to make, but I think it is necessary. Unfortunately it breaks over 250 legacy, pre-transitional syntax plugins in the corpus, that are going to be removed. That shrinks the corpus by 1.6%.

The reason is quite complex.

SourcePawn has an AST problem: the parsing AST is not distinct from the semantic AST, which means the semantics phase has no choice but to apply annotations to the AST to add type information. That is very inflexible, and I am not sure how to solve issue #844, because it requires rebuilding the AST recursively.

Compiler projects that have infinite resources (in every sense of the word) can just keep generating new ASTs. For example, Rosyln does this (it separates grammar AST from binding AST, etc). That's quite nice. However it's expensive, and requires a ton of boilerplate that I'm not prepared to do. ASTs are always very heavy on boilerplate.

The other way to go about this is to merge parsing and semantics into a single pass. Clang does this. SourcePawn is way less complex than C++, so it seems like a viable route.

How does that relate to function bracing, though?

Well, the problem is that SourcePawn doesn't need forward declarations. You can call a function that is not defined until later in the file. If we're doing semantic checks during parsing, we won't have the full definition of the function available in time.

The obvious way to resolve this is to skip all function bodies in the global scope, so we have a chance to build function signatures first. Then we can re-parse each function body. It's easy in the new lexer because we can save token streams.

However, without braces, it's very non-trivial to determine the bounds of a function body. We *have* to actually parse to see where statements end. The complexity of that is pretty high and the value seems low.

So, I'm going to make this change. If there is too much complaining it's easy to revert, and we can probably find some other solution when the time comes.