### PR TITLE
Fix the various misuage of size_t

### DIFF
--- a/compiler/assembler.cpp
+++ b/compiler/assembler.cpp
@@ -304,8 +304,8 @@ RttiBuilder::build_debuginfo()
               });
 
     // Finish up debug header statistics.
-    dbg_info_->header().num_files = dbg_files_->count();
-    dbg_info_->header().num_lines = dbg_lines_->count();
+    dbg_info_->header().num_files = (uint32_t)dbg_files_->count();
+    dbg_info_->header().num_lines = (uint32_t)dbg_lines_->count();
     dbg_info_->header().num_syms = 0;
     dbg_info_->header().num_arrays = 0;
 }
@@ -410,7 +410,7 @@ RttiBuilder::add_method(symbol* sym)
 {
     assert(!sym->unused());
 
-    uint32_t index = methods_->count();
+    uint32_t index = (uint32_t)methods_->count();
     smx_rtti_method& method = methods_->add();
     method.name = names_->add(sym->nameAtom());
     method.pcode_start = sym->addr();
@@ -422,7 +422,7 @@ RttiBuilder::add_method(symbol* sym)
 
     smx_rtti_debug_method debug;
     debug.method_index = index;
-    debug.first_local = dbg_locals_->count();
+    debug.first_local = (uint32_t)dbg_locals_->count();
 
     for (auto& iter : *sym->function()->dbgstrs) {
         const char* chars = iter.c_str();
@@ -457,12 +457,12 @@ RttiBuilder::add_enumstruct(Type* type)
         return p->value;
 
     symbol* sym = type->asEnumStruct();
-    uint32_t es_index = enumstructs_->count();
+    uint32_t es_index = (uint32_t)enumstructs_->count();
     typeid_cache_.add(p, type, es_index);
 
     smx_rtti_enumstruct es = {};
     es.name = names_->add(*cc_.atoms(), type->name());
-    es.first_field = es_fields_->count();
+    es.first_field = (uint32_t)es_fields_->count();
     es.size = sym->addr();
     enumstructs_->add(es);
 
@@ -502,7 +502,7 @@ RttiBuilder::add_struct(Type* type)
     if (p.found())
         return p->value;
 
-    uint32_t struct_index = classdefs_->count();
+    uint32_t struct_index = (uint32_t)classdefs_->count();
     typeid_cache_.add(p, type, struct_index);
 
     pstruct_t* ps = type->as<pstruct_t>();
@@ -511,7 +511,7 @@ RttiBuilder::add_struct(Type* type)
     memset(&classdef, 0, sizeof(classdef));
     classdef.flags = kClassDefType_Struct;
     classdef.name = names_->add(*cc_.atoms(), ps->name());
-    classdef.first_field = fields_->count();
+    classdef.first_field = (uint32_t)fields_->count();
     classdefs_->add(classdef);
 
     // Pre-reserve space in case we recursively add structs.
@@ -610,7 +610,7 @@ RttiBuilder::add_enum(Type* type)
     if (p.found())
         return p->value;
 
-    uint32_t index = enums_->count();
+    uint32_t index = (uint32_t)enums_->count();
     typeid_cache_.add(p, type, index);
 
     smx_rtti_enum entry;
@@ -628,7 +628,7 @@ RttiBuilder::add_funcenum(Type* type, funcenum_t* fe)
         return p->value;
 
     // Reserve slot beforehand in case the type is recursive.
-    uint32_t index = typedefs_->count();
+    uint32_t index = (uint32_t)typedefs_->count();
     typeid_cache_.add(p, type, index);
     typedefs_->add();
 
@@ -650,7 +650,7 @@ RttiBuilder::add_typeset(Type* type, funcenum_t* fe)
         return p->value;
 
     // Reserve slot beforehand in case the type is recursive.
-    uint32_t index = typesets_->count();
+    uint32_t index = (uint32_t)typesets_->count();
     typeid_cache_.add(p, type, index);
     typesets_->add();
 
@@ -1009,8 +1009,8 @@ assemble(CompileContext& cc, CodeGenerator& cg, const char* binfname, int compre
     sp_file_hdr_t* header = (sp_file_hdr_t*)buffer.bytes();
 
     if (compression_level) {
-        size_t region_size = header->imagesize - header->dataoffs;
-        size_t zbuf_max = compressBound(region_size);
+        uLong region_size = header->imagesize - header->dataoffs;
+        uLong zbuf_max = compressBound(region_size);
         std::unique_ptr<Bytef[]> zbuf = std::make_unique<Bytef[]>(zbuf_max);
 
         uLong new_disksize = zbuf_max;

--- a/compiler/driver.cpp
+++ b/compiler/driver.cpp
@@ -156,7 +156,11 @@ static void parseoptions(CompileContext& cc, int argc, char** argv) {
 
 #if defined __WIN32__ || defined _WIN32 || defined _Windows
     if (opt_hwnd.hasValue()) {
-        hwndFinish = (HWND)atoi(opt_hwnd.value().c_str());
+#if defined _WIN64
+        hwndFinish = (HWND)std::stoull(opt_hwnd.value().c_str());
+#else
+        hwndFinish = (HWND)std::stoi(opt_hwnd.value().c_str());
+#endif
         if (!IsWindow(hwndFinish))
             hwndFinish = (HWND)0;
     }

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -1430,7 +1430,7 @@ int Lexer::LexInjectedToken() {
 }
 
 void Lexer::FillTokenPos(token_pos_t* pos) {
-    uint32_t offset = state_.pos - state_.start;
+    uint32_t offset = (uint32_t)(state_.pos - state_.start);
     if (!state_.macro)
         *pos = token_pos_t(state_.loc_range.FilePos(offset), state_.tokline);
     else

--- a/compiler/sci18n.cpp
+++ b/compiler/sci18n.cpp
@@ -48,7 +48,9 @@
 #include "errors.h"
 #include "sc.h"
 
+#ifndef _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
 #define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
+#endif
 
 #if defined(__clang__)
 # pragma clang diagnostic push

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -1425,7 +1425,7 @@ bool Semantics::CheckArrayExpr(ArrayExpr* array) {
     }
 
     auto& val = array->val();
-    val.set_array(iARRAY, array->exprs().size());
+    val.set_array(iARRAY, (int)array->exprs().size());
     val.tag = lasttag;
     return true;
 }

--- a/compiler/source-file.cpp
+++ b/compiler/source-file.cpp
@@ -149,14 +149,14 @@ bool SourceFile::OffsetToLineAndCol(uint32_t offset, uint32_t* line, uint32_t* c
     ComputeLineExtents();
 
     if (offset == data_.size()) {
-        *line = line_extents_.size();
+        *line = (uint32_t)line_extents_.size();
         if (col)
             *col = 0;
         return true;
     }
 
     uint32_t lower = 0;
-    uint32_t upper = line_extents_.size();
+    uint32_t upper = (uint32_t)line_extents_.size();
     while (lower < upper) {
         uint32_t index = (lower + upper) / 2;
         uint32_t line_start = line_extents_[index];
@@ -168,7 +168,7 @@ bool SourceFile::OffsetToLineAndCol(uint32_t offset, uint32_t* line, uint32_t* c
         // The range should be (start, end].
         uint32_t line_end = (index < line_extents_.size() - 1)
                             ? line_extents_[index + 1]
-                            : data_.size();
+                            : (uint32_t)data_.size();
         if (offset >= line_end) {
             lower = index + 1;
             continue;
@@ -196,7 +196,7 @@ bool SourceFile::OffsetOfLine(uint32_t line, uint32_t* offset) {
         return false;
 
     if (line_index == line_extents_.size())
-        *offset = data_.size();
+        *offset = (uint32_t)data_.size();
     else
         *offset = line_extents_[line_index];
     return true;
@@ -211,7 +211,7 @@ tr::string SourceFile::GetLine(uint32_t line) {
 
     uint32_t end;
     if (!OffsetOfLine(line + 1, &end))
-        end = data_.size();
+        end = (uint32_t)data_.size();
 
     return data_.substr(offset, end - offset);
 }

--- a/compiler/source-manager.cpp
+++ b/compiler/source-manager.cpp
@@ -55,7 +55,7 @@ bool SourceManager::Open(const token_pos_t& from, std::shared_ptr<SourceFile> fi
         return {};
     }
 
-    file->set_sources_index(opened_files_.size());
+    file->set_sources_index((uint32_t)opened_files_.size());
     opened_files_.emplace_back(file);
     return true;
 }
@@ -69,7 +69,7 @@ std::shared_ptr<SourceFile> SourceManager::Open(const std::string& name, tr::str
 
 LocationRange SourceManager::EnterFile(std::shared_ptr<SourceFile> file, const token_pos_t& from) {
     size_t loc_index;
-    if (!TrackExtents(file->size(), &loc_index)) {
+    if (!TrackExtents((uint32_t)file->size(), &loc_index)) {
         report(from, 422);
         return {};
     }
@@ -84,7 +84,7 @@ LocationRange SourceManager::EnterMacro(const token_pos_t& from, SourceLocation 
     assert(expansion_loc.valid());
 
     size_t lr_index;
-    if (!TrackExtents(text->length(), &lr_index)) {
+    if (!TrackExtents((uint32_t)text->length(), &lr_index)) {
         report(from, 422);
         return {};
     }

--- a/compiler/source-manager.h
+++ b/compiler/source-manager.h
@@ -112,8 +112,8 @@ struct LocationRange
         if (!valid())
             return 0;
         if (is_macro())
-            return text_->length();
-        return file_->size();
+            return (uint32_t)text_->length();
+        return (uint32_t)file_->size();
     }
 
     bool owns(const SourceLocation& loc) const {

--- a/compiler/types.h
+++ b/compiler/types.h
@@ -210,7 +210,7 @@ struct structarg_t : public PoolObject
 
     typeinfo_t type;
     Atom* name;
-    unsigned int offs;
+    size_t offs;
     int index;
 };
 

--- a/include/sp_vm_api.h
+++ b/include/sp_vm_api.h
@@ -166,7 +166,7 @@ class ICallable
      * @param flags    Whether or not changes should be copied back to the input array.
      * @return      Error code, if any.
      */
-    virtual int PushArray(cell_t* inarray, unsigned int cells, int flags = 0) = 0;
+    virtual int PushArray(cell_t* inarray, size_t cells, int flags = 0) = 0;
 
     /**
      * @brief Pushes a string onto the current call.
@@ -740,7 +740,7 @@ class IPluginContext
      * @param local_addr  Will be filled with data offset to heap.
      * @param phys_addr    Physical address to heap memory.
      */
-    virtual int HeapAlloc(unsigned int cells, cell_t* local_addr, cell_t** phys_addr) = 0;
+    virtual int HeapAlloc(size_t cells, cell_t* local_addr, cell_t** phys_addr) = 0;
 
     /**
      * @brief Pops a heap address off the heap stack.  Use this to free memory allocated with

--- a/libsmx/smx-builder.cpp
+++ b/libsmx/smx-builder.cpp
@@ -34,8 +34,8 @@ SmxBuilder::write(ISmxBuffer* buf)
   header.version = SmxConsts::SP1_VERSION_1_1;
   header.compression = SmxConsts::FILE_COMPRESSION_NONE;
 
-  header.disksize = sizeof(header) +
-                    sizeof(sp_file_section_t) * sections_.size();
+  header.disksize = (uint32_t)(sizeof(header) +
+                    sizeof(sp_file_section_t) * sections_.size());
 
   // Note that |dataoffs| here is just to mimic what it would be in earlier
   // versions of Pawn. Its value does not actually matter per the SMX spec,
@@ -46,17 +46,17 @@ SmxBuilder::write(ISmxBuffer* buf)
   size_t current_string_offset = 0;
   for (size_t i = 0; i < sections_.size(); i++) {
     RefPtr<SmxSection> section = sections_[i];
-    header.disksize += section->length();
+    header.disksize += (uint32_t)section->length();
     current_string_offset += section->name().size() + 1;
   }
-  header.disksize += current_string_offset;
-  header.dataoffs += current_string_offset;
+  header.disksize += (uint32_t)current_string_offset;
+  header.dataoffs += (uint32_t)current_string_offset;
 
   header.imagesize = header.disksize;
-  header.sections = sections_.size();
+  header.sections = (uint8_t)sections_.size();
 
   // We put the string table after the sections table.
-  header.stringtab = sizeof(header) + sizeof(sp_file_section_t) * sections_.size();
+  header.stringtab = (uint32_t)(sizeof(header) + sizeof(sp_file_section_t) * sections_.size());
 
   if (!buf->write(&header, sizeof(header)))
     return false;
@@ -68,9 +68,9 @@ SmxBuilder::write(ISmxBuffer* buf)
   current_string_offset = 0;
   for (size_t i = 0; i < sections_.size(); i++) {
     sp_file_section_t s;
-    s.nameoffs = current_string_offset;
-    s.dataoffs = current_data_offset;
-    s.size = sections_[i]->length();
+    s.nameoffs = (uint32_t)current_string_offset;
+    s.dataoffs = (uint32_t)current_data_offset;
+    s.size = (uint32_t)sections_[i]->length();
     if (!buf->write(&s, sizeof(s)))
       return false;
 

--- a/libsmx/smx-builder.h
+++ b/libsmx/smx-builder.h
@@ -213,7 +213,7 @@ class SmxNameTable : public SmxSection
     if (iter != name_table_.end())
       return iter->second;
 
-    if (!ke::IsUint32AddSafe(buffer_size_, str->length() + 1)) {
+    if (!ke::IsUint32AddSafe(buffer_size_, (uint32_t)str->length() + 1)) {
       fprintf(stderr, "out of memory in nametable\n");
       abort();
     }
@@ -221,17 +221,17 @@ class SmxNameTable : public SmxSection
     uint32_t index = buffer_size_;
     name_table_.emplace(str, index);
     names_.push_back(str);
-    buffer_size_ += str->length() + 1;
+    buffer_size_ += (uint32_t)str->length() + 1;
     return index;
   }
 
   bool write(ISmxBuffer* buf) override;
   size_t length() const override {
-    return buffer_size_;
+    return (size_t)buffer_size_;
   }
 
  private:
-  std::unordered_map<Atom*, size_t> name_table_;
+  std::unordered_map<Atom*, uint32_t> name_table_;
   std::vector<Atom*> names_;
   uint32_t buffer_size_;
 };

--- a/vm/compiled-function.cpp
+++ b/vm/compiled-function.cpp
@@ -60,7 +60,7 @@ CompiledFunction::FindCipByPc(void* pc)
   if (uintptr_t(pc) < uintptr_t(code_.address()))
     return kInvalidCip;
 
-  uint32_t pcoffs = intptr_t(pc) - intptr_t(code_.address());
+  uint32_t pcoffs = (uint32_t)(intptr_t(pc) - intptr_t(code_.address()));
   if (pcoffs > code_.bytes())
     return kInvalidCip;
 

--- a/vm/compiled-function.h
+++ b/vm/compiled-function.h
@@ -62,7 +62,7 @@ class CompiledFunction
     return code_offset_;
   }
   uint32_t NumLoopEdges() const {
-    return edges_->size();
+    return (uint32_t)edges_->size();
   }
   LoopEdge& GetLoopEdge(size_t i) {
     return edges_->at(i);

--- a/vm/control-flow.cpp
+++ b/vm/control-flow.cpp
@@ -392,13 +392,13 @@ Block::unlink()
 uint32_t
 Block::startPc() const
 {
-  return start_ - graph_.rt()->code().bytes;
+  return (uint32_t)(start_ - graph_.rt()->code().bytes);
 }
 
 uint32_t
 Block::endPc() const
 {
-  return end_ - graph_.rt()->code().bytes;
+  return (uint32_t)(end_ - graph_.rt()->code().bytes);
 }
 
 } // namespace sp

--- a/vm/environment.cpp
+++ b/vm/environment.cpp
@@ -144,7 +144,7 @@ Environment::DisableProfiling()
 }
 
 bool
-Environment::InstallWatchdogTimer(int timeout_ms)
+Environment::InstallWatchdogTimer(size_t timeout_ms)
 {
   return watchdog_timer_->Initialize(timeout_ms);
 }

--- a/vm/environment.h
+++ b/vm/environment.h
@@ -64,7 +64,7 @@ class Environment : public ISourcePawnEnvironment
   // Access the current Environment.
   static Environment* get();
 
-  bool InstallWatchdogTimer(int timeout_ms);
+  bool InstallWatchdogTimer(size_t timeout_ms);
 
   void EnterExceptionHandlingScope(ExceptionHandler* handler) override;
   void LeaveExceptionHandlingScope(ExceptionHandler* handler) override;

--- a/vm/md5/md5.cpp
+++ b/vm/md5/md5.cpp
@@ -109,10 +109,10 @@ void MD5::update (const uint1 *input, uint4 input_length) {
 void MD5::update(FILE *file){
 
   unsigned char buffer[1024];
-  int len;
+  size_t len;
 
   while ((len=fread(buffer, 1, 1024, file)))
-    update(buffer, len);
+    update(buffer, (MD5::uint4)len);
 
   fclose (file);
 

--- a/vm/method-verifier.cpp
+++ b/vm/method-verifier.cpp
@@ -285,7 +285,7 @@ MethodVerifier::verifyOp(OPCODE op)
   case OP_PUSH4_C:
   case OP_PUSH5_C:
   {
-    size_t n = 1;
+    uint32_t n = 1;
     if (op >= OP_PUSH2_C)
       n = ((op - OP_PUSH2_C) / 4) + 2;
 
@@ -299,11 +299,11 @@ MethodVerifier::verifyOp(OPCODE op)
   case OP_PUSH4:
   case OP_PUSH5:
   {
-    size_t n = 1;
+    uint32_t n = 1;
     if (op >= OP_PUSH2)
       n = ((op - OP_PUSH2) / 4) + 2;
     
-    for (size_t i = 0; i < n; i++) {
+    for (uint32_t i = 0; i < n; i++) {
       cell_t offset = readCell();
       if (!verifyDatOffset(offset))
         return false;
@@ -317,11 +317,11 @@ MethodVerifier::verifyOp(OPCODE op)
   case OP_PUSH4_S:
   case OP_PUSH5_S:
   {
-    size_t n = 1;
+    uint32_t n = 1;
     if (op >= OP_PUSH2_S)
       n = ((op - OP_PUSH2_S) / 4) + 2;
 
-    for (size_t i = 0; i < n; i++) {
+    for (uint32_t i = 0; i < n; i++) {
       cell_t offset = readCell();
       if (!verifyStackOffset(offset))
         return false;
@@ -335,11 +335,11 @@ MethodVerifier::verifyOp(OPCODE op)
   case OP_PUSH4_ADR:
   case OP_PUSH5_ADR:
   {
-    size_t n = 1;
+    uint32_t n = 1;
     if (op >= OP_PUSH2_ADR)
       n = ((op - OP_PUSH2_ADR) / 4) + 2;
 
-    for (size_t i = 0; i < n; i++) {
+    for (uint32_t i = 0; i < n; i++) {
       cell_t offset = readCell();
       if (!verifyStackOffset(offset))
         return false;

--- a/vm/pcode-reader.h
+++ b/vm/pcode-reader.h
@@ -93,7 +93,7 @@ class PcodeReader
     return insn_begin_;
   }
   cell_t cip_offset() const {
-    return (cip_ - code_) * sizeof(cell_t);
+    return (cell_t)((cip_ - code_) * sizeof(cell_t));
   }
 
   void jump(cell_t offset) {

--- a/vm/plugin-context.h
+++ b/vm/plugin-context.h
@@ -34,7 +34,7 @@ class PluginContext final : public BasePluginContext
   bool Initialize();
 
  public: //IPluginContext
-  int HeapAlloc(unsigned int cells, cell_t* local_addr, cell_t** phys_addr) override;
+  int HeapAlloc(size_t cells, cell_t* local_addr, cell_t** phys_addr) override;
   int HeapPop(cell_t local_addr) override;
   int HeapRelease(cell_t local_addr) override;
   int FindNativeByName(const char* name, uint32_t* index) override;
@@ -154,8 +154,8 @@ class PluginContext final : public BasePluginContext
  private:
   PluginRuntime* m_pRuntime;
   uint8_t* memory_;
-  uint32_t data_size_;
-  uint32_t mem_size_;
+  size_t data_size_;
+  size_t mem_size_;
 
   cell_t* m_pNullVec;
   cell_t* m_pNullString;

--- a/vm/plugin-runtime.cpp
+++ b/vm/plugin-runtime.cpp
@@ -177,7 +177,7 @@ void
 PluginRuntime::InstallBuiltinNatives()
 {
   Environment* env = Environment::get();
-  for (size_t i = 0; i < image_->NumNatives(); i++) {
+  for (uint32_t i = 0; i < image_->NumNatives(); i++) {
     if (!float_table_[i].found)
       continue;
 
@@ -262,7 +262,7 @@ PluginRuntime::FindNativeByName(const char* name, uint32_t* index)
     return SP_ERROR_NOT_FOUND;
 
   if (index)
-    *index = idx;
+    *index = (uint32_t)idx;
 
   return SP_ERROR_NONE;
 }
@@ -340,7 +340,7 @@ PluginRuntime::GetNative(uint32_t index)
 uint32_t
 PluginRuntime::GetNativesNum()
 {
-  return image_->NumNatives();
+  return (uint32_t)image_->NumNatives();
 }
 
 int
@@ -351,7 +351,7 @@ PluginRuntime::FindPublicByName(const char* name, uint32_t* index)
     return SP_ERROR_NOT_FOUND;
 
   if (index)
-    *index = idx;
+    *index = (uint32_t)idx;
   return SP_ERROR_NONE;
 }
 
@@ -377,7 +377,7 @@ PluginRuntime::GetPublicByIndex(uint32_t index, sp_public_t** out)
 uint32_t
 PluginRuntime::GetPublicsNum()
 {
-  return image_->NumPublics();
+  return (uint32_t)image_->NumPublics();
 }
 
 int
@@ -407,7 +407,7 @@ PluginRuntime::FindPubvarByName(const char* name, uint32_t* index)
     return SP_ERROR_NOT_FOUND;
 
   if (index)
-    *index = idx;
+    *index = (uint32_t)idx;
   return SP_ERROR_NONE;
 }
 
@@ -429,7 +429,7 @@ PluginRuntime::GetPubvarAddrs(uint32_t index, cell_t* local_addr, cell_t** phys_
 uint32_t
 PluginRuntime::GetPubVarsNum()
 {
-  return image_->NumPubvars();
+  return (uint32_t)image_->NumPubvars();
 }
 
 IPluginContext*
@@ -464,7 +464,7 @@ PluginRuntime::GetFunctionById(funcid_t func_id)
 }
 
 ScriptedInvoker*
-PluginRuntime::GetPublicFunction(size_t index)
+PluginRuntime::GetPublicFunction(uint32_t index)
 {
   assert(index < image_->NumPublics());
   ScriptedInvoker* pFunc = entrypoints_[index];
@@ -523,7 +523,7 @@ PluginRuntime::GetCodeHash()
 {
   if (!computed_code_hash_) {
     MD5 md5_pcode;
-    md5_pcode.update((const unsigned char*)code_.bytes, code_.length);
+    md5_pcode.update((const unsigned char*)code_.bytes, (unsigned int)code_.length);
     md5_pcode.finalize();
     md5_pcode.raw_digest(code_hash_);
     computed_code_hash_ = true;
@@ -536,7 +536,7 @@ PluginRuntime::GetDataHash()
 {
   if (!computed_data_hash_) {
     MD5 md5_data;
-    md5_data.update((const unsigned char*)data_.bytes, data_.length);
+    md5_data.update((const unsigned char*)data_.bytes, (unsigned int)data_.length);
     md5_data.finalize();
     md5_data.raw_digest(data_hash_);
     computed_data_hash_ = true;
@@ -621,7 +621,7 @@ PluginRuntime::PerformFullValidation()
   std::deque<cell_t> work;
 
   Environment* env = Environment::get();
-  for (size_t i = 0; i < GetPublicsNum(); i++) {
+  for (uint32_t i = 0; i < GetPublicsNum(); i++) {
     int err;
     sp_public_t* fun;
     if ((err = GetPublicByIndex(i, &fun)) != SP_ERROR_NONE) {

--- a/vm/plugin-runtime.h
+++ b/vm/plugin-runtime.h
@@ -74,7 +74,7 @@ class PluginRuntime
   virtual unsigned char* GetDataHash() override;
   void SetNames(const char* fullname, const char* name);
   unsigned GetNativeReplacement(size_t index);
-  ScriptedInvoker* GetPublicFunction(size_t index);
+  ScriptedInvoker* GetPublicFunction(uint32_t index);
   int UpdateNativeBinding(uint32_t index, SPVM_NATIVE_FUNC pfn, uint32_t flags, void* data) override;
   int UpdateNativeBindingObject(uint32_t index, INativeCallback* callback, uint32_t flags,
                                 void* data) override;

--- a/vm/scripted-invoker.cpp
+++ b/vm/scripted-invoker.cpp
@@ -107,7 +107,7 @@ ScriptedInvoker::PushFloatByRef(float* number, int flags)
 }
 
 int
-ScriptedInvoker::PushArray(cell_t* inarray, unsigned int cells, int copyback)
+ScriptedInvoker::PushArray(cell_t* inarray, size_t cells, int copyback)
 {
   if (m_curparam >= SP_MAX_EXEC_PARAMS)
   {
@@ -118,7 +118,7 @@ ScriptedInvoker::PushArray(cell_t* inarray, unsigned int cells, int copyback)
 
   info->flags = inarray ? copyback : 0;
   info->marked = true;
-  info->size = cells;
+  info->size = (ucell_t)cells;
   info->str.is_sz = false;
   info->orig_addr = inarray;
 
@@ -150,7 +150,7 @@ ScriptedInvoker::_PushString(const char* string, int sz_flags, int cp_flags, siz
   info->marked = true;
   info->orig_addr = (cell_t*)string;
   info->flags = cp_flags;
-  info->size = len;
+  info->size = (ucell_t)len;
   info->str.sz_flags = sz_flags;
   info->str.is_sz = true;
 

--- a/vm/scripted-invoker.h
+++ b/vm/scripted-invoker.h
@@ -53,7 +53,7 @@ class ScriptedInvoker : public IPluginFunction
   int PushCellByRef(cell_t* cell, int flags);
   int PushFloat(float number);
   int PushFloatByRef(float* number, int flags);
-  int PushArray(cell_t* inarray, unsigned int cells, int copyback);
+  int PushArray(cell_t* inarray, size_t cells, int copyback);
   int PushString(const char* string);
   int PushStringEx(char* buffer, size_t length, int sz_flags, int cp_flags);
   int Execute(cell_t* result);

--- a/vm/smx-v1-image.cpp
+++ b/vm/smx-v1-image.cpp
@@ -854,10 +854,10 @@ SmxV1Image::GetPublic(size_t index, uint32_t* offsetp, const char** namep) const
 bool
 SmxV1Image::FindPublic(const char* name, size_t* indexp) const
 {
-  int high = publics_.length() - 1;
+  long high = (long)publics_.length() - 1;
   int low = 0;
   while (low <= high) {
-    int mid = (low + high) / 2;
+    long mid = (low + high) / 2;
     const char* candidate = names_ + publics_[mid].name;
     int diff = strcmp(candidate, name);
     if (diff == 0) {
@@ -893,10 +893,10 @@ SmxV1Image::GetPubvar(size_t index, uint32_t* offsetp, const char** namep) const
 bool
 SmxV1Image::FindPubvar(const char* name, size_t* indexp) const
 {
-  int high = pubvars_.length() - 1;
-  int low = 0;
+  long high = (long)pubvars_.length() - 1;
+  long low = 0;
   while (low <= high) {
-    int mid = (low + high) / 2;
+    long mid = (low + high) / 2;
     const char* candidate = names_ + pubvars_[mid].name;
     int diff = strcmp(candidate, name);
     if (diff == 0) {
@@ -928,11 +928,11 @@ SmxV1Image::ImageSize() const
 const char*
 SmxV1Image::LookupFile(uint32_t addr) const
 {
-  int high = debug_files_.length();
-  int low = -1;
+  long high = (long)debug_files_.length();
+  long low = -1;
 
   while (high - low > 1) {
-    int mid = (low + high) / 2;
+    long mid = (low + high) / 2;
     if (debug_files_[mid].addr <= addr)
       low = mid;
     else
@@ -1023,11 +1023,11 @@ SmxV1Image::GetMethodRttiByOffset(uint32_t pcode_offset) const
 bool
 SmxV1Image::LookupLine(uint32_t addr, uint32_t* line) const
 {
-  int high = debug_lines_.length();
-  int low = -1;
+  long high = (long)debug_lines_.length();
+  long low = -1;
 
   while (high - low > 1) {
-    int mid = (low + high) / 2;
+    long mid = (low + high) / 2;
     if (debug_lines_[mid].addr <= addr)
       low = mid;
     else

--- a/vm/stack-frames.cpp
+++ b/vm/stack-frames.cpp
@@ -126,7 +126,7 @@ InterpFrameIterator::cip() const
   const uint8_t* ptr = reinterpret_cast<const uint8_t*>(ivk_->cip_);
   assert(ptr >= code.bytes && ptr < code.bytes + code.length);
 
-  return ptr - code.bytes;
+  return (cell_t)(ptr - code.bytes);
 }
 
 uint32_t
@@ -189,7 +189,7 @@ cell_t
 JitFrameIterator::function_cip() const
 {
   assert(cur_frame_->frame_type == JitFrameType::Scripted);
-  return cur_frame_->function_id;
+  return (cell_t)cur_frame_->function_id;
 }
 
 cell_t
@@ -216,7 +216,7 @@ uint32_t
 JitFrameIterator::native_index() const
 {
   assert(type() == FrameType::Native);
-  return GetExitFramePayload(cur_frame_->function_id);
+  return (cell_t)GetExitFramePayload(cur_frame_->function_id);
 }
 
 FrameIterator::FrameIterator()

--- a/vm/x64/macro-assembler-x64.cpp
+++ b/vm/x64/macro-assembler-x64.cpp
@@ -38,7 +38,7 @@ MacroAssembler::leaveFrame()
 void
 MacroAssembler::enterExitFrame(ExitFrameType type, uintptr_t payload)
 {
-  enterFrame(JitFrameType::Exit, EncodeExitFrameId(type, payload));
+  enterFrame(JitFrameType::Exit, (uint32_t)EncodeExitFrameId(type, payload));
   movq(AddressOperand(Environment::get()->addressOfExit()), rbp);
 }
 


### PR DESCRIPTION
Currently working on a PR for Sourcemod that aims at enabling `/WX` on msvc, this means dealing with the various narrowing or extending of variables, when compiling the project on 64 bits.

The warnings are mostly `size_t` to `unsigned int` conversion, which are no longer valid.