### PR TITLE
Put the compiler in the sp namespace.

### DIFF
--- a/compiler/AMBuilder
+++ b/compiler/AMBuilder
@@ -21,6 +21,7 @@ module.sources += [
   'sci18n.cpp',
   'sctracker.cpp',
   'semantics.cpp',
+  'scopes.cpp',
   'source-file.cpp',
   'source-manager.cpp',
   'symbols.cpp',

--- a/compiler/array-data.h
+++ b/compiler/array-data.h
@@ -1,7 +1,6 @@
 // vim: set ts=8 sts=4 sw=4 tw=99 et:
-//  Pawn compiler - Recursive descend expresion parser
 //
-//  Copyright (c) ITB CompuPhase, 1997-2005
+//  Copyright (c) 2023 AlliedModders LLC
 //
 //  This software is provided "as-is", without any express or implied warranty.
 //  In no event will the authors be held liable for any damages arising from
@@ -25,6 +24,8 @@
 #include <sp_vm_types.h>
 #include "stl/stl-vector.h"
 
+namespace sp {
+
 struct ArrayData {
     tr::vector<cell_t> iv;
     tr::vector<cell_t> data;
@@ -39,3 +40,5 @@ struct DefaultArrayData : public ArrayData {
     cell_t iv_size;
     cell_t data_size;
 };
+
+} // namespace sp

--- a/compiler/array-helpers.cpp
+++ b/compiler/array-helpers.cpp
@@ -30,6 +30,8 @@
 #include "symbols.h"
 #include "type-checker.h"
 
+namespace sp {
+
 class ArraySizeResolver
 {
   public:
@@ -1091,3 +1093,5 @@ BuildArrayInitializer(VarDeclBase* decl, ArrayData* array, cell base_address)
     for (auto& v : array->iv)
         v += base_address;
 }
+
+} // namespace sp

--- a/compiler/array-helpers.h
+++ b/compiler/array-helpers.h
@@ -23,6 +23,8 @@
 #include "array-data.h"
 #include "parse-node.h"
 
+namespace sp {
+
 class Semantics;
 
 // Determine the static size of an iARRAY based on dimension expressions and
@@ -38,3 +40,5 @@ void BuildArrayInitializer(VarDeclBase* decl, ArrayData* array, cell_t base_addr
 void BuildArrayInitializer(const typeinfo_t& type, Expr* init, ArrayData* array);
 
 cell_t CalcArraySize(symbol* sym);
+
+} // namespace sp

--- a/compiler/assembler.cpp
+++ b/compiler/assembler.cpp
@@ -44,13 +44,15 @@
 #include "errors.h"
 #include "lexer.h"
 #include "sc.h"
+#include "scopes.h"
 #include "sctracker.h"
 #include "symbols.h"
 #include "types.h"
 
 using namespace SourcePawn;
 using namespace ke;
-using namespace sp;
+
+namespace sp {
 
 static int
 sort_by_name(const void* a1, const void* a2)
@@ -1037,3 +1039,5 @@ assemble(CompileContext& cc, CodeGenerator& cg, const char* binfname, int compre
 
     return splat_to_binary(cc, binfname, buffer.bytes(), buffer.size());
 }
+
+} // namespace sp

--- a/compiler/assembler.h
+++ b/compiler/assembler.h
@@ -30,6 +30,8 @@
 #include "shared/byte-buffer.h"
 #include "shared/string-pool.h"
 
+namespace sp {
+
 bool assemble(CompileContext& cc, CodeGenerator& cg, const char* outname,
               int compression_level);
 
@@ -49,3 +51,5 @@ class Assembler
     CompileContext& cc_;
     CodeGenerator& cg_;
 };
+
+} // namespace sp

--- a/compiler/code-generator.h
+++ b/compiler/code-generator.h
@@ -31,6 +31,8 @@
 #include "parse-node.h"
 #include "smx-assembly-buffer.h"
 
+namespace sp {
+
 class CompileContext;
 class ParseTree;
 struct symbol;
@@ -246,3 +248,5 @@ class CodeGenerator final
 
     AutoCountErrors errors_;
 };
+
+} // namespace sp

--- a/compiler/compile-context.cpp
+++ b/compiler/compile-context.cpp
@@ -25,9 +25,12 @@
 
 #include "compile-options.h"
 #include "errors.h"
+#include "scopes.h"
 #include "source-manager.h"
 #include "symbols.h"
 #include "types.h"
+
+namespace sp {
 
 CompileContext* CompileContext::sInstance = nullptr;
 
@@ -40,7 +43,7 @@ CompileContext::CompileContext()
 
     reports_ = std::make_unique<ReportManager>(*this);
     options_ = std::make_unique<CompileOptions>();
-    sources_ = std::make_unique<sp::SourceManager>(*this);
+    sources_ = std::make_unique<SourceManager>(*this);
     types_ = std::make_unique<TypeDictionary>(*this);
     types_->init();
 }
@@ -72,7 +75,7 @@ tr::vector<tr::string>* CompileContext::NewDebugStringList() {
     return &debug_strings_.front();
 }
 
-tr::unordered_map<sp::Atom*, symbol*>* CompileContext::NewSymbolMap() {
+tr::unordered_map<Atom*, symbol*>* CompileContext::NewSymbolMap() {
     symbol_maps_.emplace_front();
     return &symbol_maps_.front();
 }
@@ -100,3 +103,5 @@ void NativeAllocator::Free(void* p, size_t n) {
         cc->TrackFree(n);
     free(p);
 }
+
+} // namespace sp

--- a/compiler/compile-context.h
+++ b/compiler/compile-context.h
@@ -28,10 +28,13 @@
 #include "pool-allocator.h"
 #include "shared/string-pool.h"
 #include "source-file.h"
+#include "source-manager.h"
 #include "stl/stl-forward-list.h"
 #include "stl/stl-unordered-map.h"
 #include "stl/stl-unordered-set.h"
 #include "stl/stl-vector.h"
+
+namespace sp {
 
 class Lexer;
 class ReportManager;
@@ -40,10 +43,6 @@ class SymbolScope;
 class TypeDictionary;
 struct CompileOptions;
 struct symbol;
-
-namespace sp {
-class SourceManager;
-} // namespace sp
 
 // The thread-safe successor to scvars.
 class CompileContext final
@@ -63,23 +62,23 @@ class CompileContext final
     void TrackMalloc(size_t bytes);
     void TrackFree(size_t bytes);
 
-    SymbolScope* globals() const { return globals_; }
+    sp::SymbolScope* globals() const { return globals_; }
     tr::unordered_set<symbol*>& functions() { return functions_; }
     tr::unordered_set<symbol*>& publics() { return publics_; }
     const std::shared_ptr<Lexer>& lexer() const { return lexer_; }
     ReportManager* reports() const { return reports_.get(); }
     CompileOptions* options() const { return options_.get(); }
-    sp::SourceManager* sources() const { return sources_.get(); }
+    SourceManager* sources() const { return sources_.get(); }
     TypeDictionary* types() const { return types_.get(); }
-    sp::StringPool* atoms() { return &atoms_; }
+    StringPool* atoms() { return &atoms_; }
 
-    sp::Atom* atom(const std::string& str) {
+    Atom* atom(const std::string& str) {
         return atoms_.add(str);
     }
-    sp::Atom* atom(const char* str, size_t length) {
+    Atom* atom(const char* str, size_t length) {
         return atoms_.add(str, length);
     }
-    sp::Atom* atom(const char* str) {
+    Atom* atom(const char* str) {
         return atoms_.add(str);
     }
 
@@ -117,7 +116,7 @@ class CompileContext final
     bool& in_preprocessor() { return in_preprocessor_; }
     bool& detected_illegal_preproc_symbols() { return detected_illegal_preproc_symbols_; }
 
-    PoolAllocator& allocator() { return allocator_; }
+    cc::PoolAllocator& allocator() { return allocator_; }
 
     // No copy construction.
     CompileContext(const CompileContext&) = delete;
@@ -127,18 +126,18 @@ class CompileContext final
 
     DefaultArrayData* NewDefaultArrayData();
     tr::vector<tr::string>* NewDebugStringList();
-    tr::unordered_map<sp::Atom*, symbol*>* NewSymbolMap();
+    tr::unordered_map<Atom*, symbol*>* NewSymbolMap();
 
   private:
-    PoolAllocator allocator_;
-    SymbolScope* globals_;
+    cc::PoolAllocator allocator_;
+    sp::SymbolScope* globals_;
     std::string default_include_;
     tr::unordered_set<symbol*> functions_;
     tr::unordered_set<symbol*> publics_;
     std::unique_ptr<CompileOptions> options_;
     std::string outfname_;
     std::string errfname_;
-    std::unique_ptr<sp::SourceManager> sources_;
+    std::unique_ptr<SourceManager> sources_;
     std::shared_ptr<sp::SourceFile> inpf_org_;
     std::unique_ptr<TypeDictionary> types_;
     sp::StringPool atoms_;
@@ -163,7 +162,7 @@ class CompileContext final
     // AST attachments.
     tr::forward_list<DefaultArrayData> default_array_data_objects_;
     tr::forward_list<tr::vector<tr::string>> debug_strings_;
-    tr::forward_list<tr::unordered_map<sp::Atom*, symbol*>> symbol_maps_;
+    tr::forward_list<tr::unordered_map<Atom*, symbol*>> symbol_maps_;
 
     size_t malloc_bytes_ = 0;
     size_t malloc_bytes_peak_ = 0;
@@ -171,3 +170,5 @@ class CompileContext final
     bool in_preprocessor_ = false;
     bool detected_illegal_preproc_symbols_ = false;
 };
+
+} // namespace sp

--- a/compiler/compile-options.h
+++ b/compiler/compile-options.h
@@ -26,6 +26,8 @@
 
 #define CTRL_CHAR '\\'  /* default control character */
 
+namespace sp {
+
 struct CompileOptions {
     bool need_semicolon = false;
     std::vector<std::string> source_files;
@@ -42,3 +44,5 @@ struct CompileOptions {
     int verbosity = 1;             /* verbosity level, 0=quiet, 1=normal, 2=verbose */
     std::vector<std::pair<std::string, std::string>> predefines;
 };
+
+} // namespace sp

--- a/compiler/data-queue.cpp
+++ b/compiler/data-queue.cpp
@@ -41,6 +41,8 @@
 #include "sctracker.h"
 #include "symbols.h"
 
+namespace sp {
+
 DataQueue::DataQueue()
 {
 }
@@ -75,3 +77,5 @@ DataQueue::AddZeroes(cell count)
 {
     buffer_.resize(buffer_.size() + count, 0);
 }
+
+} // namespace sp

--- a/compiler/data-queue.h
+++ b/compiler/data-queue.h
@@ -22,6 +22,8 @@
 #include "sc.h"
 #include "symbols.h"
 
+namespace sp {
+
 class DataQueue final
 {
   public:
@@ -39,3 +41,5 @@ class DataQueue final
   private:
     tr::vector<cell> buffer_;
 };
+
+} // namespace sp

--- a/compiler/driver.cpp
+++ b/compiler/driver.cpp
@@ -31,6 +31,7 @@
 #endif
 
 using namespace ke;
+using namespace sp;
 
 #if defined _WIN32
 static HWND hwndFinish = 0;

--- a/compiler/errors.cpp
+++ b/compiler/errors.cpp
@@ -58,6 +58,8 @@
 #    pragma warning(pop)
 #endif
 
+namespace sp {
+
 void report_error(ErrorReport&& report);
 
 AutoErrorPos::AutoErrorPos(const token_pos_t& pos)
@@ -411,3 +413,5 @@ AutoCountErrors::ok() const
 {
     return old_errors_ == reports_->total_errors();
 }
+
+} // namespace sp

--- a/compiler/errors.h
+++ b/compiler/errors.h
@@ -22,8 +22,7 @@
  *
  *  Version: $Id$
  */
-#ifndef am_sourcepawn_compiler_sc5_h
-#define am_sourcepawn_compiler_sc5_h
+#pragma once
 
 #include <stdarg.h>
 
@@ -32,6 +31,8 @@
 #include <amtl/am-string.h>
 #include "lexer.h"
 #include "sc.h"
+
+namespace sp {
 
 class ParseNode;
 
@@ -42,12 +43,12 @@ enum class ErrorType {
 };
 
 struct ErrorReport {
-    sp::SourceLocation loc;
+    SourceLocation loc;
     int number;
     uint32_t fileno;
     uint32_t lineno;
     uint32_t col;
-    std::shared_ptr<sp::SourceFile> file;
+    std::shared_ptr<SourceFile> file;
     std::string message;
     ErrorType type;
 };
@@ -94,7 +95,7 @@ class MessageBuilder
         args_.emplace_back(arg);
         return *this;
     }
-    MessageBuilder& operator <<(sp::Atom* atom) {
+    MessageBuilder& operator <<(Atom* atom) {
         args_.emplace_back(atom ? atom->chars() : "<unknown>");
         return *this;
     }
@@ -190,4 +191,4 @@ class AutoCountErrors
     unsigned old_errors_;
 };
 
-#endif // am_sourcepawn_compiler_sc5_h
+} // namespace sp

--- a/compiler/expressions.cpp
+++ b/compiler/expressions.cpp
@@ -36,6 +36,8 @@
 #include "symbols.h"
 #include "types.h"
 
+namespace sp {
+
 /* Function addresses of binary operators for signed operations */
 static const int op1[17] = {
     // hier3
@@ -649,3 +651,5 @@ commutative(int oper)
             return false;
     }
 }
+
+} // namespace sp

--- a/compiler/expressions.h
+++ b/compiler/expressions.h
@@ -21,12 +21,13 @@
  *
  *  Version: $Id$
  */
-#ifndef am_sourcepawn_compiler_sc3_h
-#define am_sourcepawn_compiler_sc3_h
+#pragma once
 
 #include "lexer.h"
 #include "parse-node.h"
 #include "sc.h"
+
+namespace sp {
 
 class SemaContext;
 struct value;
@@ -56,4 +57,4 @@ void user_inc();
 void user_dec();
 int checktag(int tag, int exprtag);
 
-#endif // am_sourcepawn_compiler_sc3_h
+} // namespace sp

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -60,7 +60,7 @@
 #include "symbols.h"
 #include "types.h"
 
-using namespace sp;
+namespace sp {
 
 // Flags for litchar().
 //
@@ -310,7 +310,7 @@ void Lexer::lex_float(full_token_t* tok, cell_t whole) {
 
     /* floating point */
     float value = (float)fnum;
-    tok->numeric_value = sp::FloatCellUnion(value).cell;
+    tok->numeric_value = FloatCellUnion(value).cell;
     tok->id = tRATIONAL;
 }
 
@@ -484,7 +484,7 @@ void Lexer::HandleDirectives() {
             state_.pos = state_.end;
             break;
         case tpDEFINE: {
-            sp::Atom* symbol;
+            Atom* symbol;
             {
                 ke::SaveAndSet<bool> no_macros(&allow_substitutions_, false);
                 ke::SaveAndSet<bool> no_keywords(&allow_keywords_, false);
@@ -1215,7 +1215,7 @@ Lexer::Lexer(CompileContext& cc)
     const int kStart = tMIDDLE + 1;
     const char** tokptr = &sc_tokens[kStart - tFIRST];
     for (int i = kStart; i <= tLAST; i++, tokptr++) {
-        sp::Atom* atom = cc_.atom(*tokptr);
+        Atom* atom = cc_.atom(*tokptr);
         assert(keywords_.count(atom) == 0);
         keywords_.emplace(atom, i);
     }
@@ -1249,7 +1249,7 @@ std::string get_token_string(int tok_id) {
     return StringPrintf("%s", sc_tokens[tok_id - tFIRST]);
 }
 
-int Lexer::LexKeywordImpl(sp::Atom* atom) {
+int Lexer::LexKeywordImpl(Atom* atom) {
     auto iter = keywords_.find(atom);
     if (iter != keywords_.end())
         return iter->second;
@@ -1720,7 +1720,7 @@ void Lexer::LexStringLiteral(full_token_t* tok, int flags) {
     }
 }
 
-bool Lexer::LexKeyword(full_token_t* tok, sp::Atom* atom) {
+bool Lexer::LexKeyword(full_token_t* tok, Atom* atom) {
     int tok_id = LexKeywordImpl(atom);
     if (!tok_id)
         return false;
@@ -1777,7 +1777,7 @@ void Lexer::LexSymbolOrKeyword(full_token_t* tok) {
     }
 
     // Handle preprocessor keywords (ugh).
-    sp::Atom* atom = cc_.atom((const char *)token_start, len);
+    Atom* atom = cc_.atom((const char *)token_start, len);
     if (atom == defined_atom_) {
         tok->id = tDEFINED;
         return;
@@ -1811,7 +1811,7 @@ void Lexer::LexSymbolOrKeyword(full_token_t* tok) {
     report(31);
 }
 
-void Lexer::LexSymbol(full_token_t* tok, sp::Atom* atom) {
+void Lexer::LexSymbol(full_token_t* tok, Atom* atom) {
     tok->atom = atom;
     tok->id = tSYMBOL;
 
@@ -2236,7 +2236,7 @@ isoctal(char c)
 }
 
 bool
-Lexer::matchsymbol(sp::Atom** name)
+Lexer::matchsymbol(Atom** name)
 {
     if (lex() != tSYMBOL) {
         lexpush();
@@ -2247,7 +2247,7 @@ Lexer::matchsymbol(sp::Atom** name)
 }
 
 bool
-Lexer::needsymbol(sp::Atom** name)
+Lexer::needsymbol(Atom** name)
 {
     if (!need(tSYMBOL)) {
         *name = cc_.atom("__unknown__");
@@ -2267,7 +2267,7 @@ void Lexer::AddMacro(const char* pattern, const char* subst) {
     macros_[atom] = std::move(macro);
 }
 
-std::shared_ptr<Lexer::MacroEntry> Lexer::FindMacro(sp::Atom* atom) {
+std::shared_ptr<Lexer::MacroEntry> Lexer::FindMacro(Atom* atom) {
     auto p = macros_.find(atom);
     if (p == macros_.end())
         return nullptr;
@@ -2275,7 +2275,7 @@ std::shared_ptr<Lexer::MacroEntry> Lexer::FindMacro(sp::Atom* atom) {
     return p->second;
 }
 
-bool Lexer::DeleteMacro(sp::Atom* atom) {
+bool Lexer::DeleteMacro(Atom* atom) {
     auto p = macros_.find(atom);
     if (p == macros_.end())
         return false;
@@ -2289,7 +2289,7 @@ declare_handle_intrinsics()
 {
     // Must not have an existing Handle methodmap.
     auto& cc = CompileContext::get();
-    sp::Atom* handle_atom = cc.atom("Handle");
+    Atom* handle_atom = cc.atom("Handle");
     if (methodmap_find_by_name(handle_atom)) {
         report(156);
         return;
@@ -2414,13 +2414,13 @@ void Lexer::LexStringContinuation() {
     current_token()->atom = cc_.atom(data);
 }
 
-bool Lexer::HasMacro(sp::Atom* atom) {
+bool Lexer::HasMacro(Atom* atom) {
     return !!FindMacro(atom);
 }
 
 void Lexer::LexDefinedKeyword() {
     auto initial = *current_token();
-    sp::Atom* symbol = nullptr;
+    Atom* symbol = nullptr;
     {
         ke::SaveAndSet<bool> stop_recursion(&allow_substitutions_, false);
         ke::SaveAndSet<token_buffer_t*> switch_buffers(&token_buffer_, &preproc_buffer_);
@@ -2653,3 +2653,5 @@ void Lexer::InjectCachedTokens(TokenCache* cache) {
 
     freading_ = true;
 }
+
+} // namespace sp

--- a/compiler/lexer.h
+++ b/compiler/lexer.h
@@ -31,13 +31,15 @@
 #include "source-location.h"
 #include "source-manager.h"
 
+namespace sp {
+
 class CompileContext;
 class Type;
 
 struct full_token_t {
     int id = 0;
     union {
-        sp::Atom* atom = nullptr;
+        Atom* atom = nullptr;
         int numeric_value; // Set on tRATIONAL, tNUMBER, and tCHAR_LITERAL.
     };
     int value();
@@ -299,22 +301,22 @@ class Lexer
     bool peek(int id);
     bool match(int token);
     bool need(int token);
-    bool matchsymbol(sp::Atom** atom);
-    bool needsymbol(sp::Atom** atom);
+    bool matchsymbol(Atom** atom);
+    bool needsymbol(Atom** atom);
     int require_newline(TerminatorPolicy policy);
     int peek_same_line();
     void lexpush();
     void lexclr(int clreol);
 
-    void Init(std::shared_ptr<sp::SourceFile> sf);
+    void Init(std::shared_ptr<SourceFile> sf);
     void Start();
     bool PlungeFile(const char* name, int try_currentpath, int try_includepaths);
-    std::shared_ptr<sp::SourceFile> OpenFile(const std::string& name);
+    std::shared_ptr<SourceFile> OpenFile(const std::string& name);
     bool NeedSemicolon();
     void AddMacro(const char* pattern, const char* subst);
     void LexStringContinuation();
     void LexDefinedKeyword();
-    bool HasMacro(sp::Atom* atom);
+    bool HasMacro(Atom* atom);
 
     // Lexer must be at a '{' token. Lexes until it reaches a balanced '}' token,
     // and returns a pointer to the cached tokens.
@@ -343,7 +345,7 @@ class Lexer
     bool freading() const { return freading_; }
     int fcurrent() const { return state_.inpf->sources_index(); }
     unsigned fline() const { return state_.fline; }
-    sp::SourceFile* inpf() const { return state_.inpf.get(); }
+    SourceFile* inpf() const { return state_.inpf.get(); }
 
     unsigned char const* char_stream() const { return state_.pos; }
     unsigned char const* line_start() const { return state_.line_start; }
@@ -360,16 +362,16 @@ class Lexer
     int LexInjectedToken();
     void LexIntoToken(full_token_t* tok);
     void LexSymbolOrKeyword(full_token_t* tok);
-    int LexKeywordImpl(sp::Atom* atom);
-    bool LexKeyword(full_token_t* tok, sp::Atom* atom);
+    int LexKeywordImpl(Atom* atom);
+    bool LexKeyword(full_token_t* tok, Atom* atom);
     void LexStringLiteral(full_token_t* tok, int flags);
-    void LexSymbol(full_token_t* tok, sp::Atom* atom);
+    void LexSymbol(full_token_t* tok, Atom* atom);
     bool MaybeHandleLineContinuation();
     bool PlungeQualifiedFile(const char* name);
     full_token_t* PushSynthesizedToken(TokenKind kind, const token_pos_t& pos);
     void SynthesizeIncludePathToken();
     void SetFileDefines(std::string file);
-    void EnterFile(std::shared_ptr<sp::SourceFile>&& fp, const token_pos_t& from);
+    void EnterFile(std::shared_ptr<SourceFile>&& fp, const token_pos_t& from);
     void FillTokenPos(token_pos_t* pos);
     void SkipLineWhitespace();
     std::string SkimUntilEndOfLine(tr::vector<size_t>* macro_args = nullptr);
@@ -439,16 +441,16 @@ class Lexer
 
   private:
     struct MacroEntry {
-        sp::Atom* pattern = nullptr;
+        Atom* pattern = nullptr;
         ke::Maybe<tr::vector<int>> args;
         tr::vector<size_t> arg_positions;
-        sp::Atom* substitute = nullptr;
+        Atom* substitute = nullptr;
         std::string documentation;
         token_pos_t pos;
         bool deprecated;
     };
-    std::shared_ptr<MacroEntry> FindMacro(sp::Atom* atom);
-    bool DeleteMacro(sp::Atom* atom);
+    std::shared_ptr<MacroEntry> FindMacro(Atom* atom);
+    bool DeleteMacro(Atom* atom);
     bool EnterMacro(std::shared_ptr<MacroEntry> macro);
     bool IsInMacro() const { return state_.macro != nullptr; }
     std::string PerformMacroSubstitution(MacroEntry* macro,
@@ -456,7 +458,7 @@ class Lexer
 
   private:
     CompileContext& cc_;
-    tr::unordered_map<sp::Atom*, int> keywords_;
+    tr::unordered_map<Atom*, int> keywords_;
     std::vector<char> ifstack_;
     size_t iflevel_;             /* nesting level if #if/#else/#endif */
     size_t skiplevel_; /* level at which we started skipping (including nested #if .. #endif) */
@@ -469,14 +471,14 @@ class Lexer
     bool allow_substitutions_ = true;
     bool allow_end_of_file_ = true;
     bool allow_keywords_ = true;
-    sp::Atom* defined_atom_ = nullptr;
-    sp::Atom* line_atom_ = nullptr;
+    Atom* defined_atom_ = nullptr;
+    Atom* line_atom_ = nullptr;
 
     token_buffer_t normal_buffer_;;
     token_buffer_t preproc_buffer_;
     token_buffer_t* token_buffer_;
 
-    tr::unordered_map<sp::Atom*, std::shared_ptr<MacroEntry>> macros_;
+    tr::unordered_map<Atom*, std::shared_ptr<MacroEntry>> macros_;
     std::unordered_set<MacroEntry*> macros_in_use_;
 
     struct LexerState {
@@ -486,8 +488,8 @@ class Lexer
         void operator =(const LexerState &) = delete;
         LexerState& operator =(LexerState&&) = default;
 
-        std::shared_ptr<sp::SourceFile> inpf;
-        sp::LocationRange loc_range;
+        std::shared_ptr<SourceFile> inpf;
+        LocationRange loc_range;
         // Visual line in the file.
         int fline = 0;
         // Line # for token processing.
@@ -513,3 +515,5 @@ class Lexer
     std::deque<full_token_t> injected_token_stream_;
     bool caching_tokens_ = false;
 };
+
+} // namespace sp

--- a/compiler/main.cpp
+++ b/compiler/main.cpp
@@ -83,6 +83,8 @@
 
 using namespace ke;
 
+namespace sp {
+
 int pc_tag_string = 0;
 int pc_tag_bool = 0;
 
@@ -394,3 +396,5 @@ setconstants(void)
 
     DefineConstant(cc, cc.atom("debug"), 2, 0);
 }
+
+} // namespace sp

--- a/compiler/name-resolution.cpp
+++ b/compiler/name-resolution.cpp
@@ -30,9 +30,12 @@
 #include "parse-node.h"
 #include "parser.h"
 #include "sc.h"
+#include "scopes.h"
 #include "sctracker.h"
 #include "semantics.h"
 #include "symbols.h"
+
+namespace sp {
 
 AutoEnterScope::AutoEnterScope(SemaContext& sc, SymbolScope* scope)
   : sc_(sc),
@@ -96,7 +99,7 @@ SemaContext::BindType(const token_pos_t& pos, typeinfo_t* ti)
 }
 
 bool
-SemaContext::BindType(const token_pos_t& pos, sp::Atom* atom, bool is_label, int* tag)
+SemaContext::BindType(const token_pos_t& pos, Atom* atom, bool is_label, int* tag)
 {
     auto types = cc_.types();
 
@@ -1062,7 +1065,7 @@ FunctionDecl::BindArgs(SemaContext& sc)
     return errors.ok();
 }
 
-sp::Atom*
+Atom*
 FunctionDecl::NameForOperator()
 {
     std::vector<std::string> params;
@@ -1144,7 +1147,7 @@ EnumStructDecl::EnterNames(SemaContext& sc)
     auto data = new EnumStructData;
     root_->set_data(data);
 
-    std::unordered_set<sp::Atom*> seen;
+    std::unordered_set<Atom*> seen;
     std::vector<symbol*> fields;
 
     cell position = 0;
@@ -1246,8 +1249,8 @@ EnumStructDecl::Bind(SemaContext& sc)
     return errors.ok();
 }
 
-sp::Atom*
-Decl::DecorateInnerName(sp::Atom* parent_name, sp::Atom* field_name)
+Atom*
+Decl::DecorateInnerName(Atom* parent_name, Atom* field_name)
 {
     auto full_name = ke::StringPrintf("%s.%s", parent_name->chars(), field_name->chars());
     return CompileContext::get().atom(full_name);
@@ -1533,3 +1536,5 @@ AutoCreateScope::~AutoCreateScope() {
     sc_.set_scope(prev_);
     sc_.set_scope_creator(prev_creator_);
 }
+
+} // namespace sp

--- a/compiler/parse-node.cpp
+++ b/compiler/parse-node.cpp
@@ -21,7 +21,9 @@
 
 #include "errors.h"
 
-VarDeclBase::VarDeclBase(StmtKind kind, const token_pos_t& pos, sp::Atom* name,
+namespace sp {
+
+VarDeclBase::VarDeclBase(StmtKind kind, const token_pos_t& pos, Atom* name,
                          const typeinfo_t& type, int vclass, bool is_public, bool is_static,
                          bool is_stock, Expr* initializer)
  : Decl(kind, pos, name),
@@ -116,7 +118,7 @@ FunctionDecl::FunctionDecl(const token_pos_t& pos, const declinfo_t& decl)
 {
 }
 
-int FunctionDecl::FindNamedArg(sp::Atom* name) const {
+int FunctionDecl::FindNamedArg(Atom* name) const {
     for (size_t i = 0; i < args_.size() && args_[i]->type().ident != iVARARGS; i++) {
         if (args_[i]->name() == name)
             return (int)i;
@@ -128,3 +130,5 @@ FloatExpr::FloatExpr(CompileContext& cc, const token_pos_t& pos, cell value)
   : TaggedValueExpr(pos, cc.types()->tag_float(), value)
 {
 }
+
+} // namespace sp

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -36,7 +36,7 @@
 #include "semantics.h"
 #include "types.h"
 
-using namespace sp;
+namespace sp {
 
 Parser::Parser(CompileContext& cc, Semantics* sema)
   : cc_(cc),
@@ -424,7 +424,7 @@ Parser::parse_enum(int vclass)
         if (lexer_->match(tLABEL))
             report(153);
 
-        sp::Atom* field_name = nullptr;
+        Atom* field_name = nullptr;
         if (lexer_->need(tSYMBOL))
             field_name = lexer_->current_token()->atom;
 
@@ -456,7 +456,7 @@ Parser::parse_enumstruct()
 {
     auto pos = lexer_->pos();
 
-    sp::Atom* struct_name;
+    Atom* struct_name;
     if (!lexer_->needsymbol(&struct_name))
         return nullptr;
 
@@ -510,7 +510,7 @@ Parser::parse_pstruct()
 {
     auto pos = lexer_->pos();
 
-    sp::Atom* ident = nullptr;
+    Atom* ident = nullptr;
     lexer_->needsymbol(&ident);
 
     std::vector<StructField> fields;
@@ -550,7 +550,7 @@ Parser::parse_typedef()
 {
     auto pos = lexer_->pos();
 
-    sp::Atom* ident;
+    Atom* ident;
     if (!lexer_->needsymbol(&ident))
         return nullptr;
 
@@ -565,7 +565,7 @@ Parser::parse_typeset()
 {
     auto pos = lexer_->pos();
 
-    sp::Atom* ident = nullptr;
+    Atom* ident = nullptr;
     lexer_->needsymbol(&ident);
 
     std::vector<TypedefInfo*> types;
@@ -590,7 +590,7 @@ Parser::parse_using()
     auto pos = lexer_->pos();
 
     auto validate = [this]() -> bool {
-        sp::Atom* ident;
+        Atom* ident;
         if (!lexer_->needsymbol(&ident))
             return false;
         if (strcmp(ident->chars(), "__intrinsics__") != 0) {
@@ -623,7 +623,7 @@ Parser::parse_pragma_unused()
 
     const auto& data = lexer_->current_token()->data();
     std::vector<std::string> raw_names = ke::Split(data, ",");
-    std::vector<sp::Atom*> names;
+    std::vector<Atom*> names;
     for (const auto& raw_name : raw_names)
         names.emplace_back(cc_.atom(raw_name));
     return new PragmaUnusedStmt(pos, names);
@@ -671,7 +671,7 @@ Parser::parse_const(int vclass)
                 break;
         }
 
-        sp::Atom* name = nullptr;
+        Atom* name = nullptr;
         lexer_->needsymbol(&name);
 
         lexer_->need('=');
@@ -901,7 +901,7 @@ Parser::hier2()
         {
             // :TODO: unify this to only care about types. This will depend on
             // removing immediate name resolution from parse_new_typename.
-            sp::Atom* ident;
+            Atom* ident;
             if (lexer_->matchsymbol(&ident)) {
                 if (lexer_->match('(')) {
                     Expr* target = new SymbolExpr(lexer_->pos(), ident);
@@ -935,7 +935,7 @@ Parser::hier2()
             while (lexer_->match('('))
                 parens++;
 
-            sp::Atom* ident;
+            Atom* ident;
             if (lexer_->match(tTHIS)) {
                 ident = cc_.atom("this");
             } else {
@@ -1012,7 +1012,7 @@ Parser::hier1()
         int tok = lexer_->lex();
         if (tok == '.' || tok == tDBLCOLON) {
             auto pos = lexer_->pos();
-            sp::Atom* ident;
+            Atom* ident;
             if (!lexer_->needsymbol(&ident))
                 break;
             base = new FieldAccessExpr(pos, tok, base, ident);
@@ -1121,7 +1121,7 @@ Parser::parse_call(const token_pos_t& pos, int tok, Expr* target)
     do {
         token_pos_t name_pos;
 
-        sp::Atom* name = nullptr;
+        Atom* name = nullptr;
         if (lexer_->match('.')) {
             named_params = true;
 
@@ -1185,7 +1185,7 @@ Parser::struct_init()
 
     // '}' has already been lexed.
     do {
-        sp::Atom* name = nullptr;
+        Atom* name = nullptr;
         lexer_->needsymbol(&name);
 
         auto start_pos = lexer_->pos();
@@ -1235,7 +1235,7 @@ Parser::parse_static_assert()
     if (!expr)
         return nullptr;
 
-    sp::Atom* text = nullptr;
+    Atom* text = nullptr;
     if (lexer_->match(',') && lexer_->need(tSTRING)) {
         auto tok = lexer_->current_token();
         text = tok->atom;
@@ -1803,7 +1803,7 @@ Parser::parse_function(FunctionDecl* fun, int tokid, bool has_this)
             lexer_->lexpush();
         }
         if (lexer_->match('=')) {
-            sp::Atom* ident;
+            Atom* ident;
             if (lexer_->needsymbol(&ident))
                 fun->set_alias(ident);
         }
@@ -1889,7 +1889,7 @@ Parser::parse_methodmap()
 {
     auto pos = lexer_->pos();
 
-    sp::Atom* ident;
+    Atom* ident;
     lexer_->needsymbol(&ident);
 
     auto name_atom = ident;
@@ -1898,7 +1898,7 @@ Parser::parse_methodmap()
 
     bool nullable = lexer_->match(tNULLABLE);
 
-    sp::Atom* extends = nullptr;
+    Atom* extends = nullptr;
     if (lexer_->match('<') && lexer_->needsymbol(&ident))
         extends = ident;
 
@@ -1949,7 +1949,7 @@ Parser::parse_methodmap_method(MethodmapDecl* map)
     bool is_static = lexer_->match(tSTATIC);
     bool is_native = lexer_->match(tNATIVE);
 
-    sp::Atom* symbol = nullptr;
+    Atom* symbol = nullptr;
     full_token_t symbol_tok;
     if (lexer_->matchsymbol(&symbol))
         symbol_tok = *lexer_->current_token();
@@ -2032,7 +2032,7 @@ Parser::parse_methodmap_property(MethodmapDecl* map)
     if (!parse_new_typeexpr(&prop->type, nullptr, 0))
         return nullptr;
 
-    sp::Atom* ident;
+    Atom* ident;
     if (!lexer_->needsymbol(&ident))
         return nullptr;
     if (!lexer_->need('{'))
@@ -2057,7 +2057,7 @@ Parser::parse_methodmap_property_accessor(MethodmapDecl* map, MethodmapProperty*
 
     lexer_->need(tPUBLIC);
 
-    sp::Atom* ident;
+    Atom* ident;
     if (!lexer_->matchsymbol(&ident)) {
         if (!lexer_->match(tNATIVE)) {
             report(125);
@@ -2204,7 +2204,7 @@ Parser::parse_function_type()
 bool
 Parser::parse_decl(declinfo_t* decl, int flags)
 {
-    sp::Atom* ident = nullptr;
+    Atom* ident = nullptr;
 
     decl->type.ident = iVARIABLE;
 
@@ -2326,7 +2326,7 @@ Parser::parse_old_decl(declinfo_t* decl, int flags)
             while (true) {
                 if (!lexer_->match('_')) {
                     // If we don't get the magic tag '_', then we should have a symbol.
-                    sp::Atom* name;
+                    Atom* name;
                     if (lexer_->needsymbol(&name))
                         ti = TypenameInfo(name, true);
                 }
@@ -2366,7 +2366,6 @@ Parser::parse_old_decl(declinfo_t* decl, int flags)
                 decl->name = cc_.atom("__unknown__");
         } else {
             if (!lexer_->peek(tSYMBOL)) {
-                extern const char* sc_tokens[];
                 int tok_id = lexer_->lex();
                 switch (tok_id) {
                     case tOBJECT:
@@ -2376,8 +2375,8 @@ Parser::parse_old_decl(declinfo_t* decl, int flags)
                         if (lexer_->peek(tSYMBOL)) {
                             report(143);
                         } else {
-                            report(157) << sc_tokens[tok_id - tFIRST];
-                            decl->name = cc_.atom(sc_tokens[tok_id - tFIRST]);
+                            report(157) << get_token_string(tok_id);
+                            decl->name = cc_.atom(get_token_string(tok_id));
                         }
                         break;
                     default:
@@ -2433,7 +2432,7 @@ Parser::parse_new_decl(declinfo_t* decl, const full_token_t* first, int flags)
 }
 
 int
-Parser::operatorname(sp::Atom** name)
+Parser::operatorname(Atom** name)
 {
     /* check the operator */
     int opertok = lexer_->lex();
@@ -2695,3 +2694,5 @@ Parser::nextop(int* opidx, const int* list)
     }
     return FALSE; /* entire list scanned, nothing found */
 }
+
+} // namespace sp

--- a/compiler/parser.h
+++ b/compiler/parser.h
@@ -26,6 +26,8 @@
 #include "sc.h"
 #include "sctracker.h"
 
+namespace sp {
+
 class Semantics;
 
 class Parser
@@ -84,7 +86,7 @@ class Parser
     bool reparse_new_decl(declinfo_t* decl, int flags);
     void fix_mispredicted_postdims(declinfo_t* decl);
     void rewrite_type_for_enum_struct(typeinfo_t* info);
-    int operatorname(sp::Atom** name);
+    int operatorname(Atom** name);
 
     Stmt* parse_compound();
     Stmt* parse_local_decl(int tokid, bool autozero);
@@ -133,8 +135,10 @@ class Parser
     Semantics* sema_;
     bool in_loop_ = false;
     bool in_test_ = false;
-    std::vector<SymbolScope*> static_scopes_;
+    std::vector<sp::SymbolScope*> static_scopes_;
     std::shared_ptr<Lexer> lexer_;
     TypeDictionary* types_ = nullptr;
     std::deque<FunctionDecl*> delayed_functions_;
 };
+
+} // namespace sp

--- a/compiler/pool-objects.cpp
+++ b/compiler/pool-objects.cpp
@@ -17,6 +17,9 @@
 // SourcePawn. If not, see http://www.gnu.org/licenses/.
 #include "pool-objects.h"
 
+namespace sp {
+namespace cc {
+
 void
 PoolAllocationPolicy::reportOutOfMemory()
 {
@@ -58,3 +61,6 @@ void
 PoolAllocationPolicy::am_free(void* ptr)
 {
 }
+
+} // namespace cc
+} // namespace sp

--- a/compiler/pool-objects.h
+++ b/compiler/pool-objects.h
@@ -23,6 +23,9 @@
 
 #include <amtl/am-fixedarray.h>
 
+namespace sp {
+namespace cc {
+
 class PoolObject
 {
   public:
@@ -143,3 +146,6 @@ struct KeywordTablePolicy {
         return ke::HashCharSequence(key.str(), key.length());
     }
 };
+
+} // namespace cc
+} // namespace sp

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -28,8 +28,8 @@
  *
  *  Version: $Id$
  */
-#ifndef SC_H_INCLUDED
-#define SC_H_INCLUDED
+#pragma once
+
 #include <limits.h>
 #include <setjmp.h>
 #include <stdarg.h>
@@ -51,6 +51,8 @@
 
 typedef int32_t cell;
 typedef uint32_t ucell;
+
+namespace sp {
 
 /* Note: the "cell" and "ucell" types are defined in AMX.H */
 
@@ -159,4 +161,4 @@ static constexpr cell kMaxCells = INT_MAX / sizeof(cell);
 # define SP_BITFIELD(n)
 #endif
 
-#endif /* SC_H_INCLUDED */
+} // namespace sp

--- a/compiler/scopes.cpp
+++ b/compiler/scopes.cpp
@@ -1,6 +1,6 @@
 // vim: set ts=8 sts=4 sw=4 tw=99 et:
 //
-//  Copyright (c) AlliedModders 2021
+//  Copyright (c) AlliedModders LLC 2021
 //
 //  This software is provided "as-is", without any express or implied warranty.
 //  In no event will the authors be held liable for any damages arising from
@@ -18,13 +18,34 @@
 //      misrepresented as being the original software.
 //  3.  This notice may not be removed or altered from any source distribution.
 
-#pragma once
-
-#include "types.h"
+#include "scopes.h"
 
 namespace sp {
 
-typeinfo_t TypeInfoFromSymbol(symbol* sym);
-typeinfo_t TypeInfoFromTag(int tag);
+void SymbolScope::Add(symbol* sym) {
+    if (!symbols_) {
+        auto& cc = CompileContext::get();
+        symbols_ = cc.NewSymbolMap();
+    }
+
+    assert(symbols_->find(sym->nameAtom()) == symbols_->end());
+    symbols_->emplace(sym->nameAtom(), sym);
+}
+
+void SymbolScope::AddChain(symbol* sym) {
+    if (!symbols_) {
+        auto& cc = CompileContext::get();
+        symbols_ = cc.NewSymbolMap();
+    }
+
+    auto iter = symbols_->find(sym->nameAtom());
+    if (iter == symbols_->end()) {
+        symbols_->emplace(sym->nameAtom(), sym);
+    } else {
+        sym->next = iter->second;
+        iter->second = sym;
+    }
+}
+
 
 } // namespace sp

--- a/compiler/scopes.h
+++ b/compiler/scopes.h
@@ -1,0 +1,84 @@
+// vim: set ts=8 sts=4 sw=4 tw=99 et:
+//
+//  Copyright (c) AlliedModders LLC 2021
+//
+//  This software is provided "as-is", without any express or implied warranty.
+//  In no event will the authors be held liable for any damages arising from
+//  the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1.  The origin of this software must not be misrepresented; you must not
+//      claim that you wrote the original software. If you use this software in
+//      a product, an acknowledgment in the product documentation would be
+//      appreciated but is not required.
+//  2.  Altered source versions must be plainly marked as such, and must not be
+//      misrepresented as being the original software.
+//  3.  This notice may not be removed or altered from any source distribution.
+
+#pragma once
+
+#include "parse-node.h"
+#include "symbols.h"
+
+namespace sp {
+
+class SymbolScope final : public PoolObject
+{
+  public:
+    SymbolScope(SymbolScope* parent, ScopeKind kind, int fnumber = -1)
+      : parent_(parent),
+        kind_(kind),
+        symbols_(nullptr),
+        fnumber_(fnumber)
+    {}
+
+    symbol* Find(Atom* atom) const {
+        if (!symbols_)
+            return nullptr;
+        auto iter = symbols_->find(atom);
+        if (iter == symbols_->end())
+            return nullptr;
+        return iter->second;
+    }
+
+    void Add(symbol* sym);
+
+    // Add, but allow duplicates by linking together.
+    void AddChain(symbol* sym);
+
+    void ForEachSymbol(const std::function<void(symbol*)>& callback) {
+        if (!symbols_)
+            return;
+        for (const auto& pair : *symbols_) {
+            for (auto iter = pair.second; iter; iter = iter->next)
+                callback(iter);
+        }
+    }
+
+    bool IsGlobalOrFileStatic() const {
+        return kind_ == sGLOBAL || kind_ == sFILE_STATIC;
+    }
+    bool IsLocalOrArgument() const {
+        return kind_ == sLOCAL || kind_ == sARGUMENT;
+    }
+
+    SymbolScope* parent() const { return parent_; }
+    void set_parent(SymbolScope* scope) { parent_ = scope; }
+
+    ScopeKind kind() const { return kind_; }
+    int fnumber() const { return fnumber_; }
+
+  private:
+    SymbolScope* parent_;
+    ScopeKind kind_;
+    tr::unordered_map<Atom*, symbol*>* symbols_;
+    int fnumber_;
+};
+
+symbol* FindSymbol(SymbolScope* scope, Atom* name, SymbolScope** found = nullptr);
+symbol* FindSymbol(SemaContext& sc, Atom* name, SymbolScope** found = nullptr);
+
+} // namespace sp

--- a/compiler/sctracker.cpp
+++ b/compiler/sctracker.cpp
@@ -1,4 +1,22 @@
-/* vim: set ts=8 sts=4 sw=4 tw=99 et: */
+// vim: set ts=8 sts=4 sw=4 tw=99 et:
+//
+//  Copyright (c) 2023 AlliedModders LLC
+//
+//  This software is provided "as-is", without any express or implied warranty.
+//  In no event will the authors be held liable for any damages arising from
+//  the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1.  The origin of this software must not be misrepresented; you must not
+//      claim that you wrote the original software. If you use this software in
+//      a product, an acknowledgment in the product documentation would be
+//      appreciated but is not required.
+//  2.  Altered source versions must be plainly marked as such, and must not be
+//      misrepresented as being the original software.
+//  3.  This notice may not be removed or altered from any source distribution.
 #include "sctracker.h"
 
 #include <assert.h>
@@ -17,7 +35,9 @@
 #include "symbols.h"
 #include "types.h"
 
-funcenum_t* funcenums_add(CompileContext& cc, sp::Atom* name, bool anonymous) {
+namespace sp {
+
+funcenum_t* funcenums_add(CompileContext& cc, Atom* name, bool anonymous) {
     if (anonymous) {
         if (auto type = cc.types()->find(name)) {
             assert(type->kind() == TypeKind::Function);
@@ -71,7 +91,7 @@ functag_from_tag(int tag)
     return fe->entries.back();
 }
 
-methodmap_t::methodmap_t(methodmap_t* parent, sp::Atom* name)
+methodmap_t::methodmap_t(methodmap_t* parent, Atom* name)
  : parent(parent),
    tag(0),
    nullable(false),
@@ -101,7 +121,7 @@ methodmap_method_t::property_tag() const
 }
 
 methodmap_t*
-methodmap_add(CompileContext& cc, methodmap_t* parent, sp::Atom* name)
+methodmap_add(CompileContext& cc, methodmap_t* parent, Atom* name)
 {
     auto map = new methodmap_t(parent, name);
 
@@ -123,7 +143,7 @@ methodmap_find_by_tag(int tag)
 }
 
 methodmap_t*
-methodmap_find_by_name(sp::Atom* name)
+methodmap_find_by_name(Atom* name)
 {
     auto type = CompileContext::get().types()->find(name);
     if (!type)
@@ -132,7 +152,7 @@ methodmap_find_by_name(sp::Atom* name)
 }
 
 methodmap_method_t*
-methodmap_find_method(methodmap_t* map, sp::Atom* name)
+methodmap_find_method(methodmap_t* map, Atom* name)
 {
     auto iter = map->methods.find(name);
     if (iter != map->methods.end())
@@ -142,3 +162,5 @@ methodmap_find_method(methodmap_t* map, sp::Atom* name)
         return methodmap_find_method(map->parent, name);
     return nullptr;
 }
+
+} // namespace sp

--- a/compiler/sctracker.h
+++ b/compiler/sctracker.h
@@ -1,11 +1,32 @@
-/* vim: set sts=2 ts=8 sw=2 tw=99 et: */
-#ifndef _INCLUDE_SOURCEPAWN_COMPILER_TRACKER_H_
-#define _INCLUDE_SOURCEPAWN_COMPILER_TRACKER_H_
+// vim: set ts=8 sts=4 sw=4 tw=99 et:
+//
+//  Copyright (c) 2023 AlliedModders LLC
+//
+//  This software is provided "as-is", without any express or implied warranty.
+//  In no event will the authors be held liable for any damages arising from
+//  the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1.  The origin of this software must not be misrepresented; you must not
+//      claim that you wrote the original software. If you use this software in
+//      a product, an acknowledgment in the product documentation would be
+//      appreciated but is not required.
+//  2.  Altered source versions must be plainly marked as such, and must not be
+//      misrepresented as being the original software.
+//  3.  This notice may not be removed or altered from any source distribution.
+#pragma once
 
 #include <memory>
 
 #include "lexer.h"
 #include "pool-allocator.h"
+
+namespace sp {
+
+using namespace cc;
 
 class CompileContext;
 class SemaContext;
@@ -18,7 +39,7 @@ struct funcenum_t : public PoolObject
        anonymous(false)
     {}
     int tag;
-    sp::Atom* name;
+    Atom* name;
     PoolArray<functag_t*> entries;
     bool anonymous;
 };
@@ -34,7 +55,7 @@ struct methodmap_method_t : public PoolObject
        is_static(false)
     {}
 
-    sp::Atom* name;
+    Atom* name;
     methodmap_t* parent;
     symbol* target;
     symbol* getter;
@@ -46,7 +67,7 @@ struct methodmap_method_t : public PoolObject
 
 struct methodmap_t : public SymbolData
 {
-    methodmap_t(methodmap_t* parent, sp::Atom* name);
+    methodmap_t(methodmap_t* parent, Atom* name);
 
     methodmap_t* asMethodmap() override { return this; }
 
@@ -54,8 +75,8 @@ struct methodmap_t : public SymbolData
     int tag;
     bool nullable;
     bool keyword_nullable;
-    sp::Atom* name;
-    PoolMap<sp::Atom*, methodmap_method_t*> methods;
+    Atom* name;
+    PoolMap<Atom*, methodmap_method_t*> methods;
 
     bool must_construct_with_new() const {
         return nullable || keyword_nullable;
@@ -75,15 +96,15 @@ struct methodmap_t : public SymbolData
 /**
  * Function enumeration tags
  */
-funcenum_t* funcenums_add(CompileContext& cc, sp::Atom* name, bool anonymous);
+funcenum_t* funcenums_add(CompileContext& cc, Atom* name, bool anonymous);
 funcenum_t* funcenum_for_symbol(CompileContext& cc, symbol* sym);
 functag_t* functag_from_tag(int tag);
 
 /**
  * Method maps.
  */
-methodmap_t* methodmap_add(CompileContext& cc, methodmap_t* parent, sp::Atom* name);
-methodmap_t* methodmap_find_by_name(sp::Atom* name);
-methodmap_method_t* methodmap_find_method(methodmap_t* map, sp::Atom* name);
+methodmap_t* methodmap_add(CompileContext& cc, methodmap_t* parent, Atom* name);
+methodmap_t* methodmap_find_by_name(Atom* name);
+methodmap_method_t* methodmap_find_method(methodmap_t* map, Atom* name);
 
-#endif //_INCLUDE_SOURCEPAWN_COMPILER_TRACKER_H_
+} // namespace sp

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -33,6 +33,8 @@
 #include "sctracker.h"
 #include "symbols.h"
 
+namespace sp {
+
 Semantics::Semantics(CompileContext& cc)
   : cc_(cc)
 {
@@ -478,15 +480,15 @@ bool Expr::HasSideEffects() {
             return to<CastExpr>()->expr()->HasSideEffects();
         case ExprKind::CommaExpr: {
             auto e = to<CommaExpr>();
-            return ::HasSideEffects(e->exprs());
+            return sp::HasSideEffects(e->exprs());
         }
         case ExprKind::ArrayExpr: {
             auto e = to<ArrayExpr>();
-            return ::HasSideEffects(e->exprs());
+            return sp::HasSideEffects(e->exprs());
         }
         case ExprKind::NewArrayExpr: {
             auto e = to<NewArrayExpr>();
-            return ::HasSideEffects(e->exprs());
+            return sp::HasSideEffects(e->exprs());
         }
         case ExprKind::IndexExpr: {
             auto e = to<IndexExpr>();
@@ -3382,3 +3384,5 @@ void DeleteStmt::ProcessUses(SemaContext& sc) {
     expr_->MarkAndProcessUses(sc);
     markusage(map_->dtor->target, uREAD);
 }
+
+} // namespace sp

--- a/compiler/semantics.h
+++ b/compiler/semantics.h
@@ -25,7 +25,10 @@
 
 #include "compile-context.h"
 #include "sc.h"
+#include "scopes.h"
 #include "parse-node.h"
+
+namespace sp {
 
 class AutoCreateScope;
 class Semantics;
@@ -62,7 +65,7 @@ class SemaContext
 
     bool BindType(const token_pos_t& pos, TypenameInfo* ti);
     bool BindType(const token_pos_t& pos, typeinfo_t* ti);
-    bool BindType(const token_pos_t& pos, sp::Atom* atom, bool is_label, int* tag);
+    bool BindType(const token_pos_t& pos, Atom* atom, bool is_label, int* tag);
 
     Stmt* void_return() const { return void_return_; }
     void set_void_return(Stmt* stmt) { void_return_ = stmt; }
@@ -308,3 +311,5 @@ int check_operatortag(int opertok, int resulttag, const char* opername);
 int argcompare(ArgDecl* a1, ArgDecl* a2);
 void fill_arg_defvalue(CompileContext& cc, ArgDecl* decl);
 bool IsLegacyEnumTag(SymbolScope* scope, int tag);
+
+} // namespace sp

--- a/compiler/source-manager.h
+++ b/compiler/source-manager.h
@@ -28,12 +28,14 @@
 #include "source-file.h"
 #include "source-location.h"
 
+namespace sp {
+
 class CompileContext;
 
 // Of course, we'd love if tokens could just be SourceLocations. But peek_same_line()
 // is an extremely hot function, and line checks need to be fast, so we track
 // it explicitly.
-struct token_pos_t : public sp::SourceLocation {
+struct token_pos_t : public SourceLocation {
     int line = 0;
 
     token_pos_t() {}
@@ -42,8 +44,6 @@ struct token_pos_t : public sp::SourceLocation {
         line(line)
     {}
 };
-
-namespace sp {
 
 // Location Range. Design is taken from LLVM.
 //

--- a/compiler/stl/stl-allocator.h
+++ b/compiler/stl/stl-allocator.h
@@ -24,6 +24,8 @@
 
 #include <amtl/am-bits.h>
 
+namespace sp {
+
 class NativeAllocator
 {
   public:
@@ -72,3 +74,5 @@ class StlAllocator
     bool operator ==(const StlAllocator& other) const { return true; }
     bool operator !=(const StlAllocator& other) const { return false; }
 };
+
+} // namespace sp

--- a/compiler/stl/stl-forward-list.h
+++ b/compiler/stl/stl-forward-list.h
@@ -22,9 +22,11 @@
 
 #include "stl-allocator.h"
 
+namespace sp {
 namespace tr {
  
 template <typename T>
 using forward_list = std::forward_list<T, StlAllocator<T>>;
 
 } // namespace tr
+} // namespace sp

--- a/compiler/stl/stl-string.h
+++ b/compiler/stl/stl-string.h
@@ -23,6 +23,7 @@
 
 #include "stl-allocator.h"
 
+namespace sp {
 namespace tr {
 
 template <typename Char,
@@ -32,3 +33,4 @@ using basic_string = std::basic_string<Char, Traits, StlAllocator<Char>>;
 using string = basic_string<char>;
 
 } // namespace tr
+} // namespace sp

--- a/compiler/stl/stl-unordered-map.h
+++ b/compiler/stl/stl-unordered-map.h
@@ -22,6 +22,7 @@
 
 #include "stl-allocator.h"
 
+namespace sp {
 namespace tr {
 
 template <typename Key,
@@ -31,3 +32,4 @@ template <typename Key,
 using unordered_map = std::unordered_map<Key, T, Hash, KeyEqual, StlAllocator<std::pair<const Key, T>>>;
 
 } // namespace tr
+} // namespace sp

--- a/compiler/stl/stl-unordered-set.h
+++ b/compiler/stl/stl-unordered-set.h
@@ -22,6 +22,7 @@
 
 #include "stl-allocator.h"
 
+namespace sp {
 namespace tr {
 
 template <typename Key,
@@ -30,3 +31,4 @@ template <typename Key,
 using unordered_set = std::unordered_set<Key, Hash, KeyEqual, StlAllocator<Key>>;
 
 } // namespace tr
+} // namespace sp

--- a/compiler/stl/stl-vector.h
+++ b/compiler/stl/stl-vector.h
@@ -22,9 +22,11 @@
 
 #include "stl-allocator.h"
 
+namespace sp {
 namespace tr {
 
 template <typename T>
 using vector = std::vector<T, StlAllocator<T>>;
 
 } // namespace tr
+} // namespace sp

--- a/compiler/type-checker.cpp
+++ b/compiler/type-checker.cpp
@@ -22,6 +22,8 @@
 #include "sc.h"
 #include "symbols.h"
 
+namespace sp {
+
 typeinfo_t
 TypeInfoFromSymbol(symbol* sym)
 {
@@ -47,3 +49,5 @@ TypeInfoFromTag(int tag)
 
     return type;
 }
+
+} // namespace sp

--- a/compiler/types.cpp
+++ b/compiler/types.cpp
@@ -32,9 +32,11 @@
 #include "sctracker.h"
 #include "types.h"
 
+namespace sp {
+
 using namespace ke;
 
-Type::Type(sp::Atom* name, TypeKind kind)
+Type::Type(Atom* name, TypeKind kind)
  : name_(name),
    value_(0),
    fixed_(0),
@@ -85,7 +87,7 @@ TypeDictionary::TypeDictionary(CompileContext& cc)
   : cc_(cc)
 {}
 
-Type* TypeDictionary::find(sp::Atom* atom) {
+Type* TypeDictionary::find(Atom* atom) {
     auto iter = types_.find(atom);
     if (iter == types_.end())
         return nullptr;
@@ -102,7 +104,7 @@ Type* TypeDictionary::add(const char* name, TypeKind kind) {
     return add(cc_.atom(name), kind);
 }
 
-Type* TypeDictionary::add(sp::Atom* name, TypeKind kind) {
+Type* TypeDictionary::add(Atom* name, TypeKind kind) {
     Type* type = new Type(name, kind);
     RegisterType(type);
     return type;
@@ -138,7 +140,7 @@ TypeDictionary::defineAny()
     return add("any", TypeKind::Any);
 }
 
-Type* TypeDictionary::defineFunction(sp::Atom* name, funcenum_t* fe) {
+Type* TypeDictionary::defineFunction(Atom* name, funcenum_t* fe) {
     Type* type = add(name, TypeKind::Function);
     type->setFunction(fe);
     return type;
@@ -217,14 +219,14 @@ TypeDictionary::defineEnumStruct(const char* name, symbol* sym)
 }
 
 Type*
-TypeDictionary::defineTag(sp::Atom* name) {
+TypeDictionary::defineTag(Atom* name) {
     Type* type = add(name, TypeKind::Enum);
     if (isupper(*name->chars()))
         type->setFixed();
     return type;
 }
 
-pstruct_t* TypeDictionary::definePStruct(sp::Atom* name) {
+pstruct_t* TypeDictionary::definePStruct(Atom* name) {
     assert(find(name) == nullptr);
 
     pstruct_t* type = new pstruct_t(name);
@@ -248,7 +250,7 @@ typeinfo_t::isCharArray() const
     return numdim() == 1 && tag() == types->tag_string();
 }
 
-const structarg_t* pstruct_t::GetArg(sp::Atom* name) const {
+const structarg_t* pstruct_t::GetArg(Atom* name) const {
     for (const auto& arg : args) {
         if (arg->name == name)
             return arg;
@@ -256,3 +258,4 @@ const structarg_t* pstruct_t::GetArg(sp::Atom* name) const {
     return nullptr;
 }
 
+} // namespace sp

--- a/compiler/types.h
+++ b/compiler/types.h
@@ -23,8 +23,7 @@
  *
  *  Version: $Id$
  */
-#ifndef _INCLUDE_SOURCEPAWN_COMPILER_TYPES_H_
-#define _INCLUDE_SOURCEPAWN_COMPILER_TYPES_H_
+#pragma once
 
 #include <memory>
 
@@ -38,6 +37,10 @@
 
 typedef int32_t cell;
 typedef uint32_t ucell;
+
+namespace sp {
+
+using namespace cc;
 
 // Possible entries for "ident". These are used in the "symbol", "value"
 // and arginfo structures. Not every constant is valid for every use.
@@ -85,13 +88,13 @@ class Expr;
 struct TypenameInfo {
     TypenameInfo() {}
     explicit TypenameInfo(int tag) : resolved_tag(tag) {}
-    explicit TypenameInfo(sp::Atom* type_atom) : type_atom(type_atom) {}
-    TypenameInfo(sp::Atom* type_atom, bool is_label) : type_atom(type_atom) {
+    explicit TypenameInfo(Atom* type_atom) : type_atom(type_atom) {}
+    TypenameInfo(Atom* type_atom, bool is_label) : type_atom(type_atom) {
         if (is_label)
             set_is_label();
     }
 
-    sp::Atom* type_atom = nullptr;
+    Atom* type_atom = nullptr;
     int resolved_tag = -1;
 
     int tag() const {
@@ -127,7 +130,7 @@ struct typeinfo_t {
     PoolArray<Expr*> dim_exprs;
 
     // Type information.
-    sp::Atom* type_atom;    // Parsed atom.
+    Atom* type_atom;    // Parsed atom.
     int tag_;               // Effective tag.
 
     // If non-zero, this type was originally declared with this type, but was
@@ -206,7 +209,7 @@ struct structarg_t : public PoolObject
     {}
 
     typeinfo_t type;
-    sp::Atom* name;
+    Atom* name;
     unsigned int offs;
     int index;
 };
@@ -216,12 +219,12 @@ class Type : public PoolObject
     friend class TypeDictionary;
 
   public:
-    Type(sp::Atom* name, TypeKind kind);
+    Type(Atom* name, TypeKind kind);
 
-    sp::Atom* name() const {
+    Atom* name() const {
         return name_;
     }
-    sp::Atom* nameAtom() const { return name_; }
+    Atom* nameAtom() const { return name_; }
     TypeKind kind() const { return kind_; }
     const char* kindName() const;
     const char* prettyName() const;
@@ -320,7 +323,7 @@ class Type : public PoolObject
     void resetPtr();
 
   private:
-    sp::Atom* name_;
+    Atom* name_;
     cell value_;
     bool fixed_;
 
@@ -338,11 +341,11 @@ class Type : public PoolObject
 class pstruct_t : public Type
 {
   public:
-    explicit pstruct_t(sp::Atom* name)
+    explicit pstruct_t(Atom* name)
       : Type(name, TypeKind::Struct)
     {}
 
-    const structarg_t* GetArg(sp::Atom* name) const;
+    const structarg_t* GetArg(Atom* name) const;
 
     static bool is_a(Type* type) { return type->kind() == TypeKind::Struct; }
 
@@ -356,13 +359,13 @@ class TypeDictionary
     explicit TypeDictionary(CompileContext& cc);
 
     Type* find(int tag);
-    Type* find(sp::Atom* name);
+    Type* find(Atom* name);
 
     void init();
 
     Type* defineInt();
     Type* defineAny();
-    Type* defineFunction(sp::Atom* name, funcenum_t* fe);
+    Type* defineFunction(Atom* name, funcenum_t* fe);
     Type* defineTypedef(const char* name, Type* other);
     Type* defineString();
     Type* defineFloat();
@@ -372,8 +375,8 @@ class TypeDictionary
     Type* defineMethodmap(const char* name, methodmap_t* map);
     Type* defineEnumTag(const char* name);
     Type* defineEnumStruct(const char* name, symbol* sym);
-    Type* defineTag(sp::Atom* atom);
-    pstruct_t* definePStruct(sp::Atom* name);
+    Type* defineTag(Atom* atom);
+    pstruct_t* definePStruct(Atom* name);
 
     template <typename T>
     void forEachType(const T& callback) {
@@ -403,12 +406,12 @@ class TypeDictionary
 
   private:
     Type* add(const char* name, TypeKind kind);
-    Type* add(sp::Atom* name, TypeKind kind);
+    Type* add(Atom* name, TypeKind kind);
     void RegisterType(Type* type);
 
   private:
     CompileContext& cc_;
-    tr::unordered_map<sp::Atom*, Type*> types_;
+    tr::unordered_map<Atom*, Type*> types_;
     tr::unordered_map<int, Type*> tags_;
     Type* type_int_ = nullptr;
     Type* type_nullfunc_ = nullptr;
@@ -424,4 +427,4 @@ class TypeDictionary
 
 const char* pc_tagname(int tag);
 
-#endif // _INCLUDE_SOURCEPAWN_COMPILER_TYPES_H_
+} // namespace sp

--- a/libsmx/smx-builder.cpp
+++ b/libsmx/smx-builder.cpp
@@ -118,7 +118,7 @@ uint32_t SmxNameTable::add(StringPool& pool, const char* str, size_t len) {
   return add(pool.add(str, len));
 }
 
-uint32_t SmxNameTable::add(StringPool& pool, sp::Atom* atom) {
+uint32_t SmxNameTable::add(StringPool& pool, Atom* atom) {
   return add(pool, atom->str());
 }
 

--- a/libsmx/smx-builder.h
+++ b/libsmx/smx-builder.h
@@ -206,7 +206,7 @@ class SmxNameTable : public SmxSection
   uint32_t add(StringPool& pool, const char* str, size_t len);
   uint32_t add(StringPool& pool, const char* str);
   uint32_t add(StringPool& pool, const std::string& str);
-  uint32_t add(StringPool& pool, sp::Atom* atom);
+  uint32_t add(StringPool& pool, Atom* atom);
 
   uint32_t add(Atom* str) {
     auto iter = name_table_.find(str);

--- a/shared/pool-allocator.cpp
+++ b/shared/pool-allocator.cpp
@@ -25,7 +25,6 @@
 #include "pool-allocator.h"
 
 namespace sp {
-namespace cc {
 
 PoolAllocator::PoolAllocator()
 {
@@ -50,5 +49,4 @@ PoolAllocator::ensurePool(size_t actualBytes)
     return pools_.back().get();
 }
 
-} // namespace cc
 } // namespace sp

--- a/shared/pool-allocator.h
+++ b/shared/pool-allocator.h
@@ -35,7 +35,6 @@
 #include "shared/string-pool.h"
 
 namespace sp {
-namespace cc {
 
 // Allocates memory in chunks that are not freed until the entire allocator
 // is freed. This is intended for use with large, temporary data structures.
@@ -110,5 +109,4 @@ class PoolAllocator final
     }
 };
 
-} // namespace cc
 } // namespace sp


### PR DESCRIPTION
This is long overdue.

Unfortunately there are symbol conflicts with the vm, since PoolAllocator is duplicated. I've put that in a sub namespace for now.