### PR TITLE
Fix x64 switch tables when multiple cases share a target block

### DIFF
--- a/tests/regressions/switch-contiguous-shared-case.out
+++ b/tests/regressions/switch-contiguous-shared-case.out
@@ -1,0 +1,16 @@
+fourth
+fallthrough
+third
+fallthrough
+third
+fallthrough
+second
+fallthrough
+second
+fallthrough
+second
+fallthrough
+first
+fallthrough
+default
+fallthrough

--- a/tests/regressions/switch-contiguous-shared-case.sp
+++ b/tests/regressions/switch-contiguous-shared-case.sp
@@ -1,0 +1,32 @@
+#include <shell>
+
+// Contiguous case values compile to a dense jump table in the JIT.
+// Cases sharing one body make multiple table entries reference the same label.
+public void main()
+{
+  testContiguousShared(6);
+  testContiguousShared(5);
+  testContiguousShared(4);
+  testContiguousShared(3);
+  testContiguousShared(2);
+  testContiguousShared(1);
+  testContiguousShared(0);
+  testContiguousShared(7);
+}
+
+void testContiguousShared(int n)
+{
+  switch (n) {
+  case 0:
+    print("first\n");
+  case 1,2,3:
+    print("second\n");
+  case 4,5:
+    print("third\n");
+  case 6:
+    print("fourth\n");
+  default:
+    print("default\n");
+  }
+  print("fallthrough\n");
+}

--- a/vm/label.h
+++ b/vm/label.h
@@ -172,6 +172,13 @@ class CodeLabelBase
         status_ = (pc << 1);
         assert(ToOffset(status_) == pc);
     }
+    int32_t addPendingUse(int32_t pc) {
+        assert(!bound());
+        int32_t prev = used() ? ToOffset(status_) : 0;
+        status_ = (pc << 1);
+        assert(ToOffset(status_) == pc);
+        return prev;
+    }
     void bind(uint32_t offset) {
         assert(!bound());
         status_ = (offset << 1) | kBound;

--- a/vm/x64/assembler-x64.h
+++ b/vm/x64/assembler-x64.h
@@ -451,8 +451,15 @@ class Assembler : public AssemblerBase
             }
 
             // Finally, we've recovered the location to patch.
-            assert(data_index < address_table_.size());
-            address_table_[data_index] = pc();
+            for (;;) {
+                assert(data_index < address_table_.size());
+                int32_t next = int32_t(address_table_[data_index]);
+                assert(next <= 0);
+                address_table_[data_index] = pc();
+                if (!next)
+                    break;
+                data_index = uint32_t(-next - 1);
+            }
         }
         label->bind(pc());
     }
@@ -497,8 +504,9 @@ class Assembler : public AssemblerBase
         if (label->bound()) {
             address_table_.emplace_back(label->offset());
         } else {
-            address_table_.emplace_back(0);
-            label->use(-address_table_.size()); // 1-indexed to avoid -0.
+            int32_t prev = label->addPendingUse(-int32_t(address_table_.size() + 1));
+            assert(prev <= 0);
+            address_table_.emplace_back(uintptr_t(intptr_t(prev)));
         }
         address_table_reloc_.emplace_back((uint32_t)address_table_.size() - 1);
     }


### PR DESCRIPTION
The x64 JIT's dense switch jump tables breaks when several switch cases share one body (e.g. `case 1,2,3:`), since a PatchCodeLabel only supports a single pending use. Thread pending uses through the address table slots as a linked list so binding patches every referencing slot.