### PR TITLE
Fix error 155 when function-like macro follows enum struct / methodmap `}`

### DIFF
--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -2217,6 +2217,14 @@ int Lexer::peek_same_line() {
         return next_token()->id ? next_token()->id : tEOL;
     }
 
+    // Save the line of the current (last consumed) token before lexing ahead.
+    // lex_tok() may trigger macro expansion which calls nested lex() and
+    // advances the cursor by multiple positions. After lexpush(), the cursor
+    // may not point to the original token. We snapshot the line/file here
+    // so the comparison below uses the correct values.
+    uint32_t last_line = current_token()->start.line;
+    auto last_file = current_token()->start;
+
     // Make sure the next token is lexed, then buffer it.
     full_token_t next = lex_tok();
     if (next.id == 0 || next.id == tEOL)
@@ -2226,8 +2234,8 @@ int Lexer::peek_same_line() {
 
     // If the next token starts on the line the last token ends, then the next
     // token is considered on the same line.
-    if (next.start.line == current_token()->start.line &&
-        IsSameSourceFile(current_token()->start, next_token()->start))
+    if (next.start.line == last_line &&
+        IsSameSourceFile(last_file, next_token()->start))
     {
         return next.id;
     }
@@ -2668,8 +2676,19 @@ bool Lexer::EnterMacro(std::shared_ptr<MacroEntry> macro) {
 
     std::unordered_map<int, std::string> macro_args;
     if (macro->args) {
-        if (!match('('))
+        // Nested lex() calls below (match, need) advance the token buffer
+        // cursor. Save and restore state so the caller's position is not
+        // corrupted by macro argument parsing.
+        size_t saved_cursor = token_buffer_->cursor;
+        size_t saved_depth = token_buffer_->depth;
+        int saved_num_tokens = token_buffer_->num_tokens;
+
+        if (!match('(')) {
+            token_buffer_->cursor = saved_cursor;
+            token_buffer_->depth = saved_depth;
+            token_buffer_->num_tokens = saved_num_tokens;
             return false;
+        }
 
         auto saved_pos = pos();
 
@@ -2682,6 +2701,19 @@ bool Lexer::EnterMacro(std::shared_ptr<MacroEntry> macro) {
             macro_args.emplace(argn, std::move(arg_str));
         }
         need(')');
+
+        // Discard tokens consumed by nested lex() during arg parsing.
+        // Clear all polluted slots (from saved_cursor up to the current
+        // cursor) to prevent stale data from leaking into subsequent
+        // peek_same_line() calls.
+        int slots_polluted = token_buffer_->num_tokens - saved_num_tokens;
+        for (int i = 0; i < slots_polluted && i < MAX_TOKEN_DEPTH; i++) {
+            size_t slot = (saved_cursor + i) % MAX_TOKEN_DEPTH;
+            token_buffer_->tokens[slot] = {};
+        }
+        token_buffer_->cursor = saved_cursor;
+        token_buffer_->depth = saved_depth;
+        token_buffer_->num_tokens = saved_num_tokens;
 
         if (macro_args.size() != macro->args.get().size()) {
             report(saved_pos, 429) << macro->args.get().size() << macro_args.size();

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -2684,8 +2684,11 @@ bool Lexer::EnterMacro(std::shared_ptr<MacroEntry> macro) {
         int saved_num_tokens = token_buffer_->num_tokens;
 
         if (!match('(')) {
+            // match() failed: lex() peeked at the next token, found it
+            // wasn't '(', and called lexpush().  depth is now 1 and the
+            // pushed-back token must be replayed.  Only rewind cursor
+            // and num_tokens; leave depth alone.
             token_buffer_->cursor = saved_cursor;
-            token_buffer_->depth = saved_depth;
             token_buffer_->num_tokens = saved_num_tokens;
             return false;
         }


### PR DESCRIPTION
https://github.com/alliedmodders/sourcepawn/issues/1035
https://github.com/alliedmodders/sourcepawn/issues/1050
A function-like macro right after a methodmap/enum struct/typeset `}` — or inside a methodmap body — gets error 155.  But these cases worked fine in 1.10.

The bug: `EnterMacro()` calls `lex()` to eat macro arguments like `(a)`. Those nested `lex()` calls write tokens into the ring buffer and bump the cursor, but `EnterMacro()` never cleaned up properly afterward.`peek_same_line()` then finds stale token data, thinks there's something on the same line, and fires error 155.

The fix:
- Save and restore cursor/depth/num_tokens in `EnterMacro()`, clear the polluted buffer slots.
- Snapshot the current token's line in `peek_same_line()` before `lex_tok()` can shift things around.

Note:  need more tests.

### Cases fixed
```sourcepawn

#define M(%1) int x_%1;


// ---- methodmap ----

methodmap MM {
    public MM() { return view_as<MM>(0); }
}
M(a)


// ---- enum struct ----

enum struct ES {
    int abc;
}
M(b)


// ---- typeset ----

typeset TS {
    function int (int a);
}
M(c)


// ---- struct (pstruct) ----

struct PS {
    public int abc;
}
M(d)


// ---- static_assert ----

static_assert(true)
M(e)

// ---- macro inside methodmap body ----

#define MM_FUNC(%1) public void %1(){}

methodmap ABC
{
    public void A1(){}
    MM_FUNC(A2)
}

```
