### PR TITLE
Replace manual path mucking with std::filesystem.

### DIFF
--- a/compiler/builtins.h
+++ b/compiler/builtins.h
@@ -1,0 +1,34 @@
+// vim: set ts=8 sts=4 sw=4 tw=99 et:
+//  Pawn compiler - File input, preprocessing and lexical analysis functions
+//
+//  Copyright (c) 2023 AlliedModders LLC
+//
+//  This software is provided "as-is", without any express or implied warranty.
+//  In no event will the authors be held liable for any damages arising from
+//  the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1.  The origin of this software must not be misrepresented; you must not
+//      claim that you wrote the original software. If you use this software in
+//      a product, an acknowledgment in the product documentation would be
+//      appreciated but is not required.
+//  2.  Altered source versions must be plainly marked as such, and must not be
+//      misrepresented as being the original software.
+//  3.  This notice may not be removed or altered from any source distribution.
+
+#pragma once
+
+namespace sp {
+
+class BuiltinGenerator final {
+  public:
+    explicit BuiltinGenerator(CompileContext& cc);
+
+  private:
+    CompileContext& cc_;
+};
+
+} // namespace sp

--- a/compiler/errors.cpp
+++ b/compiler/errors.cpp
@@ -180,7 +180,7 @@ MessageBuilder::~MessageBuilder()
 
     if (report.fileno < cc.sources()->opened_files().size())
         report.file = cc.sources()->opened_files().at(report.fileno);
-    else
+    else if (!cc.sources()->opened_files().empty())
         report.file = cc.sources()->opened_files().at(0);
 
     uint32_t actual_line = cc.sources()->GetLineAndCol(where_, &report.col);
@@ -194,7 +194,8 @@ MessageBuilder::~MessageBuilder()
     report.type = DeduceErrorType(number_);
 
     std::ostringstream out;
-    out << report.file->name() << "(" << report.lineno << ") : ";
+    if (report.file)
+        out << report.file->name() << "(" << report.lineno << ") : ";
     out << GetErrorTypePrefix(report.type)
         << " " << ke::StringPrintf("%03d", report.number) << ": ";
 

--- a/compiler/lexer.h
+++ b/compiler/lexer.h
@@ -19,6 +19,8 @@
 //  3.  This notice may not be removed or altered from any source distribution.
 #pragma once
 
+#include <filesystem>
+
 #include <amtl/am-deque.h>
 #include <amtl/am-hashtable.h>
 #include <amtl/am-string.h>
@@ -310,7 +312,7 @@ class Lexer
 
     void Init(std::shared_ptr<SourceFile> sf);
     void Start();
-    bool PlungeFile(const char* name, int try_currentpath, int try_includepaths);
+    bool PlungeFile(const std::string& name, int try_currentpath, int try_includepaths);
     std::shared_ptr<SourceFile> OpenFile(const std::string& name);
     bool NeedSemicolon();
     void AddMacro(const char* pattern, const char* subst);
@@ -367,10 +369,10 @@ class Lexer
     void LexStringLiteral(full_token_t* tok, int flags);
     void LexSymbol(full_token_t* tok, Atom* atom);
     bool MaybeHandleLineContinuation();
-    bool PlungeQualifiedFile(const char* name);
+    bool PlungeQualifiedFile(const std::string& name);
     full_token_t* PushSynthesizedToken(TokenKind kind, const token_pos_t& pos);
     void SynthesizeIncludePathToken();
-    void SetFileDefines(std::string file);
+    void SetFileDefines(const std::string& file);
     void EnterFile(std::shared_ptr<SourceFile>&& fp, const token_pos_t& from);
     void FillTokenPos(token_pos_t* pos);
     void SkipLineWhitespace();
@@ -515,5 +517,7 @@ class Lexer
     std::deque<full_token_t> injected_token_stream_;
     bool caching_tokens_ = false;
 };
+
+std::string StringizePath(const std::filesystem::path& in_path);
 
 } // namespace sp

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -151,7 +151,7 @@ Parser::Parse()
                 if (!lexer_->need(tSYN_INCLUDE_PATH))
                     break;
                 auto name = lexer_->current_token()->data();
-                auto result = lexer_->PlungeFile(name.c_str() + 1, (name[0] != '<'), TRUE);
+                auto result = lexer_->PlungeFile(name.substr(1), (name[0] != '<'), TRUE);
                 if (!result && tok != tpTRYINCLUDE) {
                     report(417) << name.substr(1);
                     cc_.set_must_abort();
@@ -223,7 +223,7 @@ void Parser::CreateInitialScopes(std::vector<Stmt*>* stmts) {
     }
 
     if (!cc_.default_include().empty()) {
-        const char* incfname = cc_.default_include().c_str();
+        auto incfname = cc_.default_include();
         if (lexer_->PlungeFile(incfname, FALSE, TRUE)) {
             int fcurrent = lexer_->fcurrent();
             static_scopes_.emplace_back(new SymbolScope(cc_.globals(), sFILE_STATIC, fcurrent));

--- a/compiler/sc.h
+++ b/compiler/sc.h
@@ -64,13 +64,6 @@ namespace sp {
     '\x7f' /* termination character for preprocessor expressions (the "DEL" code) */
 #define sDEF_PREFIX "sourcemod.inc" /* default prefix filename */
 
-#ifdef _WIN32
-static constexpr char DIRSEP_CHAR = '\\';
-# define PATH_MAX _MAX_PATH
-#else
-static constexpr char DIRSEP_CHAR = '/';
-#endif
-
 struct DefaultArrayData;
 
 struct DefaultArg : public PoolObject {


### PR DESCRIPTION
This gets rid of DIRSEP_CHAR and a lot of manual string code.

It also fixes how file defines were created, which was mostly broken and working by accident.

Finally, it fixes a crash on the command-line if the input file was not found.