### PR TITLE
Remove support for function aliases.

### DIFF
--- a/compiler/assembler.cpp
+++ b/compiler/assembler.cpp
@@ -907,11 +907,7 @@ Assembler::Assemble(SmxByteBuffer* buffer)
         assert(size_t(sym->addr()) == i);
 
         sp_file_natives_t& entry = natives->add();
-
-        if (auto alias = sym->function()->alias)
-            entry.name = names->add(*cc_.atoms(), "@" + alias->nameAtom()->str());
-        else
-            entry.name = names->add(sym->nameAtom());
+        entry.name = names->add(sym->nameAtom());
 
         rtti.add_native(sym);
     }

--- a/compiler/code-generator.cpp
+++ b/compiler/code-generator.cpp
@@ -1868,11 +1868,6 @@ CodeGenerator::EmitCall(symbol* sym, cell nargs)
     assert(sym->used());
 
     if (sym->native) {
-        if (auto alias = sym->function()->alias) {
-            sym = alias;
-            assert(sym->used());
-        }
-
         if (sym->addr() < 0) {
             sym->setAddr((cell)native_list_.size());
             native_list_.emplace_back(sym);

--- a/compiler/messages.h
+++ b/compiler/messages.h
@@ -323,4 +323,5 @@ static const char* errmsg_ex[] = {
     /*439*/ "destructors cannot have return types\n",
     /*440*/ "destructor must have the same name as methodmap\n",
     /*441*/ "destructors cannot be static\n",
+    /*442*/ "method aliases are no longer supported\n",
 };

--- a/compiler/name-resolution.cpp
+++ b/compiler/name-resolution.cpp
@@ -939,13 +939,6 @@ FunctionDecl::Bind(SemaContext& outer_sc)
     if (body_)
         ok &= body_->Bind(sc);
 
-    if (sym_->native && alias_) {
-        auto alias_sym = FindSymbol(sc, alias_);
-        if (!alias_sym)
-            report(pos_, 17) << alias_;
-        sym_->function()->alias = alias_sym;
-    }
-
     if (ok && deprecate_) {
         sym_->documentation = new PoolString(deprecate_->chars(), deprecate_->length());
         sym_->deprecated = true;

--- a/compiler/parse-node.h
+++ b/compiler/parse-node.h
@@ -1547,8 +1547,6 @@ class FunctionDecl : public Decl
     const token_pos_t& end_pos() const { return end_pos_; }
     void set_end_pos(const token_pos_t& end_pos) { end_pos_ = end_pos; }
 
-    void set_alias(Atom* alias) { alias_ = alias; }
-
     const ke::Maybe<int>& this_tag() const { return this_tag_; }
     void set_this_tag(int this_tag) {
         if (this_tag != -1)
@@ -1624,7 +1622,6 @@ class FunctionDecl : public Decl
     symbol* sym_ = nullptr;
     SymbolScope* scope_ = nullptr;
     ke::Maybe<int> this_tag_;
-    Atom* alias_ = nullptr;
     PoolString* deprecate_ = nullptr;
     TokenCache* tokens_ = nullptr;
     bool analyzed_ SP_BITFIELD(1);

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -1754,9 +1754,8 @@ Parser::parse_function(FunctionDecl* fun, int tokid, bool has_this)
             lexer_->lexpush();
         }
         if (lexer_->match('=')) {
-            Atom* ident;
-            if (lexer_->needsymbol(&ident))
-                fun->set_alias(ident);
+            report(442);
+            lexer_->match(tSYMBOL);
         }
     }
 

--- a/compiler/symbols.cpp
+++ b/compiler/symbols.cpp
@@ -67,7 +67,6 @@ markusage(symbol* sym, int usage)
 FunctionData::FunctionData()
   : node(nullptr),
     forward(nullptr),
-    alias(nullptr),
     checked_one_signature(false),
     compared_prototype_args(false),
     is_member_function(false)
@@ -273,8 +272,6 @@ deduce_liveness(CompileContext& cc)
         for (const auto& other : live->function()->refers_to) {
             if (!enqueue(other))
                 continue;
-            if (auto alias = other->function()->alias)
-                enqueue(alias);
         }
     }
 }

--- a/compiler/symbols.h
+++ b/compiler/symbols.h
@@ -59,7 +59,6 @@ class FunctionData final : public SymbolData
     ReturnArrayInfo* return_array = nullptr;
     FunctionDecl* node;
     FunctionDecl* forward;
-    symbol* alias;
     symbol* array_return = nullptr;
     Label label;     // modern replacement for addr
     Label funcid;

--- a/include/core/float.inc
+++ b/include/core/float.inc
@@ -45,18 +45,18 @@ native bool __float_not(float a);
 native int __float_to_int(float a);
 native float float(int value);
 
