### PR TITLE
Add macro to string conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@
 *.suo
 *.user
 
+# IDEA
+.idea/
+
 # Build directories
 CrazyDebug*/
 Debug*/

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -2571,8 +2571,17 @@ std::string Lexer::PerformMacroSubstitution(MacroEntry* macro,
             out.push_back(substitute[pos + 1]);
             continue;
         }
-        if (stringize)
-            out += '"' + iter->second + '"';
+        if (stringize) {
+            out += '"';
+
+            auto arg_macro = FindMacro(cc_.atom(iter->second));
+            if (arg_macro != nullptr && !arg_macro->args)
+                out += arg_macro->substitute->str();
+            else
+                out += iter->second;
+
+            out += '"';
+        }
         else
             out += iter->second;
     }


### PR DESCRIPTION
The change allows you to convert a macro (which has no args) to string.

Related to alliedmodders/sourcepawn#943

---
#### Where can this be used?
In code/libraries, you can often see duplication of constants in numeric and string values (versions, parameters, etc). This creates inconvenience that one value needs to be edited in several places.
In general, if you want to quickly convert some predefined value to a string, then this can be done at the compilation stage.

---
#### A few notes:
I tried to implement "in-depth" macro parsing, but often I had to rewrite an existing function due to the inability to use custom streams. Perhaps such functionality is not needed in sp.
I also noticed that something similar had already been done in the experimental part, but for some reason it was abandoned.

imho, this is the simplest solution

