### PR TITLE
Add a better API for accessing arrays.

### DIFF
--- a/include/sp_vm_api.h
+++ b/include/sp_vm_api.h
@@ -23,8 +23,8 @@
 #include "sp_vm_types.h"
 
 /** SourcePawn Engine API Versions */
-#define SOURCEPAWN_ENGINE2_API_VERSION 0x11
-#define SOURCEPAWN_API_VERSION 0x0215
+#define SOURCEPAWN_ENGINE2_API_VERSION 0x12
+#define SOURCEPAWN_API_VERSION 0x0216
 
 namespace SourceMod {
 struct IdentityToken_t;
@@ -390,6 +390,9 @@ class IPluginDebugInfo
 };
 
 class ICompilation;
+
+struct ARRAY_HANDLE;
+typedef ARRAY_HANDLE* ARRAY_PTR;
 
 /**
    * @brief Interface to managing a runtime plugin.
@@ -1252,6 +1255,38 @@ class IPluginContext
      * the function is invalid or null.
      */
     virtual IPluginFunction* GetFunctionByIdOrError(funcid_t func) = 0;
+
+    /**
+     * @brief Convert a local address to an ARRAY_PTR handle.
+     *
+     * Not supported for plugins compiled with SourcePawn 1.10 or earlier.
+     *
+     * @param base      Array base.
+     * @param out       Array pointer handle.
+     */
+    virtual int LocalToArrayPtr(cell_t base, ARRAY_PTR* out) = 0;
+
+    /**
+     * @brief Return the data vector for an array.
+     *
+     * For character arrays, the pointer should be casted to a uint8_t* or char*.
+     * For int64 arrays, the pointer should be casted to an int64_t* or uint64_t*.
+     * For all other types, the pointer should be casted to a cell_t*.
+     *
+     * If UsesDirectArrays() is false, note that |data[i]| will not yield an
+     * interior array pointer if the array has interior arrays. Instead, the
+     * formula is:
+     *
+     *      array_base + (i * sizeof(cell_t)) + data[i]
+     *
+     * @param handle    Array pointer handle.
+     * @param size      Optional pointer to store size of the array. If zero,
+     *                  and the return pointer is not null, then the array
+     *                  length is not supported.
+     * @return          Pointer to the data vector for the array, or null if
+     *                  the array has no data vector (zero length).
+     */
+    virtual void* GetArrayData(ARRAY_PTR handle, uint32_t* size = nullptr) = 0;
 };
 
 class AutoEnterHeapScope

--- a/vm/base-context.cpp
+++ b/vm/base-context.cpp
@@ -218,3 +218,17 @@ void
 BasePluginContext::DestroyFrameIterator(IFrameIterator* it) {
     delete static_cast<FrameIterator*>(it);
 }
+
+int BasePluginContext::LocalToArrayPtr(cell_t base, ARRAY_PTR* out) {
+    cell_t* phys;
+    if (int err = LocalToPhysAddr(base, &phys))
+        return err;
+    *out = reinterpret_cast<ARRAY_PTR>(phys);
+    return SP_ERROR_NONE;
+}
+
+void* BasePluginContext::GetArrayData(ARRAY_PTR handle, uint32_t* size) {
+    if (size)
+        *size = 0;
+    return reinterpret_cast<void*>(handle);
+}

--- a/vm/base-context.h
+++ b/vm/base-context.h
@@ -44,6 +44,9 @@ class BasePluginContext : public SourcePawn::IPluginContext
     IFrameIterator* CreateFrameIterator() override;
     void DestroyFrameIterator(IFrameIterator* it) override;
 
+    int LocalToArrayPtr(cell_t base, ARRAY_PTR* out) override;
+    void* GetArrayData(ARRAY_PTR handle, uint32_t* size = nullptr) override;
+
     // Removed functions.
     int PushCell(cell_t value) override;
     int PushCellArray(cell_t* local_addr, cell_t** phys_addr, cell_t array[],

--- a/vm/shell/shell.cpp
+++ b/vm/shell/shell.cpp
@@ -308,19 +308,30 @@ static cell_t AssertEq(IPluginContext* cx, const cell_t* params)
 
 static cell_t Access2DArray(IPluginContext* cx, const cell_t* params)
 {
-  cell_t* phys_in;
+  ARRAY_PTR array;
   cell_t* phys_out;
+  uint32_t size;
 
   if (!cx->GetRuntime()->UsesDirectArrays())
     return 0;
 
   int err;
-  if ((err = cx->LocalToPhysAddr(params[1], &phys_in)) != SP_ERROR_NONE)
+  if ((err = cx->LocalToArrayPtr(params[1], &array)) != SP_ERROR_NONE)
     return cx->ThrowNativeErrorEx(err, "Could not read argument");
+
+  cell_t* phys_in = reinterpret_cast<cell_t*>(cx->GetArrayData(array, &size));
+  if (size != 0 && (uint32_t)params[2] >= size)
+    return cx->ThrowNativeErrorEx(SP_ERROR_ARRAY_BOUNDS, "Index out of bounds (level 0)");
+
+  if ((err = cx->LocalToArrayPtr(phys_in[params[2]], &array)) != SP_ERROR_NONE)
+    return cx->ThrowNativeErrorEx(err, "Could not read array level 0");
+
+  phys_in = reinterpret_cast<cell_t*>(cx->GetArrayData(array, &size));
+  if (size != 0 && (uint32_t)params[3] >= size)
+    return cx->ThrowNativeErrorEx(SP_ERROR_ARRAY_BOUNDS, "Index out of bounds (level 1)");
+
   if ((err = cx->LocalToPhysAddr(params[4], &phys_out)) != SP_ERROR_NONE)
     return cx->ThrowNativeErrorEx(err, "Could not read argument");
-  if ((err = cx->LocalToPhysAddr(phys_in[params[2]], &phys_in)) != SP_ERROR_NONE)
-    return cx->ThrowNativeErrorEx(err, "Could not read array level 0");
 
   *phys_out = phys_in[params[3]];
   return 1;
@@ -328,11 +339,12 @@ static cell_t Access2DArray(IPluginContext* cx, const cell_t* params)
 
 static cell_t Copy2dArrayToCallback(IPluginContext* cx, const cell_t* params)
 {
-  cell_t* flat_array;
+  ARRAY_PTR array;
 
   int err;
-  if ((err = cx->LocalToPhysAddr(params[1], &flat_array)) != SP_ERROR_NONE)
+  if ((err = cx->LocalToArrayPtr(params[1], &array)) != SP_ERROR_NONE)
     return cx->ThrowNativeErrorEx(err, "Could not read argument 1");
+  cell_t* flat_array = reinterpret_cast<cell_t*>(cx->GetArrayData(array));
 
   IPluginFunction* fn = cx->GetFunctionById(params[4]);
   if (!fn)


### PR DESCRIPTION
This is intended to future-proof the API, especially for multi-dimensional arrays, and avoid LocalToPhysAddr hacks.