-native float operator*(float oper1, float oper2) = __float_mul;
-native float operator/(float oper1, float oper2) = __float_div;
-native float operator+(float oper1, float oper2) = __float_add;
-native float operator-(float oper1, float oper2) = __float_sub;
-native float operator%(float oper1, float oper2) = __float_mod;
-native bool operator!(float oper1) = __float_not;
-native bool operator>(float oper1, float oper2) = __float_gt;
-native bool operator>=(float oper1, float oper2) = __float_ge;
-native bool operator<(float oper1, float oper2) = __float_lt;
-native bool operator<=(float oper1, float oper2) = __float_le;
-native bool operator!=(float oper1, float oper2) = __float_ne;
-native bool operator==(float oper1, float oper2) = __float_eq;
+stock float operator*(float oper1, float oper2) { return __float_mul(oper1, oper2); }
+stock float operator/(float oper1, float oper2) { return __float_div(oper1, oper2); }
+stock float operator+(float oper1, float oper2) { return __float_add(oper1, oper2); }
+stock float operator-(float oper1, float oper2) { return __float_sub(oper1, oper2); }
+stock float operator%(float oper1, float oper2) { return __float_mod(oper1, oper2); }
+stock bool operator!(float oper1) { return __float_not(oper1); }
+stock bool operator>(float oper1, float oper2) { return __float_gt(oper1, oper2); }
+stock bool operator>=(float oper1, float oper2) { return __float_ge(oper1, oper2); }
+stock bool operator<(float oper1, float oper2) { return __float_lt(oper1, oper2); }
+stock bool operator<=(float oper1, float oper2) { return __float_le(oper1, oper2); }
+stock bool operator!=(float oper1, float oper2) { return __float_ne(oper1, oper2); }
+stock bool operator==(float oper1, float oper2) { return __float_eq(oper1, oper2); }
 
 stock float operator++(float oper)
 {

--- a/tests/sourcemod/include/float.inc
+++ b/tests/sourcemod/include/float.inc
@@ -277,11 +277,11 @@ stock int RoundFloat(float value)
 #if !defined __sourcepawn2__
 
 // Internal aliases for backwards compatibility.
-native float __FLOAT_MUL__(float a, float b) = FloatMul;
-native float __FLOAT_DIV__(float a, float b) = FloatDiv;
-native float __FLOAT_ADD__(float a, float b) = FloatAdd;
-native float __FLOAT_SUB__(float a, float b) = FloatSub;
-native float __FLOAT_MOD__(float a, float b) = FloatMod;
+native float __FLOAT_MUL__(float a, float b);
+native float __FLOAT_DIV__(float a, float b);
+native float __FLOAT_ADD__(float a, float b);
+native float __FLOAT_SUB__(float a, float b);
+native float __FLOAT_MOD__(float a, float b);
 
 native bool __FLOAT_GT__(float a, float b);
 native bool __FLOAT_GE__(float a, float b);
@@ -291,18 +291,18 @@ native bool __FLOAT_EQ__(float a, float b);
 native bool __FLOAT_NE__(float a, float b);
 native bool __FLOAT_NOT__(float a);
 
-native float operator*(float oper1, float oper2) = FloatMul;
-native float operator/(float oper1, float oper2) = FloatDiv;
-native float operator+(float oper1, float oper2) = FloatAdd;
-native float operator-(float oper1, float oper2) = FloatSub;
-native float operator%(float oper1, float oper2) = FloatMod;
-native bool operator!(float oper1) = __FLOAT_NOT__;
-native bool operator>(float oper1, float oper2) = __FLOAT_GT__;
-native bool operator>=(float oper1, float oper2) = __FLOAT_GE__;
-native bool operator<(float oper1, float oper2) = __FLOAT_LT__;
-native bool operator<=(float oper1, float oper2) = __FLOAT_LE__;
-native bool operator!=(float oper1, float oper2) = __FLOAT_NE__;
-native bool operator==(float oper1, float oper2) = __FLOAT_EQ__;
+stock float operator*(float oper1, float oper2) { return __FLOAT_MUL__(oper1, oper2); }
+stock float operator/(float oper1, float oper2) { return __FLOAT_DIV__(oper1, oper2); }
+stock float operator+(float oper1, float oper2) { return __FLOAT_ADD__(oper1, oper2); }
+stock float operator-(float oper1, float oper2) { return __FLOAT_SUB__(oper1, oper2); }
+stock float operator%(float oper1, float oper2) { return __FLOAT_MOD__(oper1, oper2); }
+stock bool operator!(float oper1) { return __FLOAT_NOT__(oper1); }
+stock bool operator>(float oper1, float oper2) { return __FLOAT_GT__(oper1, oper2); }
+stock bool operator>=(float oper1, float oper2) { return __FLOAT_GE__(oper1, oper2); }
+stock bool operator<(float oper1, float oper2) { return __FLOAT_LT__(oper1, oper2); }
+stock bool operator<=(float oper1, float oper2) { return __FLOAT_LE__(oper1, oper2); }
+stock bool operator!=(float oper1, float oper2) { return __FLOAT_NE__(oper1, oper2); }
+stock bool operator==(float oper1, float oper2) { return __FLOAT_EQ__(oper1, oper2); }
 
 stock float operator++(float oper)
 {


### PR DESCRIPTION
This was an obscure feature used to make float.inc easier to write. It was also briefly used to make methmodmaps easier to write. However it's full of idiosyncracies and there is no type checking whatsoever for aliases.

This will require a tiny bit of fixup on the SourceMod side, but otherwise has no impact. The corpus will fail until SM is updated.