### PR TITLE
Add a replacement for ICallable.

### DIFF
--- a/include/sp_callable.h
+++ b/include/sp_callable.h
@@ -1,0 +1,137 @@
+// vim: set ts=8 sts=4 sw=4 tw=99 et:
+//
+// Copyright (C) 2006-2015 AlliedModders LLC
+//
+// This file is part of SourcePawn. SourcePawn is free software: you can
+// redistribute it and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+//
+// You should have received a copy of the GNU General Public License along with
+// SourcePawn. If not, see http://www.gnu.org/licenses/.
+//
+#pragma once
+
+#include <string.h>
+
+#include <array>
+
+#include <sp_typeutil.h>
+#include <sp_vm_types.h>
+
+/* Parameter flags */
+#define SM_PARAM_COPYBACK (1 << 0) /**< Copy an array/reference back after call */
+
+/* String parameter flags (separate from parameter flags) */
+#define SM_PARAM_STRING_UTF8 (1 << 1)   /**< String should be UTF-8 handled */
+#define SM_PARAM_STRING_COPY (1 << 2)   /**< String should be copied into the plugin */
+#define SM_PARAM_STRING_BINARY (1 << 3) /**< String should be handled as binary data */
+
+namespace sp {
+
+struct CallArgs {
+    void PushCell(cell_t cell) {
+        if (argc >= argv.size()) {
+            error = true;
+            return;
+        }
+        argv[argc].u.value = cell;
+        argv[argc].type = ARG_CELL;
+        argc++;
+        return;
+    }
+    void PushCellByRef(cell_t* cell, int flags = SM_PARAM_COPYBACK) {
+        if (argc >= argv.size()) {
+            error = true;
+            return;
+        }
+        argv[argc].u.addr = cell;
+        argv[argc].flags = flags;
+        argv[argc].type = ARG_CELL_BY_REF;
+        argc++;
+        return;
+    }
+    void PushFloat(float number) {
+        return PushCell(sp_ftoc(number));
+    }
+    void PushFloatByRef(float* number, int flags = SM_PARAM_COPYBACK) {
+        return PushCellByRef(reinterpret_cast<cell_t*>(number), flags);
+    }
+    void PushArray(cell_t* inarray, unsigned int cells, int flags = 0) {
+        if (argc >= argv.size()) {
+            error = true;
+            return;
+        }
+        argv[argc].u.addr = inarray;
+        argv[argc].flags = flags;
+        argv[argc].type = ARG_ARRAY;
+        argv[argc].array_size = cells;
+        argc++;
+        return;
+    }
+    void PushString(const char* string) {
+        if (argc >= argv.size()) {
+            error = true;
+            return;
+        }
+        argv[argc].u.addr = (void*)string;
+        argv[argc].flags = SM_PARAM_STRING_COPY;
+        argv[argc].type = ARG_CHAR_ARRAY;
+        argv[argc].array_size = strlen(string) + 1;
+        argc++;
+        return;
+    }
+    void PushString(char* buffer, size_t length, int flags) {
+        if (argc >= argv.size()) {
+            error = true;
+            return;
+        }
+        argv[argc].u.addr = buffer;
+        argv[argc].flags = flags;
+        argv[argc].type = ARG_CHAR_ARRAY;
+        argv[argc].array_size = length;
+        argc++;
+        return;
+    }
+    void PushInt64(int64_t value) {
+        if (argc >= argv.size()) {
+            error = true;
+            return;
+        }
+        argv[argc].u.i64 = value;
+        argv[argc].type = ARG_INT64;
+        argc++;
+        return;
+    }
+
+    void Reset() {
+        argc = 0;
+        error = false;
+    }
+
+    enum ArgType {
+        ARG_CELL,
+        ARG_CELL_BY_REF,
+        ARG_ARRAY,
+        ARG_CHAR_ARRAY,
+        ARG_INT64,
+    };
+
+    int api_version = kApiVersion;
+
+    struct ArgInfo {
+        union {
+            cell_t value;
+            void* addr;
+            int64_t i64;
+        } u;
+        uint16_t flags;
+        uint16_t type;
+        uint32_t array_size;
+    };
+    std::array<ArgInfo, SP_MAX_EXEC_PARAMS> argv;
+    uint32_t argc = 0;
+    bool error = false;
+};
+
+} // namespace sp

