### PR TITLE
Simplify type building in RTTI.

### DIFF
--- a/compiler/code-generator.cpp
+++ b/compiler/code-generator.cpp
@@ -104,12 +104,6 @@ void CodeGenerator::AddDebugSymbol(Decl* decl, uint32_t pc) {
     auto string = ke::StringPrintf("S:%x %x:%s %x %x %x %x %x",
                                    *addr, decl->type()->type_index(), symname, pc,
                                    asm_.position(), decl->ident(), decl->vclass(), (int)decl->is_const());
-    if (decl->type()->isArray()) {
-        string += " [ ";
-        for (int i = 0; i < decl->dim_count(); i++)
-            string += ke::StringPrintf("%x:%x ", decl->type()->type_index(), decl->dim(i));
-        string += "]";
-    }
 
     if (fun_) {
         auto data = fun_->cg();

--- a/compiler/parse-node.cpp
+++ b/compiler/parse-node.cpp
@@ -238,20 +238,6 @@ Type* Decl::type() const {
     return nullptr;
 }
 
-int Decl::dim(int n) {
-    auto var = as<VarDeclBase>();
-    assert(var);
-
-    return var->type_info().dim(n);
-}
-
-int Decl::dim_count() {
-    auto var = as<VarDeclBase>();
-    assert(var);
-
-    return (int)var->type_info().numdim();
-}
-
 bool Decl::is_const() {
     auto var = as<VarDeclBase>();
     assert(var);

--- a/compiler/parse-node.h
+++ b/compiler/parse-node.h
@@ -300,8 +300,6 @@ class Decl : public Stmt
     IdentifierKind ident_impl();
     char vclass();
     bool is_const();
-    int dim(int n);
-    int dim_count();
     virtual Type* type() const;
 
     Atom* name() const { return name_; }

--- a/vm/rtti.cpp
+++ b/vm/rtti.cpp
@@ -298,6 +298,7 @@ RttiParser::validateFunction()
     if (offset_ >= length_)
       return false;
     // A by_ref indicator is allowed here.
+    match(cb::kConst);
     match(cb::kByRef);
     if (!validate())
       return false;


### PR DESCRIPTION
Add a QualType wrapper around Type + const, and use this to significantly simplify RTTI.