### PR TITLE
Fix for #972 when a static is used by a stock Function

### DIFF
--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -2876,6 +2876,10 @@ bool Semantics::CheckFunctionDeclImpl(FunctionDecl* info) {
     if (info->as<MemberFunctionDecl>())
         maybe_used_.emplace_back(info);
 
+    // We never warn about unused stock functions.
+    if (info->is_stock())
+        maybe_used_.emplace_back(info);
+
     auto fwd = info->prototype();
     if (fwd && fwd->deprecate() && !info->is_stock())
         report(info->pos(), 234) << info->name() << fwd->deprecate();

--- a/tests/compile-only/ok-static-used-by-stock.inc
+++ b/tests/compile-only/ok-static-used-by-stock.inc
@@ -1,0 +1,7 @@
+static void SomeHelperFunction()
+{}
+
+stock void HelpMe()
+{
+	SomeHelperFunction();
+}

--- a/tests/compile-only/ok-static-used-by-stock.sp
+++ b/tests/compile-only/ok-static-used-by-stock.sp
@@ -1,0 +1,5 @@
+// warnings_are_errors: true
+#include "ok-static-used-by-stock.inc"
+
+public void main()
+{}


### PR DESCRIPTION
# Solution

This adds stock functions to the maybe used set which seems most appropriate.
We can then mark all of the functions they refer too as maybe used also.

# Testing

Added a new compile only test which should fail if there are any warnings.