### PR TITLE
Make InstallBuiltinNatives() virtual.

### DIFF
--- a/vm/plugin-runtime.h
+++ b/vm/plugin-runtime.h
@@ -94,7 +94,7 @@ class PluginRuntime
   bool UsesHeapScopes();
 
   // Mark builtin natives as bound.
-  void InstallBuiltinNatives();
+  virtual void InstallBuiltinNatives();
 
   // Return the method if it was previously analyzed; null otherwise.
   RefPtr<MethodInfo> GetMethod(cell_t pcode_offset) const;


### PR DESCRIPTION
This PR does nothing except make `sp::PluginRuntime::InstallBuiltinNatives()` a virtual function, allowing it to be called in external libraries.

I'm not sure why this isn't already exposed - if there is a reason though, feel free to inform me!