### PR TITLE
Move functag_t into the type system.

### DIFF
--- a/compiler/assembler.cpp
+++ b/compiler/assembler.cpp
@@ -133,7 +133,7 @@ class RttiBuilder
     uint32_t add_struct(Type* type);
     uint32_t add_enumstruct(Type* type);
     uint32_t encode_signature(FunctionDecl* decl);
-    void encode_signature_into(std::vector<uint8_t>& bytes, functag_t* ft);
+    void encode_signature_into(std::vector<uint8_t>& bytes, FunctionType* ft);
     void encode_enum_into(std::vector<uint8_t>& bytes, Type* type);
     void encode_type_into(std::vector<uint8_t>& bytes, Type* type);
     void encode_type_into(std::vector<uint8_t>& bytes, QualType type);
@@ -680,17 +680,17 @@ RttiBuilder::encode_funcenum_into(std::vector<uint8_t>& bytes, Type* type, funce
     }
 }
 
-void RttiBuilder::encode_signature_into(std::vector<uint8_t>& bytes, functag_t* ft) {
+void RttiBuilder::encode_signature_into(std::vector<uint8_t>& bytes, FunctionType* ft) {
     bytes.push_back(cb::kFunction);
-    bytes.push_back((uint8_t)ft->args.size());
+    bytes.push_back((uint8_t)ft->nargs());
 
-    if (ft->variadic)
+    if (ft->variadic())
         bytes.push_back(cb::kLegacyVariadic);
 
-    encode_type_into(bytes, ft->ret_type);
+    encode_type_into(bytes, ft->return_type());
 
-    for (const auto& arg : ft->args)
-        encode_type_into(bytes, arg);
+    for (size_t i = 0; i < ft->nargs(); i++)
+        encode_type_into(bytes, ft->arg_type(i));
 }
 
 typedef SmxListSection<sp_file_natives_t> SmxNativeSection;

--- a/compiler/assembler.cpp
+++ b/compiler/assembler.cpp
@@ -684,13 +684,13 @@ void RttiBuilder::encode_signature_into(std::vector<uint8_t>& bytes, functag_t* 
     bytes.push_back(cb::kFunction);
     bytes.push_back((uint8_t)ft->args.size());
 
-    if (!ft->args.empty() && ft->args[ft->args.size() - 1].is_varargs)
+    if (ft->variadic)
         bytes.push_back(cb::kLegacyVariadic);
 
     encode_type_into(bytes, ft->ret_type);
 
     for (const auto& arg : ft->args)
-        encode_type_into(bytes, QualType(arg.type, arg.is_const));
+        encode_type_into(bytes, arg);
 }
 
 typedef SmxListSection<sp_file_natives_t> SmxNativeSection;

--- a/compiler/assembler.cpp
+++ b/compiler/assembler.cpp
@@ -500,7 +500,7 @@ uint32_t RttiBuilder::encode_signature(FunctionDecl* fun) {
 
     bytes.push_back((uint8_t)argc);
     if (fun->IsVariadic())
-        bytes.push_back(cb::kVariadic);
+        bytes.push_back(cb::kLegacyVariadic);
 
     encode_type_into(bytes, fun->return_type());
 
@@ -685,7 +685,7 @@ void RttiBuilder::encode_signature_into(std::vector<uint8_t>& bytes, functag_t* 
     bytes.push_back((uint8_t)ft->args.size());
 
     if (!ft->args.empty() && ft->args[ft->args.size() - 1].is_varargs)
-        bytes.push_back(cb::kVariadic);
+        bytes.push_back(cb::kLegacyVariadic);
 
     encode_type_into(bytes, ft->ret_type);
 

--- a/compiler/errors.cpp
+++ b/compiler/errors.cpp
@@ -373,6 +373,17 @@ MessageBuilder::operator <<(Type* type)
     return *this;
 }
 
+MessageBuilder&
+MessageBuilder::operator <<(QualType type)
+{
+    std::string message;
+    if (type.is_const())
+        message += "const ";
+    message += type->prettyName();
+    args_.emplace_back(message);
+    return *this;
+}
+
 ReportManager::ReportManager(CompileContext& cc)
   : cc_(cc)
 {

--- a/compiler/errors.h
+++ b/compiler/errors.h
@@ -96,6 +96,7 @@ class MessageBuilder
         return *this;
     }
     MessageBuilder& operator <<(Type* type);
+    MessageBuilder& operator <<(QualType type);
 
     template <typename Integer,
               std::enable_if_t<std::is_integral<Integer>::value, bool> = true>

--- a/compiler/expressions.cpp
+++ b/compiler/expressions.cpp
@@ -275,12 +275,12 @@ static bool matchobjecttags(Type* formal, Type* actual, int flags) {
     return false;
 }
 
-static bool matchreturntag(const functag_t* formal, const functag_t* actual) {
-    if (formal->ret_type == actual->ret_type)
+static bool matchreturntag(const FunctionType* formal, const FunctionType* actual) {
+    if (formal->return_type() == actual->return_type())
         return true;
 
-    if (formal->ret_type->isVoid()) {
-        if (actual->ret_type->isInt())
+    if (formal->return_type()->isVoid()) {
+        if (actual->return_type()->isInt())
             return true;
     }
     return false;
@@ -337,25 +337,25 @@ static bool funcarg_compare(QualType formal, QualType actual) {
     return true;
 }
 
-bool functag_compare(const functag_t* formal, const functag_t* actual) {
+bool functag_compare(FunctionType* formal, FunctionType* actual) {
     // Check return types.
     if (!matchreturntag(formal, actual))
         return false;
 
     // Make sure there are no trailing arguments.
-    if (actual->args.size() > formal->args.size())
+    if (actual->nargs() > formal->nargs())
         return false;
-    if (actual->variadic != formal->variadic)
+    if (actual->variadic() != formal->variadic())
         return false;
 
     // Check arguments.
-    for (size_t i = 0; i < formal->args.size(); i++) {
-        auto formal_arg = formal->args[i];
+    for (size_t i = 0; i < formal->nargs(); i++) {
+        auto formal_arg = formal->arg_type(i);
 
-        if (i >= actual->args.size())
+        if (i >= actual->nargs())
             return false;
 
-        auto actual_arg = actual->args[i];
+        auto actual_arg = actual->arg_type(i);
         if (!funcarg_compare(formal_arg, actual_arg))
             return false;
     }
@@ -376,7 +376,7 @@ static bool matchfunctags(Type* formal, Type* actual) {
     if (!actual_fe || actual_fe->entries.empty())
         return false;
 
-    functag_t* actualfn = actual_fe->entries.back();
+    FunctionType* actualfn = actual_fe->entries.back();
     if (!actualfn)
         return false; 
 

--- a/compiler/expressions.h
+++ b/compiler/expressions.h
@@ -62,7 +62,7 @@ bool checktag(Type* type, Type* expr_type);
 bool checktag_string(int tag, const value* sym1);
 bool checktag(int tag, int exprtag);
 bool HasTagOnInheritanceChain(Type* type, Type* other);
-bool functag_compare(const functag_t* formal, const functag_t* actual);
+bool functag_compare(FunctionType* formal, FunctionType* actual);
 
 } // namespace cc
 } // namespace sp

--- a/compiler/name-resolution.cpp
+++ b/compiler/name-resolution.cpp
@@ -319,7 +319,7 @@ TypedefInfo::Bind(SemaContext& sc)
     auto ft = new functag_t();
     ft->ret_type = ret_type.type();
 
-    std::vector<typeinfo_t> ft_args;
+    std::vector<QualType> ft_args;
     for (auto& arg : args) {
         if (!sc.BindType(pos, &arg->type))
             return nullptr;
@@ -327,9 +327,12 @@ TypedefInfo::Bind(SemaContext& sc)
         if (!arg->type.dim_exprs.empty())
             ResolveArrayType(sc.sema(), pos, &arg->type, sARGUMENT);
 
-        ft_args.emplace_back(arg->type);
+        if (arg->type.is_varargs)
+            ft->variadic = true;
+        else
+            ft_args.emplace_back(arg->type.qualified());
     }
-    new (&ft->args) PoolArray<typeinfo_t>(ft_args);
+    new (&ft->args) PoolArray<QualType>(ft_args);
 
     return ft;
 }

--- a/compiler/parse-node.h
+++ b/compiler/parse-node.h
@@ -531,7 +531,7 @@ struct TypedefInfo : public PoolObject {
     TypenameInfo ret_type;
     PoolArray<declinfo_t*> args;
 
-    functag_t* Bind(SemaContext& sc);
+    FunctionType* Bind(SemaContext& sc);
 };
 
 class TypedefDecl : public Decl

--- a/compiler/sctracker.cpp
+++ b/compiler/sctracker.cpp
@@ -60,10 +60,15 @@ funcenum_t* funcenum_for_symbol(CompileContext& cc, Decl* sym) {
     functag_t* ft = new functag_t;
     ft->ret_type = sym->type();
 
-    std::vector<typeinfo_t> args;
-    for (auto arg : fun->canonical()->args())
-        args.emplace_back(arg->type_info());
-    new (&ft->args) PoolArray<typeinfo_t>(args);
+    std::vector<QualType> args;
+    for (auto arg : fun->canonical()->args()) {
+        const auto& ti = arg->type_info();
+        if (ti.is_varargs)
+            ft->variadic = true;
+        else
+            args.emplace_back(ti.qualified());
+    }
+    new (&ft->args) PoolArray<QualType>(args);
 
     auto name = ke::StringPrintf("::ft:%s", fun->name()->chars());
     funcenum_t* fe = funcenums_add(cc, cc.atom(name), true);

--- a/compiler/sctracker.h
+++ b/compiler/sctracker.h
@@ -39,7 +39,7 @@ struct funcenum_t : public PoolObject
     {}
     Type* type;
     Atom* name;
-    PoolArray<functag_t*> entries;
+    PoolArray<FunctionType*> entries;
     bool anonymous;
 };
 

--- a/compiler/type-checker.cpp
+++ b/compiler/type-checker.cpp
@@ -290,8 +290,8 @@ bool TypeChecker::CheckFunctionSignature(functag_t* formal, functag_t* actual) {
         if (i >= actual->args.size())
             return DiagnoseFunctionFailure();
 
-        auto formal_type = formal->args[i].type;
-        auto actual_type = actual->args[i].type;
+        auto formal_type = formal->args[i];
+        auto actual_type = actual->args[i];
         TypeChecker tc(pos_, formal_type, actual_type, TypeChecker::Generic,
                        TypeChecker::FuncArg);
         if (!tc.Check())

--- a/compiler/type-checker.cpp
+++ b/compiler/type-checker.cpp
@@ -26,11 +26,7 @@
 namespace sp {
 namespace cc {
 
-TypeChecker::TypeChecker(ParseNode* node, Type* formal, Type* actual, Context why, int flags)
-  : TypeChecker(node->pos(), formal, actual, why, flags)
-{}
-
-TypeChecker::TypeChecker(const token_pos_t& pos, Type* formal, Type* actual, Context why,
+TypeChecker::TypeChecker(const token_pos_t& pos, QualType formal, QualType actual, Context why,
                          int flags)
   : pos_(pos),
     formal_(formal),
@@ -83,8 +79,8 @@ bool TypeChecker::CheckImpl() {
     if (auto formal_array = formal_->as<ArrayType>())
         return CheckArrays(formal_array, actual_->as<ArrayType>());
 
-    Type* formal = formal_;
-    Type* actual = actual_;
+    Type* formal = *formal_;
+    Type* actual = *actual_;
     if (flags_ & AllowCoerce) {
         if (formal->isReference())
             formal = formal->inner();
@@ -294,8 +290,8 @@ bool TypeChecker::CheckFunctionSignature(functag_t* formal, functag_t* actual) {
         if (i >= actual->args.size())
             return DiagnoseFunctionFailure();
 
-        Type* formal_type = formal->args[i].type;
-        Type* actual_type = actual->args[i].type;
+        auto formal_type = formal->args[i].type;
+        auto actual_type = actual->args[i].type;
         TypeChecker tc(pos_, formal_type, actual_type, TypeChecker::Generic,
                        TypeChecker::FuncArg);
         if (!tc.Check())

--- a/compiler/type-checker.cpp
+++ b/compiler/type-checker.cpp
@@ -258,7 +258,7 @@ bool TypeChecker::CheckFunction() {
     if (!actual_fe || actual_fe->entries.empty())
         return DiagnoseFailure();
 
-    functag_t* actualfn = actual_fe->entries.back();
+    FunctionType* actualfn = actual_fe->entries.back();
     if (!actualfn)
         return DiagnoseFailure();
 
@@ -274,24 +274,27 @@ bool TypeChecker::CheckFunction() {
     return DiagnoseFunctionFailure();
 }
 
-bool TypeChecker::CheckFunctionSignature(functag_t* formal, functag_t* actual) {
-    if (formal->ret_type != actual->ret_type) {
-        if (formal->ret_type->isVoid() && actual->ret_type->isInt())
+bool TypeChecker::CheckFunctionSignature(FunctionType* formal, FunctionType* actual) {
+    if (formal->return_type() != actual->return_type()) {
+        if (formal->return_type()->isVoid() && actual->return_type()->isInt())
             return true;
         return DiagnoseFunctionFailure();
     }
 
+    if (formal->variadic() != actual->variadic())
+        return DiagnoseFunctionFailure();
+
     // Make sure there are no trailing arguments.
-    if (actual->args.size() > formal->args.size())
+    if (actual->nargs() > formal->nargs())
         return DiagnoseFunctionFailure();
 
     // Check arguments.
-    for (size_t i = 0; i < formal->args.size(); i++) {
-        if (i >= actual->args.size())
+    for (size_t i = 0; i < formal->nargs(); i++) {
+        if (i >= actual->nargs())
             return DiagnoseFunctionFailure();
 
-        auto formal_type = formal->args[i];
-        auto actual_type = actual->args[i];
+        auto formal_type = formal->arg_type(i);
+        auto actual_type = actual->arg_type(i);
         TypeChecker tc(pos_, formal_type, actual_type, TypeChecker::Generic,
                        TypeChecker::FuncArg);
         if (!tc.Check())

--- a/compiler/type-checker.h
+++ b/compiler/type-checker.h
@@ -69,7 +69,7 @@ class TypeChecker {
     bool CheckValueType(Type* formal, Type* actual);
     bool CheckArrays(ArrayType* formal, ArrayType* actual);
     bool CheckFunction();
-    bool CheckFunctionSignature(functag_t* formal, functag_t* actual);
+    bool CheckFunctionSignature(FunctionType* formal, FunctionType* actual);
     bool DiagnoseFailure();
     bool DiagnoseFunctionFailure();
 

--- a/compiler/type-checker.h
+++ b/compiler/type-checker.h
@@ -44,9 +44,19 @@ class TypeChecker {
         Ternary = 0x10,
     };
 
+    TypeChecker(ParseNode* node, QualType formal, QualType actual, Context why,
+                int flags = None)
+      : TypeChecker(node->pos(), formal, actual, why, flags)
+    {}
     TypeChecker(ParseNode* node, Type* formal, Type* actual, Context why,
-                int flags = None);
+                int flags = None)
+      : TypeChecker(node->pos(), QualType(formal), QualType(actual), why, flags)
+    {}
     TypeChecker(const token_pos_t& pos, Type* formal, Type* actual, Context why,
+                int flags = None)
+      : TypeChecker(pos, QualType(formal), QualType(actual), why, flags)
+    {}
+    TypeChecker(const token_pos_t& pos, QualType formal, QualType actual, Context why,
                 int flags = None);
 
     bool Check();
@@ -65,8 +75,8 @@ class TypeChecker {
 
   private:
     const token_pos_t& pos_;
-    Type* formal_;
-    Type* actual_;
+    QualType formal_;
+    QualType actual_;
     Context why_;
     int flags_;
     AutoDeferReports defer_;

--- a/compiler/types.h
+++ b/compiler/types.h
@@ -205,15 +205,8 @@ class QualType {
         impl_ = ke::SetPointerBits(type, is_const ? 1 : 0);
     }
 
-    static QualType FromVarargs(Type* type) {
-        return QualType{ke::SetPointerBits(type, 2)};
-    }
-
     bool is_const() const {
         return ke::GetPointerBits<2>(impl_) == 1;
-    }
-    bool is_varargs() const {
-        return ke::GetPointerBits<2>(impl_) == 2;
     }
 
     Type* operator *() const { return unqualified(); }

--- a/compiler/types.h
+++ b/compiler/types.h
@@ -219,17 +219,6 @@ struct structarg_t : public PoolObject
     int index;
 };
 
-struct functag_t : public PoolObject
-{
-    functag_t()
-     : ret_type(nullptr),
-       args()
-    {}
-    Type* ret_type;
-    PoolArray<QualType> args;
-    bool variadic;
-};
-
 class Type : public PoolObject
 {
     friend class TypeManager;

--- a/include/smx/smx-typeinfo.h
+++ b/include/smx/smx-typeinfo.h
@@ -85,10 +85,10 @@ struct smx_rtti_method {
     uint32_t pcode_end;
 
     // Method signature; offset into rtti.data. The encoding at this offset is:
-    //    FormalArgs    uint8
-    //    Variadic?     uint8
-    //    ReturnType    <return-type>
-    //    Params*       <param>
+    //    FormalArgs      uint8
+    //    LegacyVariadic? uint8
+    //    ReturnType      <return-type>
+    //    Params*         <param>
     //
     // <return-type> must be kVoid or a <type>.
     // <param> must be: kByRef? <type>
@@ -252,8 +252,9 @@ static const uint8_t kEnumStruct = 0x46; // rtti.enumstructs
 
 // For function signatures, indicating no return value.
 static const uint8_t kVoid = 0x70;
-// For functions, indicating the last argument of a function is variadic.
-static const uint8_t kVariadic = 0x71;
+// For functions, indicating the last argument of a function is variadic, and is
+// unnamed and untyped.
+static const uint8_t kLegacyVariadic = 0x71;
 // For parameters, indicating pass-by-ref.
 static const uint8_t kByRef = 0x72;
 // For reference and compound types, indicating const.

--- a/vm/rtti.cpp
+++ b/vm/rtti.cpp
@@ -193,7 +193,7 @@ RttiParser::decodeFunction()
   uint8_t argc = bytes_[offset_++];
 
   bool variadic = false;
-  if (bytes_[offset_] == cb::kVariadic) {
+  if (bytes_[offset_] == cb::kLegacyVariadic) {
     variadic = true;
     offset_++;
   }
@@ -283,7 +283,7 @@ RttiParser::validateFunction()
   if (offset_ >= length_)
     return false;
 
-  if (bytes_[offset_] == cb::kVariadic)
+  if (bytes_[offset_] == cb::kLegacyVariadic)
     offset_++;
   if (offset_ >= length_)
     return false;


### PR DESCRIPTION
This thing was pretty old. Using typeinfo_t is problematic because it's pre-binding. Move it to QualType, and create a formal FunctionType class.

This is a prerequisite to removing funcenum_t.