### PR TITLE
Eliminate stack arrays.

### DIFF
--- a/compiler/assembler.cpp
+++ b/compiler/assembler.cpp
@@ -441,7 +441,7 @@ RttiBuilder::add_enumstruct(Type* type)
     typeid_cache_.add(p, type, es_index);
 
     smx_rtti_enumstruct es = {};
-    es.name = names_->add(*cc_.atoms(), type->name());
+    es.name = names_->add(*cc_.atoms(), type->declName());
     es.first_field = es_fields_->count();
     es.size = es_decl->array_size();
     enumstructs_->add(es);
@@ -585,7 +585,7 @@ RttiBuilder::add_enum(Type* type)
 
     smx_rtti_enum entry;
     memset(&entry, 0, sizeof(entry));
-    entry.name = names_->add(*cc_.atoms(), type->name());
+    entry.name = names_->add(*cc_.atoms(), type->declName());
     enums_->add(entry);
     return index;
 }
@@ -607,7 +607,7 @@ RttiBuilder::add_funcenum(Type* type, funcenum_t* fe)
     uint32_t signature = type_pool_.add(bytes);
 
     smx_rtti_typedef& def = typedefs_->at(index);
-    def.name = names_->add(*cc_.atoms(), type->name());
+    def.name = names_->add(*cc_.atoms(), type->declName());
     def.type_id = MakeTypeId(signature, kTypeId_Complex);
     return index;
 }
@@ -632,7 +632,7 @@ RttiBuilder::add_typeset(Type* type, funcenum_t* fe)
         encode_signature_into(bytes, iter);
 
     smx_rtti_typeset& entry = typesets_->at(index);
-    entry.name = names_->add(*cc_.atoms(), type->name());
+    entry.name = names_->add(*cc_.atoms(), type->declName());
     entry.signature = type_pool_.add(bytes);
     return index;
 }

