### PR TITLE
vm/v2: flatten heap-backed arrays in the variadic region of script calls

### DIFF
--- a/tests/regressions/pass-heap-array-as-vararg.out
+++ b/tests/regressions/pass-heap-array-as-vararg.out
@@ -1,0 +1,1 @@
+(value1 1234567) (str some string) (value2 7654321)

--- a/tests/regressions/pass-heap-array-as-vararg.sp
+++ b/tests/regressions/pass-heap-array-as-vararg.sp
@@ -1,0 +1,16 @@
+#include <shell>
+
+void Func(char[] fmt, any ...)
+{
+    printf(fmt, ...);
+}
+
+public void main()
+{
+    char[] fmt = "(value1 %d) (str %s) (value2 %d)";
+    char[] str = "some string";
+    int value1 = 1234567;
+    int value2 = 7654321;
+
+    Func(fmt, value1, str, value2);
+}

--- a/vm/v2/lowering/lowering.cpp
+++ b/vm/v2/lowering/lowering.cpp
@@ -1853,11 +1853,19 @@ void MethodLowerer::LowerCall(uint32_t method_index, std::optional<uint8_t> argc
     std::vector<VReg> argv(explicit_args);
     std::vector<VReg> args_to_free;
 
+    bool package_variadic = (!method || !(method->flags & kRttiMethod_Native)) && is_variadic;
+
     for (uint32_t i = 0; i < explicit_args; i++) {
         ExprNode* node = popStack();
         VReg arg_reg = EmitNode(node);
 
-        if (node->type->IsNonFlatArray() && (method && (method->flags & kRttiMethod_Native))) {
+        // Variadic arguments are marshalled as raw cells, and the native they are
+        // eventually spread into resolves them through LocalToPhysAddr(), which
+        // expects an address of flat data. Heap-backed arrays (Array, FixedArray and
+        // ArraySlice) hold a SpArray ref instead, so flatten them here. FlatArray
+        // already holds a data address and must be left alone.
+        bool is_variadic_arg = package_variadic && (i >= expected_argc);
+        if (node->type->IsNonFlatArray() && ((method && (method->flags & kRttiMethod_Native)) || is_variadic_arg)) {
             VReg dest = AllocateTempCells(1, false);
             emit(LL_ARRAY_TO_FLAT, arg_reg, dest);
             args_to_free.push_back(arg_reg);
@@ -1866,8 +1874,6 @@ void MethodLowerer::LowerCall(uint32_t method_index, std::optional<uint8_t> argc
             argv[i] = arg_reg;
         }
     }
-
-    bool package_variadic = (!method || !(method->flags & kRttiMethod_Native)) && is_variadic;
 
     if (package_variadic) {
         uint32_t variadic_count = arg_count - expected_argc;


### PR DESCRIPTION
Resolved #1170  

Vararg cells are marshalled as addresses of flat data, which is what natives resolve through LocalToPhysAddr() / LocalToString(). A heap-backed array must be flattened first, otherwise the callee — or any native the variadic args are spread into — sees the SpArray header. Previously this was only done for direct native calls, so a heap char[] forwarded through a script variadic function reached the native as a raw heap ref and %s printed header bytes.

The guard is IsNonFlatArray(), not IsHeapItem(): that is the exact set of array types whose register value is a heap ref (Array / FixedArray / ArraySlice). FlatArray holds a data address and must be left alone, and Function / Object / Closure have no data field.

LL_ARRAY_TO_FLAT is an alias, not a copy, so mutation semantics and cost are unchanged. args_to_free is drained after EmitCall, so the array survives the call; and FreeReg is a no-op for the unowned VReg of an OP_LOAD_S local, so no spurious LL_RELEASE is emitted.

Note: This PR was primarily generated by AI.