--- a/include/sp_vm_api.h
+++ b/include/sp_vm_api.h
@@ -21,6 +21,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include "sp_vm_types.h"
+#include "sp_callable.h"
 
 /** SourcePawn Engine API Versions */
 
@@ -39,14 +40,6 @@ class ISourcePawnEnvironment;
 class IVirtualMachine;
 typedef ISourcePawnEnvironment ISourcePawnEngine;
 typedef ISourcePawnEnvironment ISourcePawnEngine2;
-
-/* Parameter flags */
-#define SM_PARAM_COPYBACK (1 << 0) /**< Copy an array/reference back after call */
-
-/* String parameter flags (separate from parameter flags) */
-#define SM_PARAM_STRING_UTF8 (1 << 0)   /**< String should be UTF-8 handled */
-#define SM_PARAM_STRING_COPY (1 << 1)   /**< String should be copied into the plugin */
-#define SM_PARAM_STRING_BINARY (1 << 2) /**< String should be handled as binary data */
 
 /**
    * @brief Pseudo-NULL reference types.
@@ -98,114 +91,12 @@ class INativeCallback : public IRefcountedObject
     virtual cell_t Invoke(IPluginContext* ctx, const cell_t* params) = 0;
 };
 
-/**
- * @brief Represents what a function needs to implement in order to be callable.
- */
-class ICallable
-{
-  public:
-    /**
-     * @brief Pushes a cell onto the current call.
-     *
-     * @param cell    Parameter value to push.
-     * @return      Error code, if any.
-     */
-    virtual int PushCell(cell_t cell) = 0;
-
-    /**
-     * @brief Pushes a cell by reference onto the current call.
-     * NOTE: On Execute, the pointer passed will be modified if copyback is enabled.
-     * NOTE: By reference parameters are cached and thus are not read until execution.
-     *     This means you cannot push a pointer, change it, and push it again and expect
-     *       two different values to come out.
-     *
-     * @param cell    Address containing parameter value to push.
-     * @param flags    Copy-back flags.
-     * @return      Error code, if any.
-     */
-    virtual int PushCellByRef(cell_t* cell, int flags = SM_PARAM_COPYBACK) = 0;
-
-    /**
-     * @brief Pushes a float onto the current call.
-     *
-     * @param number  Parameter value to push.
-     * @return      Error code, if any.
-     */
-    virtual int PushFloat(float number) = 0;
-
-    /**
-     * @brief Pushes a float onto the current call by reference.
-     * NOTE: On Execute, the pointer passed will be modified if copyback is enabled.
-     * NOTE: By reference parameters are cached and thus are not read until execution.
-     *     This means you cannot push a pointer, change it, and push it again and expect
-     *       two different values to come out.
-     *
-     * @param number  Parameter value to push.
-     * @param flags    Copy-back flags.
-     * @return      Error code, if any.
-     */
-    virtual int PushFloatByRef(float* number, int flags = SM_PARAM_COPYBACK) = 0;
-
-    /**
-     * @brief Pushes an array of cells onto the current call.
-     *
-     * On Execute, the pointer passed will be modified if non-NULL and copy-back
-     * is enabled.
-     *
-     * By reference parameters are cached and thus are not read until execution.
-     * This means you cannot push a pointer, change it, and push it again and expect
-     * two different values to come out.
-     *
-     * @param inarray  Array to copy, NULL if no initial array should be copied.
-     * @param cells    Number of cells to allocate and optionally read from the input array.
-     * @param flags    Whether or not changes should be copied back to the input array.
-     * @return      Error code, if any.
-     */
-    virtual int PushArray(cell_t* inarray, unsigned int cells, int flags = 0) = 0;
-
-    /**
-     * @brief Pushes a string onto the current call.
-     *
-     * @param string  String to push.
-     * @return      Error code, if any.
-     */
-    virtual int PushString(const char* string) = 0;
-
-    /**
-     * @brief Pushes a string or string buffer.
-     *
-     * NOTE: On Execute, the pointer passed will be modified if copy-back is enabled.
-     *
-     * @param buffer  Pointer to string buffer.
-     * @param length  Length of buffer.
-     * @param sz_flags  String flags.  In copy mode, the string will be copied
-     *          according to the handling (ascii, utf-8, binary, etc).
-     * @param cp_flags  Copy-back flags.
-     * @return      Error code, if any.
-     */
-    virtual int PushStringEx(char* buffer, size_t length, int sz_flags, int cp_flags) = 0;
-
-    /**
-     * @brief Cancels a function call that is being pushed but not yet executed.
-     */
-    virtual void Cancel() = 0;
-
-    /**
-     * @brief Pushes an int64 value onto the current call.
-     *
-     * @param number    Parameter to push.
-     * @return          Error code, if any.
-     */
-    virtual int PushInt64(int64_t value) = 0;
-};
-
-/**
+ /**
    * @brief Encapsulates a function call in a plugin.
    *
-   * NOTE: Function calls must be atomic to one execution context.
    * NOTE: This object should not be deleted.  It lives for the lifetime of the plugin.
    */
