### PR TITLE
Remove a bunch of legacy API.

### DIFF
--- a/include/sp_vm_api.h
+++ b/include/sp_vm_api.h
@@ -758,37 +758,22 @@ class IPluginContext
     virtual IPluginDebugInfo* GetDebugInfo() = 0;
 
     /**
-     * @brief Allocates memory on the secondary stack of a plugin.
-     * Note that although called a heap, it is in fact a stack.
-     *
-     * @param cells      Number of cells to allocate.
-     * @param local_addr  Will be filled with data offset to heap.
-     * @param phys_addr    Physical address to heap memory.
+     * @brief Deprecated; do not use.
      */
-    virtual int HeapAlloc(unsigned int cells, cell_t* local_addr, cell_t** phys_addr) = 0;
+    [[deprecated]]
+    virtual int HeapAlloc(unsigned int, cell_t*, cell_t**) = 0;
 
     /**
-     * @brief Pops a heap address off the heap stack.  Use this to free memory allocated with
-     *  SP_HeapAlloc().
-     * Note that in SourcePawn, the heap is in fact a bottom-up stack.  Deallocations
-     *  with this native should be performed in precisely the REVERSE order.
-     *
-     * @param local_addr  Local address to free.
-      */
-    virtual int HeapPop(cell_t local_addr) = 0;
+     * @brief Deprecated; do not use.
+     */
+    [[deprecated]]
+    virtual int HeapPop(cell_t) = 0;
 
     /**
-     * @brief Releases a heap address using a different method than SP_HeapPop().
-     * This allows you to release in any order.  However, if you allocate N
-     *  objects, release only some of them, then begin allocating again,
-     *  you cannot go back and starting freeing the originals.
-     * In other words, for each chain of allocations, if you start deallocating,
-     *  then allocating more in a chain, you must only deallocate from the current
-     *  allocation chain.  This is basically HeapPop() except on a larger scale.
-     *
-     * @param local_addr  Local address to free.
-      */
-    virtual int HeapRelease(cell_t local_addr) = 0;
+     * @brief Deprecated; do not use.
+     */
+    [[deprecated]]
+    virtual int HeapRelease(cell_t) = 0;
 
     /**
      * @brief Deprecated, use IPluginRuntime instead.
@@ -1199,6 +1184,9 @@ class IPluginContext
      * EnterHeapScope and LeaveHeapScope, or AutoEnterHeapScope).
      *
      * If |init| is not specified, the resulting array will be zeroed.
+     *
+     * The address stored in |local_addr| must not be passed to LocalToPhysAddr.
+     * Instead, LocalToArrayPtr() should be used instead.
      *
      * If an error occurs, it is automatically reported.
      *

--- a/vm/plugin-context.cpp
+++ b/vm/plugin-context.cpp
@@ -85,19 +85,11 @@ PluginContext::Initialize() {
     return true;
 }
 
-int
-PluginContext::HeapAlloc(unsigned int cells, cell_t* local_addr, cell_t** phys_addr) {
+int PluginContext::AllocArray(unsigned int cells, cell_t* local_addr, cell_t** phys_addr) {
     cell_t* addr;
     ucell_t realmem;
 
-#if 0
-  if (cells > CELLBOUNDMAX)
-  {
-    return SP_ERROR_ARAM;
-  }
-#else
     assert(cells < CELLBOUNDMAX);
-#endif
 
     realmem = cells * sizeof(cell_t);
 
@@ -127,35 +119,16 @@ PluginContext::HeapAlloc(unsigned int cells, cell_t* local_addr, cell_t** phys_a
     return SP_ERROR_NONE;
 }
 
-int
-PluginContext::HeapPop(cell_t local_addr) {
-    cell_t cellcount;
-    cell_t* addr;
-
-    /* check the bounds of this address */
-    local_addr -= sizeof(cell_t);
-    if (local_addr < (cell_t)data_size_ || local_addr >= sp_)
-        return SP_ERROR_INVALID_ADDRESS;
-
-    addr = (cell_t*)(memory_ + local_addr);
-    cellcount = (*addr) * sizeof(cell_t);
-    /* check if this memory count looks valid */
-    if ((signed)(hp_ - cellcount - sizeof(cell_t)) != local_addr)
-        return SP_ERROR_INVALID_ADDRESS;
-
-    hp_ = local_addr;
-
-    return SP_ERROR_NONE;
+int PluginContext::HeapAlloc(unsigned int cells, cell_t* local_addr, cell_t** phys_addr) {
+    return SP_ERROR_INVALID_INSTRUCTION;
 }
 
