### PR TITLE
Fix MethodVerifier::Validate not making any sense.

### DIFF
--- a/vm/environment.cpp
+++ b/vm/environment.cpp
@@ -353,8 +353,7 @@ Environment::Invoke(PluginContext* cx,
 
   // The JIT performs its own validation. Handle the interpreter here.
   {
-    auto graph = method->Validate();
-    if (!graph) {
+    if (!method->Validate()) {
       cx->ReportErrorNumber(method->validationError());
       return false;
     }

--- a/vm/interpreter.cpp
+++ b/vm/interpreter.cpp
@@ -159,8 +159,7 @@ Interpreter::visitCALL(cell_t offset)
     return false;
   }
   {
-    auto graph = target->Validate();
-    if (!graph) {
+    if (!target->Validate()) {
       cx_->ReportErrorNumber(target->validationError());
       return false;
     }

--- a/vm/jit.cpp
+++ b/vm/jit.cpp
@@ -71,7 +71,7 @@ CompilerBase::Compile(PluginContext* cx, RefPtr<MethodInfo> method, int* err)
 CompiledFunction*
 CompilerBase::emit()
 {
-  graph_ = method_info_->Validate();
+  graph_ = method_info_->BuildGraph();
   if (!graph_) {
     reportError(method_info_->validationError());
     return nullptr;

--- a/vm/method-info.h
+++ b/vm/method-info.h
@@ -28,10 +28,17 @@ class MethodInfo final : public ke::Refcounted<MethodInfo>
   MethodInfo(PluginRuntime* rt, uint32_t codeOffset);
   ~MethodInfo();
 
-  ke::RefPtr<ControlFlowGraph> Validate() {
-    if (!checked_ || !graph_)
-      InternalValidate();
+  ke::RefPtr<ControlFlowGraph> BuildGraph() {
+    InternalValidate();
     return graph_.take();
+  }
+
+  // For interpreter validation, we throw away the unused graph.
+  bool Validate() {
+    if (!checked_)
+      InternalValidate();
+    graph_ = nullptr;
+    return validation_error_ == SP_ERROR_NONE;
   }
 
   int validationError() const {


### PR DESCRIPTION
Split it into JIT and interpreter variants, since the interpreter never uses the graph.

Bug: issue #965
Test: manual benchmark