### PR TITLE
Convert most calls of CheckExpr to require a valid r-value.

### DIFF
--- a/compiler/semantics.h
+++ b/compiler/semantics.h
@@ -216,6 +216,8 @@ class Semantics final
     bool CheckStaticFieldAccessExpr(FieldAccessExpr* expr);
     bool CheckEnumStructFieldAccessExpr(FieldAccessExpr* expr, Type* type, EnumStructDecl* root,
                                         bool from_call);
+    bool CheckRvalue(Expr* expr);
+    bool CheckRvalue(const token_pos_t& pos, const value& val);
 
     bool CheckAssignmentLHS(BinaryExpr* expr);
     bool CheckAssignmentRHS(BinaryExpr* expr);

--- a/tests/compile-only/fail-property-rvalue-no-getter.sp
+++ b/tests/compile-only/fail-property-rvalue-no-getter.sp
@@ -1,0 +1,23 @@
+#include <shell>
+
+methodmap Method < Handle
+{
+    public Method(int whatever) {
+        return view_as<Method>(whatever);
+    }
+    // this will cause compiler error, and it won't report anything.
+    property int m_nBugTrigger {
+        // public int get() {return 1;} // if we comment this, then it will trigger error.
+        public set(int val) {
+            if (this.m_nBugTrigger > 5) {
+            } else {
+            }
+        }
+    }
+}
+
+public main() {
+  // Just simply call it
+  Method m = new Method(1);
+  m.m_nBugTrigger = 1; // then error here.
+}

--- a/tests/compile-only/fail-property-rvalue-no-getter.txt
+++ b/tests/compile-only/fail-property-rvalue-no-getter.txt
@@ -1,0 +1,1 @@
+(12) : error 149: no getter found for property m_nBugTrigger


### PR DESCRIPTION
Long-term, most simple calls to CheckRvalue should return a new RvalueExpr, but our current AST has no sane way to be rebuilt bottom-up.

Bug: issue #844
Test: new test case