### PR TITLE
Don't include the compiler in libsourcepawn_static.

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -393,7 +393,6 @@ class SourcePawn(object):
         vars = self.vars.copy()
         vars['binary'] = binary
 
-        builder.Build('compiler/AMBuilder', vars)
         builder.Build('libsmx/AMBuilder', vars)
         builder.Build('vm/AMBuilder', vars)
 
@@ -427,6 +426,10 @@ class SourcePawn(object):
         binary = self.root.Program(builder, 'spcomp')
         
         self.SetupBinForArch(binary, builder)
+
+        vars = self.vars.copy()
+        vars['binary'] = binary
+        builder.Build('compiler/AMBuilder', vars)
 
         binary.sources = [
             'compiler/driver.cpp',


### PR DESCRIPTION
This reduces the size from ~45MB to 8MB. In practice it doesn't matter since the compiler isn't used in the dynamically linked version.