### PR TITLE
Implement float opcodes in the x64 JIT

### DIFF
--- a/vm/x64/assembler-x64.h
+++ b/vm/x64/assembler-x64.h
@@ -863,14 +863,29 @@ class Assembler : public AssemblerBase
         emit3_sse(0x66, 0x0f, 0x6e, dest, src);
     }
 
+    void movss(FloatRegister dest, const Operand& src) {
+        emit3_sse(0xf3, 0x0f, 0x10, dest, src);
+    }
+    void addss(FloatRegister dest, const Operand& src) {
+        emit3_sse(0xf3, 0x0f, 0x58, dest, src);
+    }
     void addss(FloatRegister dest, FloatRegister src) {
         emit3_sse(0xf3, 0x0f, 0x58, dest, src);
+    }
+    void subss(FloatRegister dest, const Operand& src) {
+        emit3_sse(0xf3, 0x0f, 0x5c, dest, src);
     }
     void subss(FloatRegister dest, FloatRegister src) {
         emit3_sse(0xf3, 0x0f, 0x5c, dest, src);
     }
+    void mulss(FloatRegister dest, const Operand& src) {
+        emit3_sse(0xf3, 0x0f, 0x59, dest, src);
+    }
     void mulss(FloatRegister dest, FloatRegister src) {
         emit3_sse(0xf3, 0x0f, 0x59, dest, src);
+    }
+    void divss(FloatRegister dest, const Operand& src) {
+        emit3_sse(0xf3, 0x0f, 0x5e, dest, src);
     }
     void divss(FloatRegister dest, FloatRegister src) {
         emit3_sse(0xf3, 0x0f, 0x5e, dest, src);

--- a/vm/x64/jit_x64.cpp
+++ b/vm/x64/jit_x64.cpp
@@ -952,28 +952,42 @@ bool Compiler::visitFABS() {
 }
 
 bool Compiler::visitFLOAT() {
-    assert(false);
-    return false;
+    __ cvtsi2ss(xmm0, Operand(stk, 0));
+    __ movd(pri, xmm0);
+    __ addq(stk, 4);
+    return true;
 }
 
 bool Compiler::visitFLOATADD() {
-    assert(false);
-    return false;
+    __ movss(xmm0, Operand(stk, 0));
+    __ addss(xmm0, Operand(stk, 4));
+    __ movd(pri, xmm0);
+    __ addq(stk, 8);
+    return true;
 }
 
 bool Compiler::visitFLOATSUB() {
-    assert(false);
-    return false;
+    __ movss(xmm0, Operand(stk, 0));
+    __ subss(xmm0, Operand(stk, 4));
+    __ movd(pri, xmm0);
+    __ addq(stk, 8);
+    return true;
 }
 
 bool Compiler::visitFLOATMUL() {
-    assert(false);
-    return false;
+    __ movss(xmm0, Operand(stk, 0));
+    __ mulss(xmm0, Operand(stk, 4));
+    __ movd(pri, xmm0);
+    __ addq(stk, 8);
+    return true;
 }
 
 bool Compiler::visitFLOATDIV() {
-    assert(false);
-    return false;
+    __ movss(xmm0, Operand(stk, 0));
+    __ divss(xmm0, Operand(stk, 4));
+    __ movd(pri, xmm0);
+    __ addq(stk, 8);
+    return true;
 }
 
 bool Compiler::visitRND_TO_NEAREST() {
@@ -1005,18 +1019,106 @@ bool Compiler::visitRND_TO_ZERO() {
 }
 
 bool Compiler::visitFLOATCMP() {
-    assert(false);
-    return false;
+    // This is the old float cmp, which returns ordered results. In newly
+    // compiled code it should not be used or generated.
+    //
+    // Note that the checks here are inverted: the test is |rhs OP lhs|.
+    Label bl, ab, done;
+    __ movss(xmm0, Operand(stk, 4));
+    __ ucomiss(Operand(stk, 0), xmm0);
+    __ j(above, &ab);
+    __ j(below, &bl);
+    __ xorl(pri, pri);
+    __ jmp(&done);
+    __ bind(&ab);
+    __ movl(pri, -1);
+    __ jmp(&done);
+    __ bind(&bl);
+    __ movl(pri, 1);
+    __ bind(&done);
+    __ addq(stk, 8);
+    return true;
+}
+
+ConditionCode
+ToFloatConditionCode(CompareOp op) {
+    switch (op) {
+        case CompareOp::Sgrtr:
+            return above;
+        case CompareOp::Sgeq:
+            return above_equal;
+        case CompareOp::Sleq:
+            return below_equal;
+        case CompareOp::Sless:
+            return below;
+        case CompareOp::Eq:
+            return equal;
+        case CompareOp::Neq:
+            return not_equal;
+        default:
+            assert(false);
+            return zero;
+    }
+}
+
+void Compiler::emitFloatCmp(ConditionCode cc) {
+    unsigned lhs = 4;
+    unsigned rhs = 0;
+    if (cc == below || cc == below_equal) {
+        // NaN results in ZF=1 PF=1 CF=1
+        //
+        // ja/jae check for ZF,CF=0 and CF=0. If we make all relational compares
+        // look like ja/jae, we'll guarantee all NaN comparisons will fail (which
+        // would not be true for jb/jbe, unless we checked with jp).
+        if (cc == below)
+            cc = above;
+        else
+            cc = above_equal;
+        rhs = 4;
+        lhs = 0;
+    }
+
+    __ movss(xmm0, Operand(stk, rhs));
+    __ ucomiss(Operand(stk, lhs), xmm0);
+
+    // An equal or not-equal needs special handling for the parity bit.
+    if (cc == equal || cc == not_equal) {
+        // If NaN, PF=1, ZF=1, and E/Z tests ZF=1.
+        //
+        // If NaN, PF=1, ZF=1 and NE/NZ tests Z=0. But, we want any != with NaNs
+        // to return true, including NaN != NaN.
+        //
+        // To make checks simpler, we set |pri| to the expected value of a NaN
+        // beforehand. This also clears the top bits of |pri| for setcc.
+        Label done;
+        __ movl(pri, (cc == equal) ? 0 : 1);
+        __ j(parity, &done);
+        __ set(cc, r8_al);
+        __ bind(&done);
+    } else {
+        __ movl(pri, 0);
+        __ set(cc, r8_al);
+    }
+    __ addq(stk, 8);
 }
 
 bool Compiler::visitFLOAT_CMP_OP(CompareOp op) {
-    assert(false);
-    return false;
+    emitFloatCmp(ToFloatConditionCode(op));
+    return true;
 }
 
 bool Compiler::visitFLOAT_NOT() {
-    assert(false);
-    return false;
+    __ xorps(xmm0, xmm0);
+    __ ucomiss(Operand(stk, 0), xmm0);
+
+    // See emitFloatCmp() - this is a shorter version.
+    Label done;
+    __ movl(pri, 1);
+    __ j(parity, &done);
+    __ set(zero, r8_al);
+    __ bind(&done);
+    __ addq(stk, 4);
+    return true;
 }
 
 bool Compiler::visitHALT(cell_t value) {
@@ -1530,27 +1632,6 @@ bool Compiler::visitSUB_ALT_F32() {
     __ subss(xmm0, xmm1);
     __ movd(pri, xmm0);
     return true;
-}
-
-ConditionCode
-ToFloatConditionCode(CompareOp op) {
-    switch (op) {
-        case CompareOp::Sgrtr:
-            return above;
-        case CompareOp::Sgeq:
-            return above_equal;
-        case CompareOp::Sleq:
-            return below_equal;
-        case CompareOp::Sless:
-            return below;
-        case CompareOp::Eq:
-            return equal;
-        case CompareOp::Neq:
-            return not_equal;
-        default:
-            assert(false);
-            return zero;
-    }
 }
 
 bool Compiler::visitCompareOpF32(CompareOp op) {


### PR DESCRIPTION
The x64 JIT currently stubs the legacy float opcodes. The compiler no longer emits these, but they still enter JIT-compiled code through float native remapping. The pcode reader rewrites `sysreq.n` calls to the natives in `sNativeMap` (e.g. `FloatCompare`, `float`, `FloatAdd`) into these opcodes, including for plugins that pass `SupportsPlugin`. When that happens there is no interpreter fallback. Compilation fails and the plugin cannot run. `FloatCompare` is a current, non-deprecated SourceMod API, so newly compiled plugins can hit this.

This PR ports the x86 SSE2 handlers and adds the missing memory-operand forms of `movss`, `addss`, `subss`, `mulss` and `divss` to the x64 assembler.