### PR TITLE
Delay function body parsing.

### DIFF
--- a/compiler/parse-node.h
+++ b/compiler/parse-node.h
@@ -1566,6 +1566,9 @@ class FunctionDecl : public Decl
     Stmt* body() const { return body_; }
     void set_body(Stmt* body) { body_ = body; }
 
+    TokenCache* tokens() const { return tokens_; }
+    void set_tokens(TokenCache* tokens) { tokens_ = tokens; }
+
     void set_name(sp::Atom* name) { name_ = name; }
 
     // The undecorated name.
@@ -1631,6 +1634,7 @@ class FunctionDecl : public Decl
     ke::Maybe<int> this_tag_;
     sp::Atom* alias_ = nullptr;
     PoolString* deprecate_ = nullptr;
+    TokenCache* tokens_ = nullptr;
     bool analyzed_ SP_BITFIELD(1);
     bool analyze_result_ SP_BITFIELD(1);
     bool is_public_ SP_BITFIELD(1);

--- a/compiler/parser.h
+++ b/compiler/parser.h
@@ -136,4 +136,5 @@ class Parser
     std::vector<SymbolScope*> static_scopes_;
     std::shared_ptr<Lexer> lexer_;
     TypeDictionary* types_ = nullptr;
+    std::deque<FunctionDecl*> delayed_functions_;
 };


### PR DESCRIPTION
This patch skips parsing function bodies, instead caching tokens and attaching the token stream to the AST. After the AST is built, functions are parsed using cached tokens. This is fairly easy to do thanks to the recent Lexer/SourceManager refactoring.

This is a critical step toward collapsing the binding and semantic passes together, without re-introducing a dreaded reparse phase.

A quick estimate shows that memory use on this is pretty small. For funcommands.sp (the biggest plugin in the test suite), it's about 200KB. This is again thanks to the recent refactoring. Tokens are now 24 bytes instead of 96 bytes.

Duplicating the AST would use about 3MB since the AST is so unoptimized, and culling that down is a big project.