### PR TITLE
Add a benchmark driver and suite.

### DIFF
--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -1,0 +1,288 @@
+# vim: set sts=2 sw=2 tw=99 et:
+import argparse
+import csv
+import os
+import sys
+import time
+
+import texttable
+
+import testutil
+
+
+def get_supported_architectures_and_shells(objdir):
+  spshell_dir = os.path.join(objdir, 'spshell')
+  found = testutil.find_executables_in(spshell_dir, 'spshell')
+
+  architectures = []
+  spshells = {}
+  for arch, path in found:
+    architectures.append(arch)
+    spshells[arch] = path
+  return sorted(architectures), spshells
+
+
+def find_any_spcomp(objdir):
+  spcomp_dir = os.path.join(objdir, 'spcomp')
+  found = testutil.find_executables_in(spcomp_dir, 'spcomp')
+  if found:
+    return found[0][1]
+  return None
+
+
+def find_benchmark_tests(tests_path, filter_str=None):
+  tests = []
+  for folder in os.listdir(tests_path):
+    sub_folder = os.path.join(tests_path, folder)
+    if not os.path.isdir(sub_folder):
+      continue
+    manifest_path = os.path.join(sub_folder, 'manifest.ini')
+    if not os.path.exists(manifest_path):
+      continue
+
+    manifest = testutil.parse_manifest(manifest_path, folder, {})
+    if testutil.manifest_get(manifest, 'folder', 'type') != 'benchmark':
+      continue
+
+    if 'folder' in manifest and 'skip' in manifest['folder']:
+      manifest['folder']['skip'] = 'false'
+    for root, dirs, files in os.walk(sub_folder):
+      current_manifest_path = os.path.join(root, 'manifest.ini')
+      if root == sub_folder:
+        current_manifest = manifest
+      elif os.path.exists(current_manifest_path):
+        current_manifest = testutil.parse_manifest(
+            current_manifest_path, os.path.relpath(root, tests_path), manifest
+        )
+      else:
+        current_manifest = manifest
+
+      if testutil.manifest_get(current_manifest, 'folder', 'skip') == 'true':
+        continue
+
+      if testutil.manifest_get(current_manifest, 'folder', 'type') != 'benchmark':
+        continue
+
+      for file in files:
+        if file.endswith('.sp') or file.endswith('.smx'):
+          path = os.path.join(root, file)
+          if testutil.manifest_get(current_manifest, file, 'skip') == 'true':
+            continue
+          if filter_str and filter_str not in path:
+            continue
+          tests.append({
+              'path': os.path.abspath(path),
+              'name': file,
+              'manifest': current_manifest,
+          })
+
+  tests.sort(key=lambda t: t['path'])
+  return tests
+
+
+def map_arch_name(arch):
+  if arch == 'x86_64':
+    return 'x64'
+  return arch
+
+
+def run_benchmark_test(
+    test, spcomp, architectures, spshell_configs, spshells, tests_path, iterations
+):
+  test_path = test['path']
+  test_name = test['name']
+  test_basename = os.path.splitext(test_name)[0]
+
+  print(f'Running benchmark {test_basename}...', file=sys.stderr)
+
+  smx_name = os.path.splitext(test_name)[0] + '.smx'
+  if os.path.exists(smx_name):
+    try:
+      os.unlink(smx_name)
+    except Exception:
+      pass
+
+  core_include_path = os.path.abspath(
+      os.path.join(tests_path, '../include')
+  )
+  comp_argv = [spcomp]
+  includes = testutil.manifest_get(
+      test['manifest'], test_name, 'includes', []
+  )
+  if isinstance(includes, str):
+    includes = [includes]
+  for inc in includes:
+    comp_argv += ['-i', inc]
+
+  comp_argv += [
+      '-i',
+      core_include_path,
+      '-i',
+      tests_path,
+      '-z',
+      '1',
+  ]
+  comp_argv += [test_path]
+
+  rc, stdout, stderr = testutil.exec_argv(comp_argv)
+  if rc != 0:
+    print(
+        f"Compilation failed for {test_name} with command: {' '.join(comp_argv)}",
+        file=sys.stderr,
+    )
+    print(stdout, file=sys.stderr)
+    print(stderr, file=sys.stderr)
+
+    row_results = {'Test': test_basename}
+    for arch in architectures:
+      for config in spshell_configs[arch]:
+        col_name = f'{map_arch_name(arch)}-{config} (ms)'
+        row_results[col_name] = 'N/A'
+    return row_results
+
+  smx_path = os.path.abspath(smx_name)
+
+  row_results = {'Test': test_basename}
+
+  for arch in architectures:
+    shell_path = spshells[arch]
+    configs = spshell_configs[arch]
+    for config in configs:
+      run_argv = [shell_path]
+      run_env = os.environ.copy()
+
+      if config == 'interp':
+        run_env['DISABLE_JIT'] = '1'
+        run_argv += ['--disable-watchdog']
+
+      run_argv += [smx_path]
+
+      total_time_ms = 0.0
+      failed = False
+      for _ in range(iterations):
+        t0 = time.monotonic()
+        run_rc, run_stdout, run_stderr = testutil.exec_argv(
+            run_argv, env=run_env
+        )
+        t1 = time.monotonic()
+
+        if run_rc != 0:
+          print(
+              f'Error: {test_basename} failed to run on {arch}-{config} (exit code {run_rc})',
+              file=sys.stderr,
+          )
+          print(run_stdout, file=sys.stderr)
+          print(run_stderr, file=sys.stderr)
+          failed = True
+          break
+
+        total_time_ms += (t1 - t0) * 1000.0
+
+      col_name = f'{map_arch_name(arch)}-{config} (ms)'
+      if failed:
+        row_results[col_name] = 'N/A'
+      else:
+        avg_time_ms = total_time_ms / iterations
+        if avg_time_ms >= 0:
+          elapsed_val = int(round(avg_time_ms))
+        else:
+          elapsed_val = avg_time_ms
+        row_results[col_name] = elapsed_val
+
+  return row_results
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument('objdir', type=str, help='Build folder to benchmark.')
+  parser.add_argument(
+      '--filter',
+      default=None,
+      type=str,
+      help='Filter for tests with a particular name.',
+  )
+  parser.add_argument(
+      '--iterations',
+      default=5,
+      type=int,
+      help='Number of times to run each benchmark test.',
+  )
+
+  group = parser.add_mutually_exclusive_group()
+  group.add_argument(
+      '--pretty', action='store_true', help='Output as ASCII table.'
+  )
+  group.add_argument('--csv', action='store_true', help='Output as CSV.')
+
+  args = parser.parse_args()
+
+  if not args.csv:
+    args.pretty = True
+
+  tests_path = os.path.dirname(os.path.abspath(__file__))
+  tests = find_benchmark_tests(tests_path, args.filter)
+  if not tests:
+    print('No benchmark tests found.', file=sys.stderr)
+    sys.exit(1)
+
+  spcomp = find_any_spcomp(args.objdir)
+  if not spcomp:
+    print(f'Error: No spcomp binary found in {args.objdir}', file=sys.stderr)
+    sys.exit(1)
+
+  architectures, spshells = get_supported_architectures_and_shells(args.objdir)
+  if not architectures:
+    print(
+        f'Error: No supported architectures or spshell binaries found in {args.objdir}',
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+  spshell_configs = {}
+  for arch in architectures:
+    shell_path = spshells[arch]
+    rc, stdout, stderr = testutil.exec_argv([shell_path, '--version'])
+    output_str = stdout + stderr
+    if 'JIT' in output_str:
+      spshell_configs[arch] = ['interp', 'jit']
+    else:
+      spshell_configs[arch] = ['interp']
+
+  results = []
+  with testutil.TempFolder() as temp_folder:
+    with testutil.ChangeFolder(temp_folder):
+      for test in tests:
+        results.append(
+            run_benchmark_test(
+                test,
+                spcomp,
+                architectures,
+                spshell_configs,
+                spshells,
+                tests_path,
+                args.iterations,
+            )
+        )
+
+  headers = ['Test']
+  for arch in architectures:
+    for config in spshell_configs[arch]:
+      headers.append(f'{map_arch_name(arch)}-{config} (ms)')
+
+  if args.csv:
+    writer = csv.writer(sys.stdout)
+    writer.writerow(headers)
+    for row in results:
+      writer.writerow([row.get(col, '') for col in headers])
+  else:
+    table = texttable.Texttable(max_width=0)
+    table.set_cols_align(['l'] + ['r'] * (len(headers) - 1))
+    rows = [headers]
+    for row in results:
+      rows.append([row.get(col, '') for col in headers])
+    table.add_rows(rows)
+    print(table.draw())
+
+
+if __name__ == '__main__':
+  main()

--- a/tests/benchmarks/float-alu.sp
+++ b/tests/benchmarks/float-alu.sp
@@ -2,7 +2,7 @@
 
 public main() {
     float a1 = 1.0;
-    for (int i = 0; i < 100000000; i++) {
+    for (int i = 0; i < 5000000; i++) {
         a1 += 1.0;
         a1 -= 1.0;
         a1 *= 1.0;

--- a/tests/benchmarks/int-alu.sp
+++ b/tests/benchmarks/int-alu.sp
@@ -1,0 +1,8 @@
+#include <shell>
+
+public void main() {
+    int x = 0;
+    for (int i = 0; i < 50000000; i++)
+        x += i;
+    printnum(x);
+}

--- a/tests/benchmarks/manifest.ini
+++ b/tests/benchmarks/manifest.ini
@@ -1,2 +1,2 @@
 [folder]
-skip = true
+type = benchmark

--- a/tests/benchmarks/native-call.sp
+++ b/tests/benchmarks/native-call.sp
@@ -1,8 +1,9 @@
 #include <shell>
 
 public main() {
-    for (int i = 0; i < 100000000; i++) {
-        donothing();
+    int a, b, c;
+    for (int i = 0; i < 50000000; i++) {
+        donothing_varargs(i, c, b, a);
     }
 }
 

--- a/tests/benchmarks/scripted-call.sp
+++ b/tests/benchmarks/scripted-call.sp
@@ -1,0 +1,12 @@
+#include <shell>
+
+int wow(int a, int b, int c, int d) {
+    return a + b + c + d;
+}
+
+public void main() {
+    int a = 0;
+    for (int i = 0; i < 50000000; i++)
+        a += wow(i, i + 2, i - 3, i + 5)
+    printnum(a);
+}

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -83,40 +83,12 @@ class TestPlan(object):
     return self.args.arch == arch
 
   def find_executable(self, path):
-    if os.path.exists(path):
-      pass
-    elif os.path.exists(path + '.js'):
-      path += '.js'
-    elif os.path.exists(path + '.exe'):
-      path += '.exe'
-    else:
-      return None
-    return path
+    return testutil.find_executable(path)
 
   def find_executables_in(self, path, name):
-    kPlatformNames = {
-        'Linux': 'linux',
-        'Darwin': 'mac',
-        'Windows': 'windows',
-    }
-
-    found = []
-    for subdir in os.listdir(path):
-      parts = subdir.split('-')
-      if len(parts) < 2:
-        continue
-      our_platform = kPlatformNames.get(platform.system(), platform.system())
-      if parts[0] != our_platform:
-        continue
-      if not self.match_arch(parts[1]):
-        continue
-
-      prefix = os.path.join(path, subdir, name)
-      full_path = self.find_executable(prefix)
-      if not full_path:
-        continue
-      found.append((parts[1], os.path.abspath(full_path)))
-    return found
+    return testutil.find_executables_in(
+        path, name, arch_filter=lambda arch: self.match_arch(arch)
+    )
 
   def find_shells(self):
     search_in = os.path.join(self.args.objdir, 'spshell')
@@ -191,6 +163,9 @@ class TestPlan(object):
     manifest_path = os.path.join(folder, 'manifest.ini')
     if os.path.exists(manifest_path):
       manifest = testutil.parse_manifest(manifest_path, local_folder, manifest)
+      folder_type = manifest_get(manifest, 'folder', 'type')
+      if folder_type is not None and folder_type != 'tests':
+        return
       if manifest_get(manifest, 'folder', 'skip') == 'true':
         return
 

--- a/tests/shell.inc
+++ b/tests/shell.inc
@@ -20,6 +20,7 @@ native void report_error();
 native void unbound_native();
 native int donothing();
 native int64 add_int64(int64 a, int64 b);
+native void donothing_varargs(...);
 
 // dumb version of printf(), only supports %f, %d, %s.
 native void printf(const char[] fmt, any:...);

--- a/tests/testutil.py
+++ b/tests/testutil.py
@@ -1,5 +1,6 @@
 # vim: set ts=2 sw=2 tw=99 et:
 import os
+import platform
 import shutil
 import tempfile
 import subprocess
@@ -94,3 +95,44 @@ def manifest_get(manifest, filename, key, default_value = None):
     if key in manifest['folder']:
       return manifest['folder'][key]
   return default_value
+
+
+def find_executable(path):
+  if os.path.exists(path):
+    pass
+  elif os.path.exists(path + '.js'):
+    path += '.js'
+  elif os.path.exists(path + '.exe'):
+    path += '.exe'
+  else:
+    return None
+  return path
+
+
+def find_executables_in(search_path, name, arch_filter=None):
+  kPlatformNames = {
+      'Linux': 'linux',
+      'Darwin': 'mac',
+      'Windows': 'windows',
+  }
+  our_platform = kPlatformNames.get(platform.system(), platform.system().lower())
+
+  if not os.path.isdir(search_path):
+    return []
+
+  found = []
+  for subdir in os.listdir(search_path):
+    parts = subdir.split('-')
+    if len(parts) < 2:
+      continue
+    if parts[0] != our_platform:
+      continue
+    if arch_filter and not arch_filter(parts[1]):
+      continue
+
+    prefix = os.path.join(search_path, subdir, name)
+    full_path = find_executable(prefix)
+    if not full_path:
+      continue
+    found.append((parts[1], os.path.abspath(full_path)))
+  return found

--- a/vm/shell/shell.cpp
+++ b/vm/shell/shell.cpp
@@ -140,6 +140,11 @@ static cell_t AddInt64(IPluginContext* cx, const cell_t* params)
   return 0;
 }
 
+static cell_t DoNothingVarargs(IPluginContext* cx, const cell_t* params)
+{
+  return 0;
+}
+
 static cell_t PrintNums(IPluginContext* cx, const cell_t* params)
 {
   for (size_t i = 1; i <= size_t(params[0]); i++) {
@@ -252,8 +257,16 @@ static cell_t CallWithString(IPluginContext* cx, const cell_t* params) {
   int sz_flags = params[4];
   int cp_flags = params[5];
 
+  int translated_flags = cp_flags;
+  if (sz_flags & (1 << 0))
+    translated_flags |= SM_PARAM_STRING_UTF8;
+  if (sz_flags & (1 << 1))
+    translated_flags |= SM_PARAM_STRING_COPY;
+  if (sz_flags & (1 << 2))
+    translated_flags |= SM_PARAM_STRING_BINARY;
+
   CallArgs args;
-  args.PushString(buf, length, sz_flags | cp_flags);
+  args.PushString(buf, length, translated_flags);
   args.PushCell(length);
 
   cell_t rval;
@@ -478,6 +491,7 @@ static int Execute(const char* file)
   BindNative(rt.get(), "print_test_struct", PrintTestStruct);
   BindNative(rt.get(), "add_test_structs", AddTestStructs);
   BindNative(rt.get(), "add_int64", AddInt64);
+  BindNative(rt.get(), "donothing_varargs", DoNothingVarargs);
 
   IPluginFunction* fun = rt->GetFunctionByName("main");
   if (!fun)


### PR DESCRIPTION
This is a quick redux of runtests.py that instead runs benchmark scripts and prints out the timings.

Example output:

```
Running benchmark float-alu...
Running benchmark int-alu...
Running benchmark native-call...
Running benchmark scripted-call...
+---------------+-----------------+--------------+-----------------+--------------+
|     Test      | x86-interp (ms) | x86-jit (ms) | x64-interp (ms) | x64-jit (ms) |
+===============+=================+==============+=================+==============+
| float-alu     |             999 |          101 |             740 |          101 |
+---------------+-----------------+--------------+-----------------+--------------+
| int-alu       |            3105 |           56 |            2113 |           55 |
+---------------+-----------------+--------------+-----------------+--------------+
| native-call   |            3872 |          112 |            2915 |          118 |
+---------------+-----------------+--------------+-----------------+--------------+
| scripted-call |            8957 |          167 |            6687 |          204 |
+---------------+-----------------+--------------+-----------------+--------------+
```