-class IPluginFunction : public ICallable
+class IPluginFunction
 {
   public:
     /**
@@ -253,6 +144,26 @@ class IPluginFunction : public ICallable
     virtual IPluginRuntime* GetParentRuntime() = 0;
 
     /**
+     * @brief Returns a name to identify this function for debugging purposes.
+     *
+     * @return       String name.
+     */
+    virtual const char* DebugName() = 0;
+
+    // These functions are provided for source-level compatibility, but are
+    // deprecated. Invoke() should be used instead. Errors are never returned.
+    virtual void Cancel() = 0;
+    virtual int PushCell(cell_t cell) = 0;
+    virtual int PushCellByRef(cell_t* cell, int flags = SM_PARAM_COPYBACK) = 0;
+    virtual int PushFloat(float number) = 0;
+    virtual int PushFloatByRef(float* number, int flags = SM_PARAM_COPYBACK) = 0;
+    virtual int PushArray(cell_t* inarray, unsigned int cells, int flags = 0) = 0;
+    virtual int PushString(const char* string) = 0;
+    virtual int PushStringEx(char* buffer, size_t length, int sz_flags, int cp_flags) = 0;
+    virtual int PushInt64(int64_t value) = 0;
+    virtual bool Invoke(cell_t* rval = nullptr) = 0;
+
+    /**
      * @brief Executes the function, resets the pushed parameter list, and
      * performs any copybacks.
      *
@@ -262,16 +173,9 @@ class IPluginFunction : public ICallable
      * handled via ExceptionHandler or propagated to its caller.
      *
      * @param result    Pointer to store return value in.
-     * @return        True on success, false on error.
+     * @return          True on success, false on error.
      */
-    virtual bool Invoke(cell_t* rval = nullptr) = 0;
-
-    /**
-     * @brief Returns a name to identify this function for debugging purposes.
-     *
-     * @return       String name.
-     */
-    virtual const char* DebugName() = 0;
+    virtual bool Invoke(const sp::CallArgs& args, cell_t* rval = nullptr) = 0;
 };
 
 /**
@@ -951,6 +855,9 @@ class ISourcePawnEnvironment
     ISourcePawnEnvironment* Environment() { return this; }
     ISourcePawnEngine* APIv1() { return this; }
     ISourcePawnEngine2* APIv2() { return this; }
+
+    // Return the API version of this SourcePawn VM.
+    virtual uint32_t GetApiVersion() = 0;
 
     /**
      * @brief Allocates executable memory.

--- a/include/sp_vm_types.h
+++ b/include/sp_vm_types.h
@@ -45,6 +45,10 @@ typedef uint32_t funcid_t; /**< Function index code */
 
 #include "sp_typeutil.h"
 
+namespace sp {
+static constexpr uint32_t kApiVersion = 1;
+} // namespace sp
+
 #define SP_MAX_EXEC_PARAMS 32 /**< Maximum number of parameters in a function signature */
 #define SP_MAX_CALL_ARGUMENTS \
     127 /**< Maximum number of arguments when calling a function (relates to the bit pattern of sEXPRSTART) */

