### PR TITLE
Simplify flow tracking.

### DIFF
--- a/compiler/code-generator.cpp
+++ b/compiler/code-generator.cpp
@@ -1451,9 +1451,8 @@ CodeGenerator::EmitIfStmt(IfStmt* stmt)
     EmitStmt(stmt->on_true());
     if (stmt->on_false()) {
         Label flab2;
-        if (!stmt->on_true()->IsTerminal()) {
+        if (stmt->on_true()->flow_type() == Flow_None)
             __ emit(OP_JUMP, &flab2);
-        }
         __ bind(&flab1);
         EmitStmt(stmt->on_false());
         if (flab2.used())
@@ -1739,8 +1738,8 @@ CodeGenerator::EmitDoWhileStmt(DoWhileStmt* stmt)
 
         EmitStmt(body);
 
-        __ bind(&loop_cx.continue_to);
-        if (body->flow_type() != Flow_Break && body->flow_type() != Flow_Return) {
+        if (!IsTerminalFlow(body->flow_type()) || loop_cx.continue_to.used()) {
+            __ bind(&loop_cx.continue_to);
             if (cond->tree_has_heap_allocs()) {
                 // Need to create a temporary heap scope here.
                 Label on_true, join;
@@ -1778,7 +1777,7 @@ CodeGenerator::EmitDoWhileStmt(DoWhileStmt* stmt)
             EmitTest(cond, false, &loop_cx.break_to);
         }
         EmitStmt(body);
-        if (!body->IsTerminal())
+        if (body->flow_type() == Flow_None)
             __ emit(OP_JUMP, &loop_cx.continue_to);
     }
 
@@ -1804,9 +1803,7 @@ CodeGenerator::EmitLoopControl(int token)
         __ emit(OP_JUMP, &loop_->continue_to);
 }
 
-void
-CodeGenerator::EmitForStmt(ForStmt* stmt)
-{
+void CodeGenerator::EmitForStmt(ForStmt* stmt) {
     ke::Maybe<AutoEnterScope> debug_scope;
 
     auto scope = stmt->scope();
@@ -1823,10 +1820,8 @@ CodeGenerator::EmitForStmt(ForStmt* stmt)
 
     auto body = stmt->body();
     bool body_always_exits = false;
-    if (body->flow_type() == Flow_Return || body->flow_type() == Flow_Break) {
-        if (!stmt->has_continue())
-            body_always_exits = true;
-    }
+    if (IsTerminalFlow(body->flow_type()) && !stmt->has_continue())
+        body_always_exits = true;
 
     auto advance = stmt->advance();
     auto cond = stmt->cond();
@@ -1910,7 +1905,7 @@ CodeGenerator::EmitSwitchStmt(SwitchStmt* stmt)
         }
 
         EmitStmt(stmt);
-        if (!stmt->IsTerminal())
+        if (stmt->flow_type() == Flow_None)
             __ emit(OP_JUMP, &exit_label);
     }
 
@@ -1920,7 +1915,7 @@ CodeGenerator::EmitSwitchStmt(SwitchStmt* stmt)
         __ bind(&default_label);
 
         EmitStmt(stmt->default_case());
-        if (!stmt->default_case()->IsTerminal())
+        if (stmt->default_case()->flow_type() == Flow_None)
             __ emit(OP_JUMP, &exit_label);
 
         defcase = &default_label;
@@ -2193,7 +2188,7 @@ void CodeGenerator::TrackHeapAlloc(ParseNode* node, MemuseType type, int size) {
 
 void CodeGenerator::EnterHeapScope(FlowType flow_type) {
     EnterMemoryScope(heap_scopes_);
-    if (flow_type == Flow_None || flow_type == Flow_Mixed) {
+    if (flow_type != Flow_Return) {
         heap_scopes_.back().needs_restore = true;
         __ emit(OP_HEAP_SAVE);
     }

--- a/compiler/parse-node.cpp
+++ b/compiler/parse-node.cpp
@@ -84,17 +84,6 @@ LogicalExpr::FlattenLogical(int token, std::vector<Expr*>* out)
     }
 }
 
-bool Stmt::IsTerminal() const {
-    switch (flow_type()) {
-        case Flow_Break:
-        case Flow_Continue:
-        case Flow_Return:
-            return true;
-        default:
-            return false;
-    }
-}
-
 BlockStmt*
 BlockStmt::WrapStmt(Stmt* stmt)
 {

--- a/compiler/parse-node.h
+++ b/compiler/parse-node.h
@@ -99,11 +99,14 @@ class ParseNode : public PoolObject
 
 enum FlowType {
     Flow_None,
-    Flow_Break,
     Flow_Continue,
+    Flow_Break,
     Flow_Return,
-    Flow_Mixed
 };
+
+static inline bool IsTerminalFlow(FlowType type) {
+    return type == Flow_Return || type == Flow_Break;
+}
 
 class Stmt : public ParseNode
 {
@@ -123,8 +126,6 @@ class Stmt : public ParseNode
 
     FlowType flow_type() const { return flow_type_; }
     void set_flow_type(FlowType type) { flow_type_ = type; }
-
-    bool IsTerminal() const;
 
     StmtKind kind() const { return kind_; }
     bool is(StmtKind k) const { return kind() == k; }

--- a/compiler/semantics.cpp
+++ b/compiler/semantics.cpp
@@ -2232,14 +2232,6 @@ bool Semantics::CheckIfStmt(IfStmt* stmt) {
         FlowType b = stmt->on_false()->flow_type();
         if (a == b)
             stmt->set_flow_type(a);
-        else if (a != Flow_None && b != Flow_None)
-            stmt->set_flow_type(Flow_Mixed);
-    } else if (stmt->on_true()->flow_type() != Flow_None) {
-        // Ideally, we'd take the "on-true" flow type and propagate it upward.
-        // But that's not accurate, because it's really mixed with an implicit
-        // fallthrough. There's no nice way to handle this and the flow tracker
-        // is already way too complex.
-        stmt->set_flow_type(Flow_Mixed);
     }
 
     if (*always_returns)
@@ -2333,16 +2325,15 @@ bool Semantics::CheckBlockStmt(BlockStmt* block) {
     for (const auto& stmt : block->stmts()) {
         cc_.reports()->ResetErrorFlag();
 
-        if (ok && !sc_->warned_unreachable() && (sc_->always_returns() ||
-            (block->flow_type() != Flow_None && block->flow_type() != Flow_Mixed)))
+        if (ok && !sc_->warned_unreachable() &&
+            (sc_->always_returns() || block->flow_type() != Flow_None))
         {
             report(stmt, 225);
             sc_->set_warned_unreachable();
         }
         ok &= CheckStmt(stmt);
 
-        FlowType flow = stmt->flow_type();
-        if (flow != Flow_None && block->flow_type() == Flow_None)
+        if (FlowType flow = stmt->flow_type(); flow != Flow_None)
             block->set_flow_type(flow);
     }
 
@@ -2703,10 +2694,8 @@ bool Semantics::CheckSwitchStmt(SwitchStmt* stmt) {
 
     auto update_flow = [&](FlowType other) -> void {
         if (flow) {
-            if (*flow == Flow_None || other == Flow_None)
+            if (*flow != other)
                 *flow = Flow_None;
-            else if (*flow != other)
-                *flow = Flow_Mixed;
         } else {
             flow.init(other);
         }


### PR DESCRIPTION
The control-flow tracking algorithm of statements made no sense and historically has been buggy. This patch simplifies it. If the last statement of a block is a return, continue, or break, that is the flow type of the block.

When analyzing loop bodies, "return" or "break" flow types indicate that the loop does not iterate, unless a "continue" is also present in the body.