### PR TITLE
Update use of Removed ConfigParser.readfp() Function

### DIFF
--- a/tests/testutil.py
+++ b/tests/testutil.py
@@ -64,7 +64,10 @@ def parse_manifest(path, local_folder, source = {}):
 
   with open(path, 'r') as fp:
     cfg = configparser.ConfigParser()
-    cfg.readfp(fp)
+    try:
+      cfg.read_file(fp)
+    except AttributeError:
+      cfg.readfp(fp) # Removed as of configparser version 3.2
 
   for section in cfg.sections():
     if section not in manifest:


### PR DESCRIPTION
# Solution

This was replaced with read_file() in version 3.2. Added a try cactch block around this code so we can delegate through to either version.

# Testing

Testing scripts runs correctly with python 3.12.4.