--- a/compiler/code-generator.cpp
+++ b/compiler/code-generator.cpp
@@ -327,11 +327,7 @@ CodeGenerator::EmitLocalVar(VarDeclBase* decl)
     bool is_struct = (decl->ident() == iVARIABLE && decl->type()->isEnumStruct());
 
     if (decl->ident() == iVARIABLE && !is_struct) {
-        cell_t cells = 1;
-        if (auto es = decl->type()->asEnumStruct())
-            cells = es->array_size();
-
-        markstack(decl, MEMUSE_STATIC, cells);
+        markstack(decl, MEMUSE_STATIC, 1);
         decl->BindAddress(-current_stack_ * sizeof(cell));
 
         if (init) {
@@ -348,14 +344,9 @@ CodeGenerator::EmitLocalVar(VarDeclBase* decl)
                 EmitExpr(init->right());
                 __ emit(OP_PUSH_PRI);
             }
-        } else if (cells == 1) {
+        } else {
             // Note: we no longer honor "decl" for scalars.
             __ emit(OP_PUSH_C, 0);
-        } else {
-            __ emit(OP_STACK, -(cells * sizeof(cell_t)));
-            __ emit(OP_CONST_PRI, 0);
-            __ emit(OP_ADDR_ALT, decl->addr());
-            __ emit(OP_FILL, cells * sizeof(cell_t));
         }
     } else if (decl->ident() == iARRAY || is_struct) {
         ArrayData array;

--- a/compiler/messages.h
+++ b/compiler/messages.h
@@ -331,4 +331,5 @@ static const char* errmsg_ex[] = {
     /*446*/ "enum structs are not allowed in legacy structs\n",
     /*447*/ "invalid use of enum struct in expression\n",
     /*448*/ "invalid enum struct initializer\n",
+    /*449*/ "cannot use type \"%s\" in an operator overload\n",
 };

--- a/compiler/name-resolution.cpp
+++ b/compiler/name-resolution.cpp
@@ -836,7 +836,7 @@ FunctionDecl::BindArgs(SemaContext& sc)
         Type* type = typeinfo.type;
         if (type->isEnumStruct()) {
             if (is_native_)
-                report(var->pos(), 135) << type->name();
+                report(var->pos(), 135) << type;
         }
 
         /* Stack layout:
@@ -937,7 +937,12 @@ Atom* FunctionDecl::NameForOperator() {
             report(pos_, 59) << var->name();
         count++;
 
-        params.emplace_back(var->type()->name()->str());
+        if (!var->type()->canOperatorOverload()) {
+            report(pos_, 449) << var->type();
+            continue;
+        }
+
+        params.emplace_back(var->type()->declName()->str());
     }
 
     /* for '!', '++' and '--', count must be 1

--- a/compiler/name-resolution.cpp
+++ b/compiler/name-resolution.cpp
@@ -397,12 +397,12 @@ ConstDecl::Bind(SemaContext& sc)
 }
 
 bool VarDeclBase::Bind(SemaContext& sc) {
-    if (!sc.BindType(pos(), &type_))
-        return false;
-
     // |int x = x| should bind to outer x, not inner.
     if (init_)
         init_rhs()->Bind(sc);
+
+    if (!sc.BindType(pos(), &type_))
+        return false;
 
     if (type_.ident == iARRAY)
         ResolveArraySize(sc.sema(), this);

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -174,7 +174,7 @@ bool Semantics::CheckVarDecl(VarDeclBase* decl) {
     if (type.ident == iARRAY || type.ident == iREFARRAY || type.type->isEnumStruct()) {
         if (!CheckArrayDeclaration(decl))
             return false;
-        if (decl->vclass() == sLOCAL && decl->ident() == iREFARRAY)
+        if (decl->vclass() == sLOCAL)
             pending_heap_allocation_ = true;
         return true;
     }

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -3386,7 +3386,7 @@ int argcompare(ArgDecl* a1, ArgDecl* a2) {
 bool IsLegacyEnumType(SymbolScope* scope, Type* type) {
     if (!type->isEnum())
         return false;
-    auto decl = FindSymbol(scope, type->nameAtom());
+    auto decl = FindSymbol(scope, type->name());
     if (!decl)
         return false;
     if (auto ed = decl->as<EnumDecl>())

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -1323,7 +1323,7 @@ bool Semantics::CheckCastExpr(CastExpr* expr) {
     } else if (out_val.type()->isVoid()) {
         report(expr, 89);
     } else if (atype->isEnumStruct() || ltype->isEnumStruct()) {
-        report(expr, 95) << atype->name();
+        report(expr, 95) << atype;
     }
     if (ltype->isReference() && !atype->isReference()) {
         if (atype->isEnumStruct()) {
@@ -1821,7 +1821,7 @@ bool Semantics::CheckEnumStructFieldAccessExpr(FieldAccessExpr* expr, Type* type
 
     auto field_decl = expr->resolved();
     if (!field_decl) {
-        report(expr, 105) << type->name() << expr->name();
+        report(expr, 105) << type << expr->name();
         return false;
     }
 
@@ -1879,7 +1879,7 @@ bool Semantics::CheckStaticFieldAccessExpr(FieldAccessExpr* expr) {
     Type* type = base_val.type();
     Decl* field = FindEnumStructField(type, expr->name());
     if (!field) {
-        report(expr, 105) << type->name() << expr->name();
+        report(expr, 105) << type << expr->name();
         return false;
     }
 
@@ -3386,7 +3386,7 @@ int argcompare(ArgDecl* a1, ArgDecl* a2) {
 bool IsLegacyEnumType(SymbolScope* scope, Type* type) {
     if (!type->isEnum())
         return false;
-    auto decl = FindSymbol(scope, type->name());
+    auto decl = FindSymbol(scope, type->declName());
     if (!decl)
         return false;
     if (auto ed = decl->as<EnumDecl>())

--- a/compiler/smx-assembly-buffer.h
+++ b/compiler/smx-assembly-buffer.h
@@ -149,13 +149,17 @@ class SmxAssemblyBuffer : public ByteBuffer
 
   void address(VarDeclBase* sym, regid reg) {
     if (sym->ident() == iREFARRAY || sym->type()->isReference() ||
-        (sym->type()->isEnumStruct() && sym->vclass() == sARGUMENT))
+        (sym->ident() == iARRAY && sym->vclass() == sLOCAL) ||
+        (sym->type()->isEnumStruct() && (sym->vclass() == sARGUMENT || sym->vclass() == sLOCAL)))
     {
       if (reg == sPRI)
         emit(OP_LOAD_S_PRI, sym->addr());
       else
         emit(OP_LOAD_S_ALT, sym->addr());
     } else {
+      if (sym->ident() == iARRAY) {
+        assert(sym->vclass() == sGLOBAL || sym->vclass() == sSTATIC);
+      }
       if (reg == sPRI) {
         if (sym->vclass() == sLOCAL || sym->vclass() == sARGUMENT)
           emit(OP_ADDR_PRI, sym->addr());

--- a/compiler/types.cpp
+++ b/compiler/types.cpp
@@ -46,7 +46,7 @@ Type::Type(Atom* name, TypeKind kind)
 const char* Type::prettyName() const {
   if (kind_ == TypeKind::Function)
     return kindName();
-  return name()->chars();
+  return declName()->chars();
 }
 
 const char*
@@ -75,6 +75,10 @@ Type::kindName() const
     default:
       return "type";
   }
+}
+
+bool Type::canOperatorOverload() const {
+    return isEnum() || isMethodmap() || isFloat() || isInt();
 }
 
 TypeManager::TypeManager(CompileContext& cc)
@@ -107,8 +111,8 @@ void TypeManager::RegisterType(Type* type, bool unique_name) {
     by_index_.emplace_back(type);
 
     if (unique_name) {
-        assert(types_.find(type->name()) == types_.end());
-        types_.emplace(type->name(), type);
+        assert(types_.find(type->declName()) == types_.end());
+        types_.emplace(type->declName(), type);
     }
 }
 
@@ -201,7 +205,7 @@ Type* TypeManager::defineReference(Type* inner) {
     if (auto it = ref_types_.find(inner); it != ref_types_.end())
         return it->second;
 
-    auto name = inner->name()->str() + "&";
+    auto name = inner->declName()->str() + "&";
     Type* type = new Type(cc_.atom(name), TypeKind::Reference);
     type->setReference(inner);
     RegisterType(type, false);

--- a/compiler/types.h
+++ b/compiler/types.h
@@ -213,9 +213,7 @@ class Type : public PoolObject
   public:
     Type(Atom* name, TypeKind kind);
 
-    Atom* name() const {
-        return name_;
-    }
+    Atom* declName() const { return name_; }
     TypeKind kind() const { return kind_; }
     const char* kindName() const;
     const char* prettyName() const;
@@ -243,6 +241,8 @@ class Type : public PoolObject
     bool isFloat() const { return isBuiltin(BuiltinType::Float); }
     bool isBool() const { return isBuiltin(BuiltinType::Bool); }
     bool isReference() const { return kind_ == TypeKind::Reference; }
+
+    bool canOperatorOverload() const;
 
     bool coercesFromInt() const {
         if (kind_ == TypeKind::Enum)

--- a/compiler/types.h
+++ b/compiler/types.h
@@ -216,7 +216,6 @@ class Type : public PoolObject
     Atom* name() const {
         return name_;
     }
-    Atom* nameAtom() const { return name_; }
     TypeKind kind() const { return kind_; }
     const char* kindName() const;
     const char* prettyName() const;

--- a/vm/opcodes.cpp
+++ b/vm/opcodes.cpp
@@ -154,6 +154,11 @@ SpewOpcode(FILE* fp, PluginRuntime* runtime, const cell_t* start, const cell_t* 
       fprintf(fp, "%d, %d, %d, %d, %d", cip[1], cip[2], cip[3], cip[4], cip[5]);
       break;
 
+    case OP_INITARRAY_PRI:
+    case OP_INITARRAY_ALT:
+      fprintf(fp, "%d %d %d %d %d", cip[1], cip[2], cip[3], cip[4], cip[5]);
+      break;
+
     default:
       break;
   }


### PR DESCRIPTION
The only real difference between iARRAY and iREFARRAY is that local
iARRAYs are allocated on the stack, whereas iREFARRAY declarations are
allocated on the heap (with GENARRAY).

Long-term, all arrays should be allocated in the VM, not the compiler.
Let's bite the bullet now and remove this oddity. This will make it
simpler to unify how arrays work.

With this change, the stack exclusively contains scalars. All local
arrays are allocated on the heap, and their addresses are stored in a
stack variable.

Global and static arrays are unaffected since all global arrays are
iARRAYs.