-int
-PluginContext::HeapRelease(cell_t local_addr) {
-    if (local_addr < (cell_t)data_size_)
-        return SP_ERROR_INVALID_ADDRESS;
+int PluginContext::HeapPop(cell_t) {
+    return SP_ERROR_INVALID_INSTRUCTION;
+}
 
-    hp_ = local_addr - sizeof(cell_t);
-
-    return SP_ERROR_NONE;
+int PluginContext::HeapRelease(cell_t) {
+    return SP_ERROR_INVALID_INSTRUCTION;
 }
 
 int

--- a/vm/plugin-context.h
+++ b/vm/plugin-context.h
@@ -34,9 +34,9 @@ class PluginContext final : public BasePluginContext
     bool Initialize();
 
   public: //IPluginContext
-    int HeapAlloc(unsigned int cells, cell_t* local_addr, cell_t** phys_addr) override;
-    int HeapPop(cell_t local_addr) override;
-    int HeapRelease(cell_t local_addr) override;
+    [[deprecated]] int HeapAlloc(unsigned int, cell_t*, cell_t**) override;
+    [[deprecated]] int HeapPop(cell_t) override;
+    [[deprecated]] int HeapRelease(cell_t) override;
     int FindNativeByName(const char* name, uint32_t* index) override;
     int GetNativeByIndex(uint32_t index, sp_native_t** native) override;
     uint32_t GetNativesNum() override;
@@ -67,6 +67,8 @@ class PluginContext final : public BasePluginContext
     bool GetFunctionByIdOrNull(funcid_t func, IPluginFunction** out) override;
     IPluginFunction* GetFunctionByIdOrError(funcid_t func_id) override;
     bool Invoke(funcid_t fnid, const cell_t* params, unsigned int num_params, cell_t* result);
+
+    int AllocArray(unsigned int cells, cell_t* local_addr, cell_t** phys_addr);
 
     size_t HeapSize() const {
         return mem_size_;

--- a/vm/scripted-invoker.cpp
+++ b/vm/scripted-invoker.cpp
@@ -189,8 +189,7 @@ ScriptedInvoker::Execute(cell_t* result) {
     return SP_ERROR_NONE;
 }
 
-bool
-ScriptedInvoker::Invoke(cell_t* result) {
+bool ScriptedInvoker::Invoke(cell_t* result) {
     if (!IsRunnable()) {
         Cancel();
         env_->ReportError(SP_ERROR_NOT_RUNNABLE);
@@ -201,6 +200,11 @@ ScriptedInvoker::Invoke(cell_t* result) {
         env_->ReportError(err);
         return false;
     }
+
+    context_->EnterHeapScope();
+    ke::ScopeGuard leave_heap_scope([this]() -> void {
+        context_->LeaveHeapScope();
+    });
 
     //This is for re-entrancy!
     cell_t temp_params[SP_MAX_EXEC_PARAMS];
@@ -221,8 +225,8 @@ ScriptedInvoker::Invoke(cell_t* result) {
         if (temp_info[i].marked) {
             if (!temp_info[i].str.is_sz) {
                 /* Allocate a normal/generic array */
-                int err = context_->HeapAlloc(temp_info[i].size, &temp_info[i].local_addr,
-                                              &temp_info[i].phys_addr);
+                int err = context_->AllocArray(temp_info[i].size, &temp_info[i].local_addr,
+                                               &temp_info[i].phys_addr);
                 if (err != SP_ERROR_NONE) {
                     env_->ReportError(err);
                     ok = false;
@@ -238,7 +242,7 @@ ScriptedInvoker::Invoke(cell_t* result) {
 
                 /* Allocate the buffer */
                 int err =
-                    context_->HeapAlloc(cells, &temp_info[i].local_addr, &temp_info[i].phys_addr);
+                    context_->AllocArray(cells, &temp_info[i].local_addr, &temp_info[i].phys_addr);
                 if (err != SP_ERROR_NONE) {
                     env_->ReportError(err);
                     ok = false;
@@ -302,9 +306,6 @@ ScriptedInvoker::Invoke(cell_t* result) {
                 }
             }
         }
-
-        if (int err = context_->HeapPop(temp_info[i].local_addr))
-            env_->ReportError(err);
     }
 
     return !env_->hasPendingException();


### PR DESCRIPTION
HeapAlloc, HeapPop, and HeapRelease are not really compatible with the direction the VM is going. Remove the implementations and mark them as deprecated.

SourceMod will need some fixups here, but it should be trivial.