### PR TITLE
Unused arguments in stock functions are now triggering warnings

### DIFF
--- a/compiler/name-resolution.cpp
+++ b/compiler/name-resolution.cpp
@@ -892,7 +892,7 @@ FunctionDecl::BindArgs(SemaContext& sc)
 
         if (var->type_info().ident == iREFERENCE)
             var->set_is_read();
-        if (is_callback_ || is_stock_ || is_public_)
+        if (is_callback_ || is_public_)
             var->set_is_read();
 
         /* arguments of a public function may not have a default value */

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -2494,9 +2494,9 @@ bool Semantics::TestSymbol(Decl* sym, bool testconst) {
         default: {
             auto var = sym->as<VarDeclBase>();
             /* a variable */
-            if (!var->is_stock() && !var->is_used() && !var->is_public()) {
-                report(sym, 203) << sym->name(); /* symbol isn't used (and not stock) */
-            } else if (!var->is_stock() && !var->is_public() && !var->is_read()) {
+            if (!var->is_used() && !var->is_public()) {
+                report(sym, 203) << sym->name(); /* symbol isn't used (and not public) */
+            } else if (!var->is_public() && !var->is_read()) {
                 report(sym, 204) << sym->name(); /* value assigned to symbol is never used */
             }
         }

--- a/tests/compile-only/ok-argument-shadows-function.sp
+++ b/tests/compile-only/ok-argument-shadows-function.sp
@@ -5,6 +5,8 @@ int min(int a, int b) {
 }
 
 stock void test(float min, float max) {
+#pragma unused min
+#pragma unused max
 }
 
 public main() {

--- a/tests/compile-only/warn-unused-arg.sp
+++ b/tests/compile-only/warn-unused-arg.sp
@@ -1,0 +1,23 @@
+public void main()
+{
+	public_func(0);
+	normal_func(0);
+	static_func(0);
+	stock_func(0);
+}
+
+public void public_func(int n)
+{
+}
+
+void normal_func(int n)
+{
+}
+
+static void static_func(int n)
+{
+}
+
+stock void stock_func(int n)
+{
+}

--- a/tests/compile-only/warn-unused-arg.txt
+++ b/tests/compile-only/warn-unused-arg.txt
@@ -1,0 +1,3 @@
+(13) : warning 203: symbol is never used: "n"
+(17) : warning 203: symbol is never used: "n"
+(21) : warning 203: symbol is never used: "n"


### PR DESCRIPTION
These changes fix #784

`tests/compile-only/warn-unused-arg.sp` adds coverage for unused arguments in `public`, `static`, `stock` and regular functions

Note that `tests/compile-only/ok-argument-shadows-function.sp` had to be modified (`#pragma unused` added) to take into account that arguments should now be used in stock functions.


Feel free to tell me if I missed anything!