### PR TITLE
Clean up pstruct implementation details.

### DIFF
--- a/compiler/expressions.h
+++ b/compiler/expressions.h
@@ -43,7 +43,6 @@ int NextExprOp(Lexer* lexer, int* opidx, int* list);
 struct UserOperation;
 bool find_userop(SemaContext& sc, int oper, int tag1, int tag2, int numparam,
                  const value* lval, UserOperation* op);
-void emit_userop(const UserOperation& user_op, value* lval);
 
 int commutative(int oper);
 cell calc(cell left, int oper_tok, cell right, char* boolresult);
@@ -53,8 +52,6 @@ int matchtag_commutative(int formaltag, int actualtag, int flags);
 int matchtag_string(int ident, int tag);
 int checkval_string(const value* sym1, const value* sym2);
 int checktag_string(int tag, const value* sym1);
-void user_inc();
-void user_dec();
 int checktag(int tag, int exprtag);
 
 } // namespace sp

--- a/compiler/parse-node.cpp
+++ b/compiler/parse-node.cpp
@@ -313,4 +313,12 @@ IdentifierKind Decl::ident_impl() {
     }
 }
 
+LayoutFieldDecl* PstructDecl::FindField(Atom* name) {
+    for (const auto& field : fields_) {
+        if (field->name() == name)
+            return field;
+    }
+    return nullptr;
+}
+
 } // namespace sp

--- a/compiler/parse-node.h
+++ b/compiler/parse-node.h
@@ -53,6 +53,7 @@ struct UserOperation
 typedef void (*OpFunc)();
 
 class Expr;
+class LayoutFieldDecl;
 class MethodmapDecl;
 class MethodmapMethodDecl;
 class SemaContext;
@@ -493,26 +494,14 @@ class EnumDecl : public Decl
     MethodmapDecl* mm_ = nullptr;
 };
 
-struct StructField {
-    StructField(const token_pos_t& pos, Atom* name, const typeinfo_t& typeinfo)
-      : pos(pos), name(name), type(typeinfo), field(nullptr)
-    {}
-
-    token_pos_t pos;
-    Atom* name;
-    typeinfo_t type;
-    structarg_t* field;
-};
-
 // "Pawn Struct", or p-struct, a hack to effect a replacement for register_plugin()
 // when SourceMod was first being prototyped. Theoretically these could be retooled
 // as proper structs.
 class PstructDecl : public Decl
 {
   public:
-    PstructDecl(const token_pos_t& pos, Atom* name, const std::vector<StructField>& fields)
+    PstructDecl(const token_pos_t& pos, Atom* name, const std::vector<LayoutFieldDecl*>& fields)
       : Decl(StmtKind::PstructDecl, pos, name),
-        ps_(nullptr),
         fields_(fields)
     {}
 
@@ -522,11 +511,12 @@ class PstructDecl : public Decl
 
     static bool is_a(Stmt* node) { return node->kind() == StmtKind::PstructDecl; }
 
-    PoolArray<StructField>& fields() { return fields_; }
+    LayoutFieldDecl* FindField(Atom* name);
+
+    PoolArray<LayoutFieldDecl*>& fields() { return fields_; }
 
   protected:
-    pstruct_t* ps_;
-    PoolArray<StructField> fields_;
+    PoolArray<LayoutFieldDecl*> fields_;
 };
 
 struct TypedefInfo : public PoolObject {

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -494,7 +494,7 @@ Parser::parse_pstruct()
     Atom* ident = nullptr;
     lexer_->needsymbol(&ident);
 
-    std::vector<StructField> fields;
+    std::vector<LayoutFieldDecl*> fields;
 
     lexer_->need('{');
     do {
@@ -515,7 +515,7 @@ Parser::parse_pstruct()
         }
 
         if (ident)
-            fields.push_back(StructField(pos, decl.name, decl.type));
+            fields.push_back(new LayoutFieldDecl(pos, decl));
 
         lexer_->require_newline(TerminatorPolicy::NewlineOrSemicolon);
     } while (!lexer_->peek('}'));

--- a/compiler/semantics.h
+++ b/compiler/semantics.h
@@ -189,7 +189,7 @@ class Semantics final
     bool CheckVarDecl(VarDeclBase* decl);
     bool CheckConstDecl(VarDecl* decl);
     bool CheckPstructDecl(VarDeclBase* decl);
-    bool CheckPstructArg(VarDeclBase* decl, const pstruct_t* ps,
+    bool CheckPstructArg(VarDeclBase* decl, PstructDecl* ps,
                          const StructInitFieldExpr* field, std::vector<bool>* visited);
 
     // Expressions.

--- a/compiler/types.cpp
+++ b/compiler/types.cpp
@@ -28,6 +28,7 @@
 #include <utility>
 
 #include "compile-context.h"
+#include "parse-node.h"
 #include "sc.h"
 #include "sctracker.h"
 #include "types.h"
@@ -42,7 +43,6 @@ Type::Type(Atom* name, TypeKind kind)
    fixed_(0),
    kind_(kind)
 {
-    private_ptr_ = nullptr;
 }
 
 const char*
@@ -61,7 +61,7 @@ Type::kindName() const
   switch (kind_) {
     case TypeKind::EnumStruct:
       return "enum struct";
-    case TypeKind::Struct:
+    case TypeKind::Pstruct:
       return "struct";
     case TypeKind::Methodmap:
       return "methodmap";
@@ -220,11 +220,11 @@ TypeManager::defineTag(Atom* name) {
     return type;
 }
 
-pstruct_t* TypeManager::definePStruct(Atom* name) {
-    assert(find(name) == nullptr);
+Type* TypeManager::definePstruct(PstructDecl* decl) {
+    assert(find(decl->name()) == nullptr);
 
-    pstruct_t* type = new pstruct_t(name);
-    RegisterType(type);
+    Type* type = add(decl->name(), TypeKind::Pstruct);
+    type->setPstruct(decl);
     return type;
 }
 
@@ -242,14 +242,6 @@ typeinfo_t::isCharArray() const
 {
     auto types = CompileContext::get().types();
     return numdim() == 1 && tag() == types->tag_string();
-}
-
-const structarg_t* pstruct_t::GetArg(Atom* name) const {
-    for (const auto& arg : args) {
-        if (arg->name == name)
-            return arg;
-    }
-    return nullptr;
 }
 
 } // namespace sp


### PR DESCRIPTION
Pstructs had ancillary structures that were completely obviated by AST types. Remove these and refactor callers.