### PR TITLE
Consume whitespace ahead of multiline strings

### DIFF
--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -926,16 +926,7 @@ void Lexer::HandleNewline(char c, char continuation) {
     if (continuation != '\\') {
         state_.tokline++;
         tokens_on_line_ = 0;
-    } else {
-        // New line was escaped, eat all leading whitespace
-        while (true) {
-            char c = peek();
-            if (!IsSpace(c))
-                break;
-            advance();
-        }
     }
-
     state_.line_start = char_stream();
 }
 
@@ -1211,7 +1202,16 @@ void Lexer::packedstring(full_token_t* tok, char term) {
         might_be_multiline = false;
         if (c == '\\') {
             if (MaybeHandleLineContinuation())
+            {
+                // New line was escaped, eat all leading whitespace to match previous behavior
+                while (true) {
+                    char c = peek();
+                    if (!IsSpace(c))
+                        break;
+                    advance();
+                }
                 continue;
+            }
         }
         if (IsNewline(c))
             break;

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -926,7 +926,16 @@ void Lexer::HandleNewline(char c, char continuation) {
     if (continuation != '\\') {
         state_.tokline++;
         tokens_on_line_ = 0;
+    } else {
+        // New line was escaped, eat all leading whitespace
+        while (true) {
+            char c = peek();
+            if (!IsSpace(c))
+                break;
+            advance();
+        }
     }
+
     state_.line_start = char_stream();
 }
 


### PR DESCRIPTION
I believe this matches prior behavior, scalawags be about I hear.


```cpp
#include <sourcemod>
public void OnPluginStart()
{
    char code[1024];
    FormatEx(code, sizeof(code), 
    "<><><><><><><><><><><><><><><><><><><><> %s 1\n\
    <><><><><><><><><><><><><><><><><><><><> %s 1\n"
    , "param1", "param2");
    PrintToServer("%s", code);
}
```

This would lex the string literal into being

```
<><><><><><><><><><><><><><><><><><><><> %s 1
    <><><><><><><><><><><><><><><><><><><><> %s 1
```

See: https://github.com/alliedmodders/sourcemod/issues/2340