### PR TITLE
Remove typeinfo_t::dim_.

### DIFF
--- a/compiler/assembler.cpp
+++ b/compiler/assembler.cpp
@@ -427,10 +427,6 @@ RttiBuilder::add_enumstruct(Type* type)
     for (auto iter = enumlist.begin(); iter != enumlist.end(); iter++) {
         auto field = (*iter);
 
-        int dims[1], dimcount = 0;
-        if (field->type_info().numdim())
-            dims[dimcount++] = field->type_info().dim(0);
-
         smx_rtti_es_field info;
         info.name = names_->add(field->name());
         info.type_id = to_typeid(field->type());

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -2852,12 +2852,12 @@ bool Semantics::CheckFunctionDeclImpl(FunctionDecl* info) {
     }
 
     if (info->is_public() || info->is_forward()) {
-        if (decl.type.numdim() > 0)
+        if (decl.type.dim_exprs.size() > 0)
             report(info->pos(), 141);
     }
 
     if (info->is_native()) {
-        if (decl.type.numdim() > 0) {
+        if (decl.type.dim_exprs.size() > 0) {
             report(info->pos(), 83);
             return false;
         }
@@ -3108,8 +3108,6 @@ int argcompare(ArgDecl* a1, ArgDecl* a2) {
         result = a1->type_info().is_const == a2->type_info().is_const; /* "const" flag */
     if (result)
         result = a1->type() == a2->type();
-    if (result)
-        result = a1->type_info().dim_ == a2->type_info().dim_; /* array dimensions & index tags */
     if (result)
         result = !!a1->default_value() == !!a2->default_value(); /* availability of default value */
     if (auto a1_def = a1->default_value()) {

--- a/compiler/types.cpp
+++ b/compiler/types.cpp
@@ -288,10 +288,6 @@ Type* TypeManager::defineReference(Type* inner) {
     return type;
 }
 
-bool typeinfo_t::isCharArray() const {
-    return numdim() == 1 && type->isChar();
-}
-
 bool TypeManager::ArrayCachePolicy::matches(const Lookup& lookup, ArrayType* type) {
     return lookup.type == type->inner() && lookup.size == type->size();
 }

--- a/compiler/types.h
+++ b/compiler/types.h
@@ -136,9 +136,6 @@ struct typeinfo_t {
         is_varargs(false)
     {}
 
-    // Array information.
-    PoolArray<int> dim_;
-
     // Either null or an array of size |numdim|, pool-allocated.
     PoolArray<Expr*> dim_exprs;
 
@@ -157,10 +154,6 @@ struct typeinfo_t {
 
     TypenameInfo ToTypenameInfo() const;
 
-    int numdim() const { return (int)dim_.size(); }
-    int dim(int i) const { return dim_[i]; }
-    const PoolArray<int>& dim_vec() const { return dim_; }
-
     bool bindable() const { return type_atom || type; }
 
     void set_type(const TypenameInfo& rt) {
@@ -175,12 +168,6 @@ struct typeinfo_t {
     }
 
     void set_type(Type* t) { type = t; }
-
-    bool isCharArray() const;
-    Expr* get_dim_expr(int i) {
-        assert(i < numdim());
-        return (size_t)i < dim_exprs.size() ? dim_exprs[i] : nullptr;
-    }
 };
 
 struct functag_t : public PoolObject

--- a/tests/compile-only/ok-reparse-newdecl-array.sp
+++ b/tests/compile-only/ok-reparse-newdecl-array.sp
@@ -1,0 +1,5 @@
+
+public main() {
+    int maxlength;
+    char[] buffer = new char[maxlength], sChar = new char[maxlength];
+}


### PR DESCRIPTION
This removes more cruft leftover from the tag system, and merges the dimension vector into typeinfo_t::dim_exprs. This is roughly a 4-5% reduction in memory usage, but the real goal is another step toward eliminating matchtag() and iFUNCTN.