### PR TITLE
Remove iREFERENCE and add a new reference type.

### DIFF
--- a/compiler/assembler.cpp
+++ b/compiler/assembler.cpp
@@ -558,7 +558,7 @@ uint32_t RttiBuilder::encode_signature(FunctionDecl* fun) {
         Type* type = arg->type();
         int numdim = arg->type_info().numdim();
 
-        if (arg->type_info().ident == iREFERENCE)
+        if (arg->type()->isReference())
             bytes.push_back(cb::kByRef);
 
         std::vector<int> dims;
@@ -736,7 +736,7 @@ RttiBuilder::encode_signature_into(std::vector<uint8_t>& bytes, functag_t* ft)
         encode_type_into(bytes, ft->ret_type);
 
     for (const auto& arg : ft->args) {
-        if (arg.ident == iREFERENCE)
+        if (arg.reference)
             bytes.push_back(cb::kByRef);
 
         std::vector<int> dims;

--- a/compiler/expressions.cpp
+++ b/compiler/expressions.cpp
@@ -384,6 +384,16 @@ static bool HasTagOnInheritanceChain(Type* type, Type* other) {
 }
 
 bool matchtag(Type* formal, Type* actual, int flags) {
+    Type* given_formal = formal;
+    Type* given_actual = actual;
+
+    if (flags & MATCHTAG_COERCE) {
+        if (formal->isReference())
+            formal = formal->inner();
+        if (actual->isReference())
+            actual = actual->inner();
+    }
+
     if (formal == actual)
         return true;
 
@@ -401,7 +411,7 @@ bool matchtag(Type* formal, Type* actual, int flags) {
 
     if (formal->asEnumStruct() || actual->asEnumStruct()) {
         if (formal != actual) {
-            report(134) << formal << actual;
+            report(134) << given_formal << given_actual;
             return false;
         }
         return true;
@@ -454,7 +464,7 @@ bool matchtag(Type* formal, Type* actual, int flags) {
     }
 
     if (!(flags & MATCHTAG_SILENT))
-        report(213) << formal << actual;
+        report(213) << given_formal << given_actual;
     return false;
 }
 

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -2254,7 +2254,7 @@ Parser::parse_old_decl(declinfo_t* decl, int flags)
     int numtags = 0;
     if (flags & DECLFLAG_ARGUMENT) {
         if (lexer_->match('&'))
-            type->ident = iREFERENCE;
+            type->reference = true;
 
         // grammar for multitags is:
         //   multi-tag ::= '{' (symbol (',' symbol)*)? '}' ':'
@@ -2478,7 +2478,7 @@ Parser::parse_post_array_dims(declinfo_t* decl, int flags)
     typeinfo_t* type = &decl->type;
 
     // Illegal declaration (we'll have a name since ref requires decl).
-    if (type->ident == iREFERENCE)
+    if (type->reference)
         report(67) << decl->name;
 
     parse_post_dims(type);
@@ -2532,7 +2532,7 @@ Parser::parse_new_typeexpr(typeinfo_t* type, const full_token_t* first, int flag
             if (type->ident == iARRAY || type->ident == iREFARRAY)
                 report(137);
             else
-                type->ident = iREFERENCE;
+                type->reference = true;
         }
     }
 

--- a/compiler/smx-assembly-buffer.h
+++ b/compiler/smx-assembly-buffer.h
@@ -148,7 +148,7 @@ class SmxAssemblyBuffer : public ByteBuffer
   }
 
   void address(VarDeclBase* sym, regid reg) {
-    if (sym->ident() == iREFARRAY || sym->ident() == iREFERENCE ||
+    if (sym->ident() == iREFARRAY || sym->type()->isReference() ||
         (sym->type()->isEnumStruct() && sym->vclass() == sARGUMENT))
     {
       if (reg == sPRI)

--- a/compiler/value-inl.h
+++ b/compiler/value-inl.h
@@ -76,8 +76,6 @@ inline bool value::canRematerialize() const {
         case iVARIABLE:
         case iCONSTEXPR:
             return true;
-        case iREFERENCE:
-            return sym->vclass() == sARGUMENT || sym->vclass() == sLOCAL;
         default:
             return false;
     }


### PR DESCRIPTION
Historically, Pawn constructed critical type information from two sources of information: the tag, and the identifier kind. The identifier kind describes whether the value refers to an array, variable, expression result, reference, etc.

IdentifierKind is hugely problematic since it's not formally part of the type. This means it can't participate in things like matchtag() and find_userop(). It also creates situations where the two can become out of sync. For example, changing iREFERENCE to iVARIABLE without an RvalueExpr is a bug that is no longer possible.

With the recent removal of "semantic tags", we were able to remove iENUMSTRUCT. Now, we are removing iREFERENCE, and creating a new reference type. As before, this requires some auditing and additional type checks. Mostly though, it is a simplification, since iVARIABLE and iREFERENCE are equivalent in most code paths.