### PR TITLE
Forbid spontaneous tag creation (aka, tag removal part 2).

### DIFF
--- a/compiler/name-resolution.cpp
+++ b/compiler/name-resolution.cpp
@@ -101,13 +101,8 @@ bool SemaContext::BindType(const token_pos_t& pos, Atom* atom, bool is_label, Ty
 
     Type* type = types->find(atom);
     if (!type) {
-        if (!is_label) {
-            report(pos, 139) << atom;
-            return false;
-        }
-
-        *out_type = types->defineTag(atom);
-        return true;
+        report(pos, 139) << atom;
+        return false;
     }
 
     *out_type = type;


### PR DESCRIPTION
Many years ago we introduced Transitional Syntax. Well, this tiny patch is the start of the transition to just "syntax".

In the original Pawn language, tags were applied via labels, and labels could appear anywhere. There was no formal method for creating them: they simply existed as soon as they were used, and they behaved as if there was an empty enum declared at global scope, even if the tag was used locally.

This behavior is difficult to preserve, much less properly define, and the globalness is particularly troublesome. By disabling this feature, we're guaranteed that every type name references a type declaration in the same scope chain.

This breaks 28 plugins in the corpus - a happily small number. These plugins all have weird typos or are using labels in incomprehensible ways. So, this esoteric language feature won't be missed.