### PR TITLE
Fix bug where default array assignment wasn't fully checked.

### DIFF
--- a/compiler/array-helpers.cpp
+++ b/compiler/array-helpers.cpp
@@ -517,11 +517,6 @@ bool FixedArrayValidator::CheckArgument(SymbolExpr* expr) {
         return false;
     }
 
-    // No more checks needed if we want an iREFARRAY, since iARRAYs convert
-    // implicitly.
-    if (type_.ident == iREFARRAY)
-        return true;
-
     for (int i = 0; i < type_.numdim(); i++) {
         if (type_.dim(i) && type_.dim(i) != dim[i]) {
             report(expr->pos(), 48);

--- a/tests/compile-only/fail-array-default-argument-mismatch.sp
+++ b/tests/compile-only/fail-array-default-argument-mismatch.sp
@@ -1,0 +1,7 @@
+int x[][] = { {1, 2}, {3}, {5, 6, 7} };
+
+void tests(int blah[3][2] = x) {
+}
+
+public main() {
+}

--- a/tests/compile-only/fail-array-default-argument-mismatch.txt
+++ b/tests/compile-only/fail-array-default-argument-mismatch.txt
@@ -1,0 +1,1 @@
+(3) : error 048: arrays do not match


### PR DESCRIPTION
This now fails:

	int Array[2][3];

	void f(int array[3][2] = Array) {}