### PR TITLE
Forbid initializing string arrays with literals that are too long.

### DIFF
--- a/compiler/array-helpers.cpp
+++ b/compiler/array-helpers.cpp
@@ -585,11 +585,12 @@ bool ArrayValidator::ValidateRank(ArrayType* rank, Expr* init) {
             return false;
         }
 
-        auto cells = char_array_cells(str->text()->length() + 1);
+        auto bytes = str->text()->length() + 1;
+        auto cells = char_array_cells(bytes);
         if (!AddCells(cells))
             return false;
 
-        if (rank->size() && cells > rank->size()) {
+        if (rank->size() && bytes > rank->size()) {
             report(str->pos(), 47);
             return false;
         }

--- a/tests/compile-only/fail-string-too-big-for-array.sp
+++ b/tests/compile-only/fail-string-too-big-for-array.sp
@@ -1,0 +1,3 @@
+char str[10] = "asdasdsadassadadsdas";
+
+public main() {}

--- a/tests/compile-only/fail-string-too-big-for-array.txt
+++ b/tests/compile-only/fail-string-too-big-for-array.txt
@@ -1,0 +1,1 @@
+(1) : error 047: array sizes do not match, or destination array is too small


### PR DESCRIPTION
Bug: issue #971
Test: new test case, modified corpus