--- a/vm/environment.h
+++ b/vm/environment.h
@@ -59,6 +59,8 @@ class Environment : public ISourcePawnEnvironment
     // active code running on the stack.
     void Shutdown();
 
+    uint32_t GetApiVersion() override { return kApiVersion; }
+
     // ISourcePawnEnvironment (from Engine/Engine2)
     void* AllocatePageMemory(size_t size) override;
     void SetReadWrite(void* ptr) override;

--- a/vm/scripted-invoker.cpp
+++ b/vm/scripted-invoker.cpp
@@ -10,10 +10,13 @@
 // You should have received a copy of the GNU General Public License along with
 // SourcePawn. If not, see http://www.gnu.org/licenses/.
 //
-
 #include "scripted-invoker.h"
+
 #include <stdio.h>
 #include <string.h>
+
+#include <utility>
+
 #include "environment.h"
 #include "method-info.h"
 #include "plugin-runtime.h"
@@ -28,8 +31,6 @@ using namespace SourcePawn;
 ScriptedInvoker::ScriptedInvoker(PluginRuntime* runtime, funcid_t id, uint32_t pub_id)
  : env_(Environment::get()),
    context_(runtime),
-   m_curparam(0),
-   m_errorstate(SP_ERROR_NONE),
    m_FnId(id)
 {
     runtime->GetPublicByIndex(pub_id, &public_);
@@ -56,103 +57,184 @@ ScriptedInvoker::GetParentContext() {
     return context_;
 }
 
-int
-ScriptedInvoker::PushCell(cell_t cell) {
-    if (m_curparam >= SP_MAX_EXEC_PARAMS)
-        return SetError(SP_ERROR_PARAMS_MAX);
-
-    m_info[m_curparam].marked = false;
-    m_params[m_curparam] = cell;
-    m_curparam++;
-
-    return SP_ERROR_NONE;
+int ScriptedInvoker::PushCell(cell_t cell) {
+    default_args_.PushCell(cell);
+    return default_args_.error ? SP_ERROR_PARAMS_MAX : SP_ERROR_NONE;
 }
 
-int
-ScriptedInvoker::PushCellByRef(cell_t* cell, int flags) {
-    return PushArray(cell, 1, flags);
+int ScriptedInvoker::PushCellByRef(cell_t* cell, int flags) {
+    default_args_.PushCellByRef(cell, flags);
+    return default_args_.error ? SP_ERROR_PARAMS_MAX : SP_ERROR_NONE;
 }
 
-int
-ScriptedInvoker::PushFloat(float number) {
-    cell_t val = sp::FloatCellUnion(number).cell;
-
-    return PushCell(val);
+int ScriptedInvoker::PushFloat(float number) {
+    default_args_.PushFloat(number);
+    return default_args_.error ? SP_ERROR_PARAMS_MAX : SP_ERROR_NONE;
 }
 
-int
-ScriptedInvoker::PushFloatByRef(float* number, int flags) {
-    return PushCellByRef((cell_t*)number, flags);
+int ScriptedInvoker::PushFloatByRef(float* number, int flags) {
+    default_args_.PushFloatByRef(number, flags);
+    return default_args_.error ? SP_ERROR_PARAMS_MAX : SP_ERROR_NONE;
 }
 
-int
-ScriptedInvoker::PushArray(cell_t* inarray, unsigned int cells, int copyback) {
-    if (m_curparam >= SP_MAX_EXEC_PARAMS) {
-        return SetError(SP_ERROR_PARAMS_MAX);
-    }
-
-    ParamInfo* info = &m_info[m_curparam];
-
-    info->flags = inarray ? copyback : 0;
-    info->marked = true;
-    info->size = cells;
-    info->str.is_sz = false;
-    info->orig_addr = inarray;
-
-    m_curparam++;
-
-    return SP_ERROR_NONE;
+int ScriptedInvoker::PushArray(cell_t* inarray, unsigned int cells, int copyback) {
+    default_args_.PushArray(inarray, cells, copyback ? SM_PARAM_COPYBACK : 0);
+    return default_args_.error ? SP_ERROR_PARAMS_MAX : SP_ERROR_NONE;
 }
 
 int ScriptedInvoker::PushInt64(int64_t value) {
-    if (m_curparam >= SP_MAX_EXEC_PARAMS) {
-        return SetError(SP_ERROR_PARAMS_MAX);
+    default_args_.PushInt64(value);
+    return default_args_.error ? SP_ERROR_PARAMS_MAX : SP_ERROR_NONE;
+}
+
+int ScriptedInvoker::PushString(const char* string) {
+    default_args_.PushString(string);
+    return default_args_.error ? SP_ERROR_PARAMS_MAX : SP_ERROR_NONE;
+}
+
+int ScriptedInvoker::PushStringEx(char* buffer, size_t length, int sz_flags, int cp_flags) {
+    default_args_.PushString(buffer, length, sz_flags | cp_flags);
+    return default_args_.error ? SP_ERROR_PARAMS_MAX : SP_ERROR_NONE;
+}
+
+void ScriptedInvoker::Cancel() {
+    default_args_.Reset();
+}
+
+bool ScriptedInvoker::Invoke(const CallArgs& args, cell_t* result) {
+    assert(!env_->hasPendingException());
+
+    if (!IsRunnable()) {
+        env_->ReportError(SP_ERROR_NOT_RUNNABLE);
+        return false;
+    }
+    if (args.error) {
+        env_->ReportError(SP_ERROR_PARAMS_MAX);
+        return false;
     }
 
-    Int64CellUnion u(value);
-    return PushArray(u.cells, 2, 0);
+    context_->EnterHeapScope();
+    ke::ScopeGuard leave_heap_scope([this]() -> void {
+        context_->LeaveHeapScope();
+    });
+
+    std::array<cell_t, SP_MAX_EXEC_PARAMS> params;
+    assert(args.argc <= params.size());
+
+    std::array<std::pair<void*, uint32_t>, SP_MAX_EXEC_PARAMS> cows;
+    uint32_t ncows = 0;
+
+    for (uint32_t i = 0; i < args.argc; i++) {
+        const auto& arg = args.argv[i];
+
+        // Simple case, no memory allocation needed.
+        if (arg.type == CallArgs::ARG_CELL) {
+            params[i] = arg.u.value;
+            continue;
+        }
+
+        void* addr = nullptr;
+        uint32_t nbytes = 0;
+        switch (arg.type) {
+            case CallArgs::ARG_CELL_BY_REF: {
+                nbytes = sizeof(cell_t);
+                if ((addr = context_->heapAllocEx(nbytes, &params[i])) == nullptr)
+                    return false;
+                *reinterpret_cast<cell_t*>(addr) = *reinterpret_cast<cell_t*>(arg.u.addr);
+                break;
+            }
+            case CallArgs::ARG_INT64: {
+                nbytes = sizeof(int64_t);
+                if ((addr = context_->heapAllocEx(nbytes, &params[i])) == nullptr)
+                    return false;
+                *reinterpret_cast<int64_t*>(addr) = *reinterpret_cast<int64_t*>(arg.u.addr);
+                break;
+            }
+            case CallArgs::ARG_ARRAY: {
+                nbytes = arg.array_size * sizeof(cell_t);
+                int err = context_->AllocArray(nbytes, &params[i],
+                                               reinterpret_cast<cell_t**>(&addr));
+                if (err != SP_ERROR_NONE) {
+                    env_->ReportError(err);
+                    return false;
+                }
+                memcpy(addr, arg.u.addr, arg.array_size * sizeof(cell_t));
+                break;
+            }
+            case CallArgs::ARG_CHAR_ARRAY: {
+                uint32_t ncells = (arg.array_size + sizeof(cell_t) - 1) / sizeof(cell_t);
+                nbytes = ncells * sizeof(cell_t);
+
+                int err = context_->AllocArray(nbytes, &params[i],
+                                               reinterpret_cast<cell_t**>(&addr));
+                if (err != SP_ERROR_NONE) {
+                    env_->ReportError(err);
+                    return false;
+                }
+
+                if (arg.flags & SM_PARAM_STRING_COPY) {
+                    if (arg.flags & SM_PARAM_STRING_UTF8) {
+                        context_->StringToLocalUTF8(params[i], arg.array_size,
+                                                    reinterpret_cast<const char *>(arg.u.addr),
+                                                    NULL);
+                    } else if (arg.flags & SM_PARAM_STRING_BINARY) {
+                        memcpy(addr, arg.u.addr, arg.array_size);
+                    } else {
+                        context_->StringToLocal(params[i], arg.array_size,
+                                                reinterpret_cast<const char *>(arg.u.addr));
+                    }
+                } else {
+                    *reinterpret_cast<cell_t*>(addr) = 0;
+                }
+                break;
+            }
+            default:
+                env_->ReportError(SP_ERROR_PARAM);
+                return false;
+        }
+
+        if (arg.flags & SM_PARAM_COPYBACK)
+            cows[ncows++] = std::pair<void*, uint32_t>{addr, i};
+    }
+
+    {
+        const char* debugName = this->DebugName();
+        size_t debugNameLength = strlen(debugName) + 2;
+        volatile char* volatile debugNameForCrashDumps = (char*)alloca(debugNameLength);
+        SafeStrcpy((char*)debugNameForCrashDumps + 1, debugNameLength - 1, debugName);
+    }
+
+    if (!context_->Invoke(m_FnId, params.data(), args.argc, result))
+        return false;
+
+    assert(!env_->hasPendingException());
+
+    for (uint32_t i = 0; i < ncows; i++) {
+        void* src = cows[i].first;
+        const auto& arg = args.argv[cows[i].second];
+
+        switch (arg.type) {
+            case CallArgs::ARG_CELL_BY_REF:
+                *reinterpret_cast<cell_t*>(arg.u.addr) = *reinterpret_cast<cell_t*>(src);
+                break;
+            case CallArgs::ARG_INT64:
+                *reinterpret_cast<int64_t*>(arg.u.addr) = *reinterpret_cast<int64_t*>(src);
+                break;
+            case CallArgs::ARG_ARRAY:
+                memcpy(arg.u.addr, src, arg.array_size * sizeof(cell_t));
+                break;
+            case CallArgs::ARG_CHAR_ARRAY:
+                memcpy(arg.u.addr, src, arg.array_size);
+                break;
+            default:
+                assert(false);
+        }
+    }
+
+    return !env_->hasPendingException();
 }
 
-int
-ScriptedInvoker::PushString(const char* string) {
-    return _PushString(string, SM_PARAM_STRING_COPY, 0, strlen(string) + 1);
-}
-
-int
-ScriptedInvoker::PushStringEx(char* buffer, size_t length, int sz_flags, int cp_flags) {
-    return _PushString(buffer, sz_flags, cp_flags, length);
-}
-
-int
-ScriptedInvoker::_PushString(const char* string, int sz_flags, int cp_flags, size_t len) {
-    if (m_curparam >= SP_MAX_EXEC_PARAMS)
-        return SetError(SP_ERROR_PARAMS_MAX);
-
-    ParamInfo* info = &m_info[m_curparam];
-
-    info->marked = true;
-    info->orig_addr = (cell_t*)string;
-    info->flags = cp_flags;
-    info->size = len;
-    info->str.sz_flags = sz_flags;
-    info->str.is_sz = true;
-
-    m_curparam++;
-
-    return SP_ERROR_NONE;
-}
-
-void
-ScriptedInvoker::Cancel() {
-    if (!m_curparam)
-        return;
-
-    m_errorstate = SP_ERROR_NONE;
-    m_curparam = 0;
-}
-
-int
-ScriptedInvoker::Execute(cell_t* result) {
+int ScriptedInvoker::Execute(cell_t* result) {
     Environment* env = Environment::get();
     env->clearPendingException();
 
@@ -177,146 +259,20 @@ ScriptedInvoker::Execute(cell_t* result) {
 }
 
 bool ScriptedInvoker::Invoke(cell_t* result) {
-    if (!IsRunnable()) {
-        Cancel();
-        env_->ReportError(SP_ERROR_NOT_RUNNABLE);
-        return false;
-    }
-    if (int err = m_errorstate) {
-        Cancel();
-        env_->ReportError(err);
-        return false;
-    }
-
-    context_->EnterHeapScope();
-    ke::ScopeGuard leave_heap_scope([this]() -> void {
-        context_->LeaveHeapScope();
-    });
-
-    //This is for re-entrancy!
-    cell_t temp_params[SP_MAX_EXEC_PARAMS];
-    ParamInfo temp_info[SP_MAX_EXEC_PARAMS];
-    unsigned int numparams = m_curparam;
-    unsigned int i;
-
-    if (numparams) {
-        //Save the info locally, then reset it for re-entrant calls.
-        memcpy(temp_info, m_info, numparams * sizeof(ParamInfo));
-    }
-    m_curparam = 0;
-
-    /* Browse the parameters and build arrays */
-    bool ok = true;
-    for (i = 0; i < numparams; i++) {
-        /* Is this marked as an array? */
-        if (temp_info[i].marked) {
-            if (!temp_info[i].str.is_sz) {
-                /* Allocate a normal/generic array */
-                int err = context_->AllocArray(temp_info[i].size, &temp_info[i].local_addr,
-                                               &temp_info[i].phys_addr);
-                if (err != SP_ERROR_NONE) {
-                    env_->ReportError(err);
-                    ok = false;
-                    break;
-                }
-                if (temp_info[i].orig_addr) {
-                    memcpy(temp_info[i].phys_addr, temp_info[i].orig_addr,
-                           sizeof(cell_t) * temp_info[i].size);
-                }
-            } else {
-                /* Calculate cells required for the string */
-                size_t cells = (temp_info[i].size + sizeof(cell_t) - 1) / sizeof(cell_t);
-
-                /* Allocate the buffer */
-                int err =
-                    context_->AllocArray(cells, &temp_info[i].local_addr, &temp_info[i].phys_addr);
-                if (err != SP_ERROR_NONE) {
-                    env_->ReportError(err);
-                    ok = false;
-                    break;
-                }
-
-                /* Copy original string if necessary */
-                if ((temp_info[i].str.sz_flags & SM_PARAM_STRING_COPY) &&
-                    (temp_info[i].orig_addr != NULL)) {
-                    /* Cut off UTF-8 properly */
-                    if (temp_info[i].str.sz_flags & SM_PARAM_STRING_UTF8) {
-                        context_->StringToLocalUTF8(temp_info[i].local_addr, temp_info[i].size,
-                                                    (const char*)temp_info[i].orig_addr, NULL);
-                    } else if (temp_info[i].str.sz_flags & SM_PARAM_STRING_BINARY) {
-                        /* Copy a binary blob */
-                        memmove(temp_info[i].phys_addr, temp_info[i].orig_addr, temp_info[i].size);
-                    } else {
-                        /* Copy ASCII characters */
-                        context_->StringToLocal(temp_info[i].local_addr, temp_info[i].size,
-                                                (const char*)temp_info[i].orig_addr);
-                    }
-                } else if (temp_info[i].str.sz_flags & SM_PARAM_COPYBACK) {
-                    *temp_info[i].phys_addr = 0;
-                }
-            } /* End array/string calculation */
-            /* Update the pushed parameter with the byref local address */
-            temp_params[i] = temp_info[i].local_addr;
-        } else {
-            /* Just copy the value normally */
-            temp_params[i] = m_params[i];
-        }
-    }
-
-    /* Make the call if we can */
-    if (ok) {
-        const char* debugName = this->DebugName();
-        size_t debugNameLength = strlen(debugName) + 2;
-        volatile char* volatile debugNameForCrashDumps = (char*)alloca(debugNameLength);
-        SafeStrcpy((char*)debugNameForCrashDumps + 1, debugNameLength - 1, debugName);
-
-        ok = context_->Invoke(m_FnId, temp_params, numparams, result);
-    }
-
-    /* i should be equal to the last valid parameter + 1 */
-    bool docopies = ok;
-    while (i--) {
-        if (!temp_info[i].marked)
-            continue;
-
-        if (docopies && (temp_info[i].flags & SM_PARAM_COPYBACK)) {
-            if (temp_info[i].orig_addr) {
-                if (temp_info[i].str.is_sz) {
-                    memcpy(temp_info[i].orig_addr, temp_info[i].phys_addr, temp_info[i].size);
-                } else {
-                    if (temp_info[i].size == 1) {
-                        *temp_info[i].orig_addr = *(temp_info[i].phys_addr);
-                    } else {
-                        memcpy(temp_info[i].orig_addr, temp_info[i].phys_addr,
-                               temp_info[i].size * sizeof(cell_t));
-                    }
-                }
-            }
-        }
-    }
-
-    return !env_->hasPendingException();
+    bool ok = Invoke(default_args_, result);
+    default_args_.Reset();
+    return ok;
 }
 
-IPluginRuntime*
-ScriptedInvoker::GetParentRuntime() {
+IPluginRuntime* ScriptedInvoker::GetParentRuntime() {
     return context_->runtime();
 }
 
-funcid_t
-ScriptedInvoker::GetFunctionID() {
+funcid_t ScriptedInvoker::GetFunctionID() {
     return m_FnId;
 }
 
-int
-ScriptedInvoker::SetError(int err) {
-    m_errorstate = err;
-
-    return err;
-}
-
-RefPtr<MethodInfo>
-ScriptedInvoker::AcquireMethod() {
+RefPtr<MethodInfo> ScriptedInvoker::AcquireMethod() {
     if (!method_)
         method_ = context_->runtime()->AcquireMethod(public_->code_offs);
     return method_;

--- a/vm/scripted-invoker.h
+++ b/vm/scripted-invoker.h
@@ -63,9 +63,8 @@ class ScriptedInvoker : public IPluginFunction
     bool IsRunnable() override;
     funcid_t GetFunctionID() override;
     IPluginRuntime* GetParentRuntime() override;
-    const char* DebugName() override {
-        return full_name_.get();
-    }
+    const char* DebugName() override { return full_name_.get(); }
+    bool Invoke(const sp::CallArgs& args, cell_t* rval = nullptr) override;
 
   public:
     sp_public_t* Public() const {
@@ -76,16 +75,9 @@ class ScriptedInvoker : public IPluginFunction
     RefPtr<MethodInfo> AcquireMethod();
 
   private:
-    int _PushString(const char* string, int sz_flags, int cp_flags, size_t len);
-    int SetError(int err);
-
-  private:
     Environment* env_;
     PluginContext* context_;
-    cell_t m_params[SP_MAX_EXEC_PARAMS];
-    ParamInfo m_info[SP_MAX_EXEC_PARAMS];
-    unsigned int m_curparam;
-    int m_errorstate;
+    CallArgs default_args_;
     funcid_t m_FnId;
     std::unique_ptr<char[]> full_name_;
     sp_public_t* public_;

--- a/vm/shell/shell.cpp
+++ b/vm/shell/shell.cpp
@@ -252,11 +252,12 @@ static cell_t CallWithString(IPluginContext* cx, const cell_t* params) {
   int sz_flags = params[4];
   int cp_flags = params[5];
 
-  fn->PushStringEx(buf, length, sz_flags, cp_flags);
-  fn->PushCell(length);
+  CallArgs args;
+  args.PushString(buf, length, sz_flags | cp_flags);
+  args.PushCell(length);
 
   cell_t rval;
-  if (!fn->Invoke(&rval))
+  if (!fn->Invoke(args, &rval))
     return 0;
   return rval;
 }
@@ -358,10 +359,12 @@ static cell_t Copy2dArrayToCallback(IPluginContext* cx, const cell_t* params)
     return 0;
 
   cell_t ignore;
-  fn->PushCell(addr);
-  fn->PushCell(params[2]);
-  fn->PushCell(params[3]);
-  fn->Execute(&ignore);
+  CallArgs args;
+  args.PushCell(addr);
+  args.PushCell(params[2]);
+  args.PushCell(params[3]);
+  if (!fn->Invoke(args, &ignore))
+    return 0;
   return 0;
 }
 


### PR DESCRIPTION
This adds a new CallArgs class, and removes ICallable. For source-level compatibility, the ICallable methods are now on IPluginFunction, and internally simply wrap a CallArgs.

CallArgs has two advantages over the old ICallable API.

First, there are no virtual calls, making it much more efficient to use. On my laptop, the new Invoke is about 15% faster.

Second, it can be prepared once, and re-used multiple times.